### PR TITLE
Refactor LLM clients to avoid indentation issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,7 @@ __pycache__/
 *.pyc
 .env
 *.zip
+.bin
+*.bin
 .DS_Store
 /.vscode/

--- a/README.md
+++ b/README.md
@@ -1,75 +1,58 @@
 # FluidRAG
 
-A standalone RAG-style spec extractor with a Flask backend and ESM frontend.
-It implements a **standard → Fluid → HEP** text pipeline, then runs five
-parallel LLM passes (Mechanical, Electrical, Controls, Software, Project Management)
-to extract exact specification sentences. Results are merged and returned as a CSV.
+FluidRAG is a standalone RAG-style specification extraction tool with a Flask backend and an ESM frontend. It applies a **standard → Fluid → HEP** preprocessing pipeline, then runs five asynchronous LLM passes (Mechanical, Electrical, Controls, Software, and Project Management) to collect exact specification statements. Duplicate specifications found by multiple passes are merged and exported as a CSV with the columns **Document**, **(Sub)Section #**, **(Sub)Section Name**, **Specification**, and **Pass**.
 
-Light-theme UI inspired by M365 Copilot.
+The UI follows a light Microsoft 365 Copilot-inspired theme and surfaces detailed progress logs in both the Flask console and the browser DevTools console.
 
-## Quick Start
+## Quick start
 
 ```bash
-# 1) Create and activate venv (Windows example)
+# 1. Create and activate a virtual environment (Windows example)
 py -3.12 -m venv .venv
-.venv\Scripts\activate
+.\.venv\Scripts\activate
 
-# 2) Install backend deps
+# 2. Install dependencies
 pip install -r backend/requirements.txt
 
-# 3) Configure API key
+# 3. Configure LLM credentials
 copy .env.example .env
-# edit .env and set OPENROUTER_API_KEY
+# edit .env and set OPENROUTER_API_KEY for OpenRouter (optional but recommended)
+# optionally set LLAMACPP_URL / LLAMACPP_MODELS / LLAMACPP_DEFAULT_MODEL for llama.cpp
 
-# 4) Run
-python backend/app.py
-
-# 5) Open
-# http://127.0.0.1:5142/
+# 4. Run the development server
+python run.py  # starts Flask and opens the frontend
 ```
 
-> If `OPENROUTER_API_KEY` is missing, the app runs with deterministic mock
-> outputs (no real extraction). Set the key for real LLM calls.
+> Without `OPENROUTER_API_KEY`, network calls fall back to mocked responses so you can exercise the UI end-to-end.
 
-## How it works
+## Guided workflow
 
-1. **Preprocess**
-   * Load `.pdf`, `.docx`, or `.txt`
-   * Detect section headings via regex heuristics (`1`, `1.1`, etc.).
-   * Segment text into section-bounded chunks.
+1. **Upload & model selection**  
+   Choose an LLM provider (OpenRouter cloud or a local llama.cpp endpoint) and select a model. Upload `.pdf`, `.docx`, or `.txt` files; the backend stores them in a session-specific temp directory. Use the **Test LLM** button to verify connectivity with the provider using the legacy concatenated role/message prompt format.
+2. **Preprocess (standard chunking)**  
+   Split the document into overlapping ~4k-token coarse chunks while persisting per-page strings for subsequent stages.
+3. **Determine headers**  
+   Run hybrid heading detection (regex + LLM confirmation) in ≤120k-token batches to produce section/subsection spans. The API returns an outline preview and full LLM debug logs for DevTools inspection.
+4. **Fluid → HEP refinement**  
+   Refine the section chunks toward ~1–2k tokens with Fluid and attach entropy/cluster metadata via HEP to inform downstream weighting.
+5. **Async passes & merge**  
+   Rank chunks per pass using entropy and keyword heuristics, enforce a 120k-token request budget, and dispatch asynchronous LLM calls. Exact specifications are deduplicated across passes, rendered in-app, and offered as `FluidRAG_results.csv` for download.
 
-2. **Fluid Refinement**
-   * Merge very short chunks, split very long ones using overlaps to aim
-     for ~1-2k token equivalents.
+## Configuration notes
 
-3. **HEP Clustering**
-   * TF‑IDF features + k‑means.
-   * Attach `cluster_id` and a simple entropy score to each chunk.
+- Update `backend/app.py` → `OPENROUTER_FREE_MODELS` to adjust the OpenRouter shortlist; popular free models such as DeepSeek, Ollama, and Mistral are included by default.
+- Environment variables (`LLAMACPP_URL`, `LLAMACPP_MODELS`, `LLAMACPP_DEFAULT_MODEL`) control llama.cpp connectivity.
+- Prompts live in `backend/prompts/__init__.py` for reuse across passes.
+- Frontend modules live under `frontend/js/` and are loaded as ES modules.
 
-4. **Async Passes**
-   * For each chunk, run 5 extraction passes concurrently via OpenRouter.
-   * Each pass returns a JSON array of **exact quotations** matching domain criteria.
+## Dev containers / Codespaces
 
-5. **Merge & CSV**
-   * Combine identical `"Specification"` strings across passes into a single row.
-   * `"Pass"` becomes a semicolon‑separated list.
-
-## Configuration
-
-* Edit `backend/app.py` → `OPENROUTER_FREE_MODELS` to change the default model list.
-* Prompts live in `backend/prompts/__init__.py`. Tweak to your liking.
-
-## GitHub Codespaces / Dev Containers
-
-A ready-to-use dev container is included. In VS Code:
-
-1. Install **Dev Containers** extension.
-2. `File → Open Folder...` → choose this project.
-3. When prompted, **Reopen in Container**.
-4. Inside the container:
+1. Install the **Dev Containers** extension in VS Code.
+2. Open this folder and accept **Reopen in Container** when prompted.
+3. Inside the container, run:
    ```bash
    pip install -r backend/requirements.txt
-   python backend/app.py
+   python run.py
    ```
 
 ## License

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,143 +1,371 @@
 import asyncio
-import io
+import base64
+import json
 import logging
 import os
 import tempfile
 import time
-import base64
-from dataclasses import dataclass, field
-from typing import List, Dict, Any, Optional
+import uuid
+from dataclasses import dataclass
+from typing import Dict, Any, List, Optional
 
-from flask import Flask, request, jsonify, send_from_directory
+from flask import Flask, request, jsonify
 from werkzeug.utils import secure_filename
 
 from dotenv import load_dotenv
 load_dotenv()
 
-from .pipeline.preprocess import load_document_to_text_pages, detect_headers_and_sections
-from .pipeline.fluid import fluid_refine_chunks
-from .pipeline.hep_cluster import hep_cluster_chunks
-from .pipeline.llm import OpenRouterClient
-from .pipeline.passes import run_all_passes_async
-from .pipeline.csv_writer import rows_to_csv_bytes
+# Support running either as part of the backend package or as a direct script.
+try:  # pragma: no cover - import resolution shim
+    from backend.pipeline.preprocess import (
+        load_document_to_text_pages,
+        standard_pre_chunks,
+        detect_headers_and_sections_async,
+    )
+    from backend.pipeline.fluid import fluid_refine_chunks
+    from backend.pipeline.hep_cluster import hep_cluster_chunks
+    from backend.pipeline.llm import (
+        create_llm_client,
+        LLMAuthError,
+        provider_default_model,
+    )
+    from backend.pipeline.passes import run_all_passes_async
+    from backend.pipeline.csv_writer import rows_to_csv_bytes
+except ImportError:  # pragma: no cover - fallback when executed as package module
+    from .pipeline.preprocess import (
+        load_document_to_text_pages,
+        standard_pre_chunks,
+        detect_headers_and_sections_async,
+    )
+    from .pipeline.fluid import fluid_refine_chunks
+    from .pipeline.hep_cluster import hep_cluster_chunks
+    from .pipeline.llm import (
+        create_llm_client,
+        LLMAuthError,
+        provider_default_model,
+    )
+    from .pipeline.passes import run_all_passes_async
+    from .pipeline.csv_writer import rows_to_csv_bytes
 
-# -------------- Logging --------------
 logging.basicConfig(
     level=logging.DEBUG,
     format="%(asctime)s [%(levelname)s] %(name)s: %(message)s"
 )
 log = logging.getLogger("FluidRAG")
 
-# -------------- Flask App --------------
 app = Flask(__name__, static_folder="../frontend", static_url_path="")
-app.config["MAX_CONTENT_LENGTH"] = 50 * 1024 * 1024  # 50MB
+app.config["MAX_CONTENT_LENGTH"] = 50 * 1024 * 1024
 ALLOWED_EXT = {".pdf", ".docx", ".txt"}
 
-# Models list (free-ish on OpenRouter; users may swap/extend as desired)
 OPENROUTER_FREE_MODELS = [
+    "deepseek/deepseek-chat:free",
+    "deepseek/deepseek-r1:free",
     "mistralai/mistral-7b-instruct:free",
+    "mistralai/mixtral-8x7b-instruct:free",
+    "meta-llama/llama-3.1-8b-instruct:free",
+    "ollama/llama3.1-8b:free",
+    "qwen/qwen-2.5-7b-instruct:free",
     "openchat/openchat-7b:free",
     "gryphe/mythomist-7b:free",
     "google/gemma-7b-it:free"
 ]
 
+_llamacpp_env = os.environ.get("LLAMACPP_MODELS", "")
+if _llamacpp_env:
+    LLAMACPP_MODELS = [m.strip() for m in _llamacpp_env.split(",") if m.strip()]
+else:
+    LLAMACPP_MODELS = [
+        os.environ.get("LLAMACPP_DEFAULT_MODEL", "llama.cpp/default") or "llama.cpp/default"
+    ]
+
+DEFAULT_PROVIDER = "openrouter"
+DEFAULT_MODEL = OPENROUTER_FREE_MODELS[0]
+DEFAULT_LOCAL_MODEL = LLAMACPP_MODELS[0]
+
+MODEL_PROVIDERS = {
+    "openrouter": {
+        "label": "OpenRouter",
+        "models": OPENROUTER_FREE_MODELS,
+        "default_model": DEFAULT_MODEL
+    },
+    "llamacpp": {
+        "label": "llama.cpp",
+        "models": LLAMACPP_MODELS,
+        "default_model": DEFAULT_LOCAL_MODEL
+    }
+}
+
+
+def _normalize_provider(value: Optional[str]) -> str:
+    if not value:
+        return DEFAULT_PROVIDER
+    provider = value.strip().lower()
+    return provider if provider in MODEL_PROVIDERS else DEFAULT_PROVIDER
+
+
+def _resolve_model(provider: str, requested: Optional[str]) -> str:
+    if requested:
+        return requested
+    env_default = provider_default_model(provider)
+    if env_default:
+        return env_default
+    return MODEL_PROVIDERS[_normalize_provider(provider)]["default_model"]
+
+
+@dataclass
+class PipelineState:
+    tmpdir: str
+    filename: str
+    file_path: str
+    pages: Optional[List[str]] = None
+    pre_chunks: Optional[List[Dict[str, Any]]] = None
+    section_chunks: Optional[List[Dict[str, Any]]] = None
+    refined_chunks: Optional[List[Dict[str, Any]]] = None
+    clustered_chunks: Optional[List[Dict[str, Any]]] = None
+    model: Optional[str] = None
+    provider: Optional[str] = None
+
+
+PIPELINE_STATES: Dict[str, PipelineState] = {}
+
+
 @app.get("/")
 def index():
-    # Serve the frontend
     return app.send_static_file("index.html")
+
 
 @app.get("/api/models")
 def get_models():
     log.debug("[API] /api/models")
-    return jsonify({"ok": True, "models": OPENROUTER_FREE_MODELS})
+    return jsonify({
+        "ok": True,
+        "providers": MODEL_PROVIDERS,
+        "default_provider": DEFAULT_PROVIDER
+    })
 
-@dataclass
-class SectionChunk:
-    document: str
-    section_number: str
-    section_name: str
-    text: str
-    meta: Dict[str, Any] = field(default_factory=dict)
 
-@app.post("/api/process")
-def process_file():
-    """Upload a file and run the full pipeline, returning a CSV (base64) + rows."""
-    ts0 = time.time()
-    log.debug("[API] /api/process invoked")
+def _get_state_or_404(session_id: str) -> Optional[PipelineState]:
+    state = PIPELINE_STATES.get(session_id)
+    if not state:
+        return None
+    return state
+
+
+@app.post("/api/upload")
+def upload_file():
+    log.debug("[API] /api/upload invoked")
     if "file" not in request.files:
         return jsonify({"ok": False, "error": "No file provided"}), 400
-
     file = request.files["file"]
-    model = request.form.get("model", OPENROUTER_FREE_MODELS[0])
     filename = secure_filename(file.filename or "upload")
+    if not filename:
+        return jsonify({"ok": False, "error": "Invalid filename"}), 400
     ext = os.path.splitext(filename)[1].lower()
     if ext not in ALLOWED_EXT:
         return jsonify({"ok": False, "error": f"Unsupported file type: {ext}"}), 400
-
     tmpdir = tempfile.mkdtemp(prefix="fluidrag_")
     fpath = os.path.join(tmpdir, filename)
     file.save(fpath)
-    log.debug(f"[API] Saved upload to {fpath}")
+    session_id = uuid.uuid4().hex
+    PIPELINE_STATES[session_id] = PipelineState(tmpdir=tmpdir, filename=filename, file_path=fpath)
+    log.debug("[API] upload stored session=%s path=%s", session_id, fpath)
+    return jsonify({"ok": True, "session_id": session_id, "filename": filename})
 
-    # Step 1: Load and chunk pages
-    log.debug("[STEP] load_document_to_text_pages")
-    pages = load_document_to_text_pages(fpath)
 
-    # Step 2: Detect headers/sections (regex + LLM assist)
-    log.debug("[STEP] detect_headers_and_sections")
-    sections = detect_headers_and_sections(pages)
+@app.post("/api/preprocess")
+def preprocess_document():
+    payload = request.get_json(force=True)
+    session_id = payload.get("session_id")
+    state = _get_state_or_404(session_id)
+    if not state:
+        return jsonify({"ok": False, "error": "Invalid session"}), 404
+    provider = _normalize_provider(payload.get("provider") or state.provider)
+    model = _resolve_model(provider, payload.get("model"))
+    ts = time.time()
+    pages = load_document_to_text_pages(state.file_path)
+    pre_chunks = standard_pre_chunks(pages)
+    state.pages = pages
+    state.pre_chunks = pre_chunks
+    state.model = model
+    state.provider = provider
+    elapsed = round((time.time() - ts) * 1000, 1)
+    log.debug("[API] preprocess pages=%s chunks=%s", len(pages), len(pre_chunks))
+    return jsonify({
+        "ok": True,
+        "pages": len(pages),
+        "pre_chunks": len(pre_chunks),
+        "metrics_ms": {"preprocess": elapsed}
+    })
 
-    # Step 3: Fluid refinement (merge/split; target ~1-2k tokens equiv.)
-    log.debug("[STEP] fluid_refine_chunks")
-    refined = fluid_refine_chunks(sections)
 
-    # Step 4: HEP clustering (entropy-based tf-idf seeding)
-    log.debug("[STEP] hep_cluster_chunks")
+@app.post("/api/determine-headers")
+def determine_headers():
+    payload = request.get_json(force=True)
+    session_id = payload.get("session_id")
+    state = _get_state_or_404(session_id)
+    if not state:
+        return jsonify({"ok": False, "error": "Invalid session"}), 404
+    if not state.pages:
+        return jsonify({"ok": False, "error": "Run preprocess first"}), 400
+    provider = _normalize_provider(payload.get("provider") or state.provider)
+    model = _resolve_model(provider, payload.get("model"))
+    state.model = model
+    state.provider = provider
+    client = create_llm_client(provider)
+    ts = time.time()
+    try:
+        section_chunks = asyncio.run(detect_headers_and_sections_async(state.pages, client, model))
+    except LLMAuthError as exc:
+        llm_debug = client.drain_debug_records()
+        log.error("[API] header detection auth error (%s): %s", provider, exc)
+        return jsonify({
+            "ok": False,
+            "error": str(exc),
+            "needs_api_key": provider == "openrouter",
+            "llm_debug": llm_debug
+        }), 401
+    except Exception as exc:
+        llm_debug = client.drain_debug_records()
+        log.exception("[API] header detection failed")
+        return jsonify({"ok": False, "error": str(exc), "llm_debug": llm_debug}), 500
+    llm_debug = client.drain_debug_records()
+    state.section_chunks = section_chunks
+    elapsed = round((time.time() - ts) * 1000, 1)
+    preview = [
+        {
+            "section_number": ch["section_number"],
+            "section_name": ch["section_name"],
+            "chars": len(ch["text"])
+        }
+        for ch in section_chunks[:5]
+    ]
+    return jsonify({
+        "ok": True,
+        "sections": len(section_chunks),
+        "preview": preview,
+        "metrics_ms": {"headers": elapsed},
+        "llm_debug": llm_debug
+    })
+
+
+@app.post("/api/process")
+def process_pipeline():
+    payload = request.get_json(force=True)
+    session_id = payload.get("session_id")
+    state = _get_state_or_404(session_id)
+    if not state:
+        return jsonify({"ok": False, "error": "Invalid session"}), 404
+    if not state.section_chunks:
+        return jsonify({"ok": False, "error": "Determine headers before processing"}), 400
+    provider = _normalize_provider(payload.get("provider") or state.provider)
+    model = _resolve_model(provider, payload.get("model"))
+    state.model = model
+    state.provider = provider
+    ts0 = time.time()
+    log.debug("[API] process session=%s provider=%s model=%s", session_id, provider, model)
+
+    refined = fluid_refine_chunks(state.section_chunks)
     clustered = hep_cluster_chunks(refined)
+    state.refined_chunks = refined
+    state.clustered_chunks = clustered
 
-    # Step 5: Async passes with OpenRouter
-    log.debug("[STEP] run_all_passes_async")
-    client = OpenRouterClient()
-    results = asyncio.run(run_all_passes_async(clustered, client, model=model))
-
-    # Step 6: Merge same specification text across passes
-    merged = {}
-    for r in results:
-        key = (r["document"], r["section_number"], r["section_name"], r["specification"].strip())
-        if key not in merged:
-            merged[key] = {
+    client = create_llm_client(provider)
+    try:
+        rows_raw = asyncio.run(run_all_passes_async(clustered, client, model=model))
+    except LLMAuthError as exc:
+        llm_debug = client.drain_debug_records()
+        log.error("[API] process auth error (%s): %s", provider, exc)
+        return jsonify({
+            "ok": False,
+            "error": str(exc),
+            "needs_api_key": provider == "openrouter",
+            "llm_debug": llm_debug
+        }), 401
+    rows_merged: Dict[Any, Dict[str, Any]] = {}
+    for r in rows_raw:
+        key = (
+            r["document"],
+            r["section_number"],
+            r["section_name"],
+            r["specification"].strip()
+        )
+        if key not in rows_merged:
+            rows_merged[key] = {
                 "Document": r["document"],
                 "(Sub)Section #": r["section_number"],
                 "(Sub)Section Name": r["section_name"],
                 "Specification": r["specification"].strip(),
-                "Pass": set([r["pass"]])
+                "Pass": {r["pass"]}
             }
         else:
-            merged[key]["Pass"].add(r["pass"])
+            rows_merged[key]["Pass"].add(r["pass"])
     rows = []
-    for v in merged.values():
-        v["Pass"] = "; ".join(sorted(list(v["Pass"])))
-        rows.append(v)
+    for value in rows_merged.values():
+        value["Pass"] = "; ".join(sorted(list(value["Pass"])))
+        rows.append(value)
 
-    # Step 7: CSV
     csv_bytes = rows_to_csv_bytes(rows)
     b64 = base64.b64encode(csv_bytes).decode("utf-8")
-
-    elapsed = round((time.time() - ts0)*1000, 1)
-    log.debug(f"[DONE] Process complete in {elapsed} ms, rows={len(rows)}")
-
+    elapsed = round((time.time() - ts0) * 1000, 1)
+    llm_debug = client.drain_debug_records()
+    log.debug("[DONE] Process session=%s rows=%s ms=%s", session_id, len(rows), elapsed)
     return jsonify({
         "ok": True,
         "rows": rows,
         "csv_base64": b64,
         "filename": "FluidRAG_results.csv",
-        "metrics_ms": {"total": elapsed}
+        "metrics_ms": {"total": elapsed},
+        "llm_debug": llm_debug
     })
 
-# Serve frontend assets
+
+@app.post("/api/llm-test")
+def llm_test():
+    payload = request.get_json(force=True, silent=True) or {}
+    provider = _normalize_provider(payload.get("provider"))
+    model = _resolve_model(provider, payload.get("model"))
+    client = create_llm_client(provider)
+
+    async def _probe():
+        system = "You validate connectivity for FluidRAG."
+        user = (
+            "Respond with JSON {\"status\": \"ok\", \"message\": \"FluidRAG connectivity confirmed\"}. "
+            "No additional text."
+        )
+        return await client.acomplete(model=model, system=system, user=user, temperature=0.0, max_tokens=120)
+
+    try:
+        content = asyncio.run(_probe())
+        parsed = json.loads(content)
+    except LLMAuthError as exc:
+        llm_debug = client.drain_debug_records()
+        return jsonify({
+            "ok": False,
+            "error": str(exc),
+            "needs_api_key": provider == "openrouter",
+            "llm_debug": llm_debug
+        }), 401
+    except json.JSONDecodeError:
+        llm_debug = client.drain_debug_records()
+        return jsonify({
+            "ok": False,
+            "error": "LLM returned non-JSON response",
+            "llm_debug": llm_debug,
+            "raw": content
+        }), 502
+    except Exception as exc:
+        llm_debug = client.drain_debug_records()
+        log.exception("[API] LLM test failed")
+        return jsonify({"ok": False, "error": str(exc), "llm_debug": llm_debug}), 500
+
+    llm_debug = client.drain_debug_records()
+    return jsonify({"ok": True, "response": parsed, "llm_debug": llm_debug})
+
+
 @app.get("/<path:asset>")
 def static_proxy(asset):
     return app.send_static_file(asset)
+
 
 if __name__ == "__main__":
     port = int(os.environ.get("PORT", 5142))

--- a/backend/pipeline/llm.py
+++ b/backend/pipeline/llm.py
@@ -1,11 +1,36 @@
 import os
 import logging
-from typing import Optional, Dict, Any
+import time
+from typing import Optional
+
 import httpx
 
 log = logging.getLogger("FluidRAG.llm")
 
 OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
+LLAMACPP_URL = os.environ.get("LLAMACPP_URL", "http://localhost:8080/v1/chat/completions")
+
+
+class LLMAuthError(RuntimeError):
+    """Raised when an LLM endpoint reports an authorization failure."""
+
+    def __init__(self, message: str):
+        super().__init__(message)
+
+
+class OpenRouterAuthError(LLMAuthError):
+    """Compatibility alias for existing OpenRouter-specific handling."""
+
+
+class BaseLLMClient:
+    def __init__(self):
+        self._debug_records = []
+
+    def drain_debug_records(self):
+        data = list(self._debug_records)
+        self._debug_records.clear()
+        return data
+
 
 def _concat_old_style(system: Optional[str], user: str) -> str:
     """Return a single-string prompt where role and message are concatenated."""
@@ -15,21 +40,24 @@ def _concat_old_style(system: Optional[str], user: str) -> str:
     parts.append(f"user: {user.strip()}")
     return "\n\n".join(parts)
 
-class OpenRouterClient:
+class OpenRouterClient(BaseLLMClient):
     def __init__(self, api_key: Optional[str] = None):
+        super().__init__()
         self.api_key = api_key or os.environ.get("OPENROUTER_API_KEY", "").strip()
+        self._auth_error_message: Optional[str] = None
         if not self.api_key:
             log.warning("[llm] OPENROUTER_API_KEY not set; returning mock outputs")
 
     async def acomplete(self, model: str, system: Optional[str], user: str, **kwargs) -> str:
         prompt = _concat_old_style(system, user)
-        if not self.api_key:
-            return '[]'  # mock JSON for offline
-
-        headers = {
-            "Authorization": f"Bearer {self.api_key}",
-            "HTTP-Referer": "https://localhost/",
-            "X-Title": "FluidRAG"
+        timestamp = time.time()
+        base_record = {
+            "model": model,
+            "timestamp": timestamp,
+            "request": {
+                "url": OPENROUTER_URL,
+                "prompt": prompt,
+            }
         }
         payload = {
             "model": model,
@@ -39,10 +67,206 @@ class OpenRouterClient:
             "temperature": kwargs.get("temperature", 0.2),
             "max_tokens": kwargs.get("max_tokens", 512)
         }
+        headers_log = {
+            "HTTP-Referer": "https://localhost/",
+            "X-Title": "FluidRAG"
+        }
+        if self._auth_error_message:
+            record = dict(base_record)
+            record["request"].update({
+                "headers": {**headers_log, "Authorization": "*** (cached failure)"},
+                "payload": payload
+            })
+            record["response"] = {
+                "status": 401,
+                "error": self._auth_error_message,
+                "cached": True
+            }
+            self._debug_records.append(record)
+            raise OpenRouterAuthError(self._auth_error_message)
+        if not self.api_key:
+            record = dict(base_record)
+            record["request"].update({
+                "headers": {**headers_log, "Authorization": "(missing)"},
+                "payload": payload
+            })
+            record["response"] = {"mock": True, "body": "[]"}
+            self._debug_records.append(record)
+            return '[]'  # mock JSON for offline
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "HTTP-Referer": "https://localhost/",
+            "X-Title": "FluidRAG"
+        }
         timeout = httpx.Timeout(60.0, connect=20.0)
-        async with httpx.AsyncClient(timeout=timeout, http2=True) as client:
-            r = await client.post(OPENROUTER_URL, headers=headers, json=payload)
-            r.raise_for_status()
-            data = r.json()
-            content = data["choices"][0]["message"]["content"]
-            return content or ""
+        headers_log = {**headers_log, "Authorization": "***"}
+        record = dict(base_record)
+        record["request"].update({
+            "headers": headers_log,
+            "payload": payload
+        })
+        try:
+            async with httpx.AsyncClient(timeout=timeout, http2=True) as client:
+                r = await client.post(OPENROUTER_URL, headers=headers, json=payload)
+                status = r.status_code
+                r.raise_for_status()
+                data = r.json()
+                content = data["choices"][0]["message"]["content"]
+                record["response"] = {
+                    "status": status,
+                    "body": data,
+                    "content": content
+                }
+                return content or ""
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code if exc.response else None
+            body_text: Optional[str] = None
+            try:
+                body_text = exc.response.text
+            except Exception:  # pragma: no cover - defensive
+                body_text = None
+            record["response"] = {
+                "status": status,
+                "error": str(exc),
+                "body_text": body_text
+            }
+            if status == 401:
+                message = (
+                    "OpenRouter rejected the request (401 Unauthorized). "
+                    "Confirm that OPENROUTER_API_KEY is set to a valid key "
+                    "with access to the selected model."
+                )
+                self._auth_error_message = message
+                log.error("[llm] %s", message)
+                raise OpenRouterAuthError(message) from exc
+            log.exception("[llm] HTTP error from OpenRouter")
+            raise
+        except Exception as exc:
+            record["response"] = {
+                "status": None,
+                "error": str(exc)
+            }
+            log.exception("[llm] request failed")
+            raise
+        finally:
+            self._debug_records.append(record)
+
+
+class LlamaCppClient(BaseLLMClient):
+    """Client for llama.cpp servers that expose an OpenAI-compatible API."""
+
+    def __init__(self, base_url: Optional[str] = None, api_key: Optional[str] = None):
+        super().__init__()
+        self.base_url = (base_url or LLAMACPP_URL).rstrip("/")
+        self.api_key = api_key or os.environ.get("LLAMACPP_API_KEY", "").strip()
+        self._auth_error_message: Optional[str] = None
+
+    async def acomplete(self, model: str, system: Optional[str], user: str, **kwargs) -> str:
+        prompt = _concat_old_style(system, user)
+        timestamp = time.time()
+        base_record = {
+            "model": model,
+            "timestamp": timestamp,
+            "request": {
+                "url": self.base_url,
+                "prompt": prompt,
+            }
+        }
+
+        payload = {
+            "model": model,
+            "messages": [
+                {"role": "system", "content": system or ""},
+                {"role": "user", "content": user}
+            ],
+            "temperature": kwargs.get("temperature", 0.2),
+            "max_tokens": kwargs.get("max_tokens", 512)
+        }
+
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        record = dict(base_record)
+        log_headers = dict(headers)
+        if "Authorization" in log_headers:
+            log_headers["Authorization"] = "***"
+        record["request"].update({
+            "headers": log_headers,
+            "payload": payload
+        })
+
+        if self._auth_error_message:
+            record["response"] = {
+                "status": 401,
+                "error": self._auth_error_message,
+                "cached": True
+            }
+            self._debug_records.append(record)
+            raise LLMAuthError(self._auth_error_message)
+
+        timeout = httpx.Timeout(60.0, connect=20.0)
+        try:
+            async with httpx.AsyncClient(timeout=timeout, http2=True) as client:
+                r = await client.post(self.base_url, headers=headers, json=payload)
+                status = r.status_code
+                r.raise_for_status()
+                data = r.json()
+                message = data.get("choices", [{}])[0]
+                content = (
+                    message.get("message", {}).get("content")
+                    if isinstance(message.get("message"), dict)
+                    else message.get("text", "")
+                )
+                record["response"] = {
+                    "status": status,
+                    "body": data,
+                    "content": content
+                }
+                return content or ""
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code if exc.response else None
+            body_text: Optional[str] = None
+            try:
+                body_text = exc.response.text
+            except Exception:
+                body_text = None
+            record["response"] = {
+                "status": status,
+                "error": str(exc),
+                "body_text": body_text
+            }
+            if status in (401, 403):
+                message = (
+                    "The llama.cpp endpoint rejected the request (authorization failure). "
+                    "Confirm that the server is running and credentials (if any) are correct."
+                )
+                self._auth_error_message = message
+                log.error("[llm] %s", message)
+                raise LLMAuthError(message) from exc
+            log.exception("[llm] HTTP error from llama.cpp endpoint")
+            raise
+        except Exception as exc:
+            record["response"] = {
+                "status": None,
+                "error": str(exc)
+            }
+            log.exception("[llm] llama.cpp request failed")
+            raise
+        finally:
+            self._debug_records.append(record)
+
+
+def create_llm_client(provider: str) -> BaseLLMClient:
+    normalized = (provider or "openrouter").strip().lower()
+    if normalized == "llamacpp":
+        return LlamaCppClient()
+    return OpenRouterClient()
+
+
+def provider_default_model(provider: str) -> Optional[str]:
+    normalized = (provider or "openrouter").strip().lower()
+    if normalized == "llamacpp":
+        return os.environ.get("LLAMACPP_DEFAULT_MODEL")
+    return None

--- a/backend/pipeline/passes.py
+++ b/backend/pipeline/passes.py
@@ -1,15 +1,73 @@
 import asyncio
 import json
 import logging
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Tuple
 
-from .llm import OpenRouterClient
+from .llm import BaseLLMClient, LLMAuthError
+from .preprocess import approximate_tokens
 from ..prompts import PASS_PROMPTS
 
 log = logging.getLogger("FluidRAG.passes")
 
-async def _extract_for_pass(client: OpenRouterClient, model: str, chunk: Dict[str, Any], pass_name: str):
-    system = f"You are analyzing a technical specification for the '{pass_name}' domain. "              f"Return ONLY a JSON array of exact quotations from the provided text."
+PASS_KEYWORDS = {
+    "Mechanical": [
+        "material", "dimension", "torque", "pressure", "flow", "tolerance", "fastener",
+        "ip", "nema", "mount", "weight", "temperature", "lubrication", "bearing"
+    ],
+    "Electrical": [
+        "voltage", "current", "power", "phase", "frequency", "breaker", "fuse",
+        "wire", "ground", "emc", "ul", "ce", "panel", "circuit"
+    ],
+    "Controls": [
+        "plc", "pac", "i/o", "sensor", "actuator", "protocol", "safety", "relay",
+        "interlock", "hmi", "logic", "alarm", "sequence"
+    ],
+    "Software": [
+        "software", "code", "language", "version", "library", "os", "endpoint", "database",
+        "logging", "cyber", "backup", "testing", "validation"
+    ],
+    "Project Management": [
+        "deliverable", "milestone", "approval", "documentation", "training", "fat",
+        "sat", "warranty", "responsibility", "schedule", "change", "review"
+    ]
+}
+
+
+def _score_chunk(chunk: Dict[str, Any], pass_name: str) -> Tuple[float, int]:
+    text_lower = chunk["text"].lower()
+    score = 0.0
+    for kw in PASS_KEYWORDS.get(pass_name, []):
+        if kw in text_lower:
+            score += 1.0
+    score += float(chunk.get("meta", {}).get("hep_entropy", 0.0)) * 0.1
+    tokens = approximate_tokens(chunk["text"])
+    return score, tokens
+
+
+def _select_chunks_for_pass(chunks: List[Dict[str, Any]], pass_name: str, max_tokens: int) -> List[Dict[str, Any]]:
+    scored = []
+    for ch in chunks:
+        score, tokens = _score_chunk(ch, pass_name)
+        scored.append((score, tokens, ch))
+    scored.sort(key=lambda item: item[0], reverse=True)
+    selected: List[Dict[str, Any]] = []
+    budget = 0
+    for score, tokens, ch in scored:
+        if selected and budget + tokens > max_tokens:
+            continue
+        selected.append(ch)
+        budget += tokens
+    if not selected and scored:
+        selected = [scored[0][2]]
+    log.debug("[passes] %s selected %s chunks (budget=%s tokens)", pass_name, len(selected), budget)
+    return selected
+
+
+async def _extract_for_pass(client: BaseLLMClient, model: str, chunk: Dict[str, Any], pass_name: str):
+    system = (
+        f"You are analyzing a technical specification for the '{pass_name}' domain. "
+        f"Return ONLY a JSON array of exact quotations from the provided text."
+    )
     user = PASS_PROMPTS[pass_name] + "\n\nTEXT:\n" + chunk["text"]
     try:
         content = await client.acomplete(model=model, system=system, user=user, temperature=0.0, max_tokens=800)
@@ -21,34 +79,36 @@ async def _extract_for_pass(client: OpenRouterClient, model: str, chunk: Dict[st
                 if s2 and s2 not in out:
                     out.append(s2)
         return out
-    except Exception as e:
+    except LLMAuthError as exc:
+        log.error("[passes] Authorization failure for %s pass: %s", pass_name, exc)
+        raise
+    except Exception:
         log.exception(f"[passes] LLM extraction failed for {pass_name} chunk")
         return []
 
-async def run_all_passes_async(chunks: List[Dict[str, Any]], client: OpenRouterClient, model: str):
-    """Run Mechanical/Electrical/Controls/Software/PM passes asynchronously over chunks."""
+
+async def run_all_passes_async(chunks: List[Dict[str, Any]], client: BaseLLMClient, model: str, max_tokens: int = 120_000):
+    """Run Mechanical/Electrical/Controls/Software/PM passes asynchronously over filtered chunks."""
     pass_names = list(PASS_PROMPTS.keys())
     tasks = []
-    for ch in chunks:
-        for pn in pass_names:
+    job_meta = []
+    for pn in pass_names:
+        selected = _select_chunks_for_pass(chunks, pn, max_tokens)
+        for ch in selected:
             tasks.append(_extract_for_pass(client, model, ch, pn))
-
+            job_meta.append((pn, ch))
     log.debug(f"[passes] launching {len(tasks)} async LLM extractions")
     results = await asyncio.gather(*tasks)
 
     rows = []
-    idx = 0
-    for ch in chunks:
-        for pn in pass_names:
-            specs = results[idx]
-            idx += 1
-            for spec in specs:
-                rows.append({
-                    "document": ch["document"],
-                    "section_number": ch["section_number"],
-                    "section_name": ch["section_name"],
-                    "specification": spec,
-                    "pass": pn
-                })
+    for (pn, ch), specs in zip(job_meta, results):
+        for spec in specs:
+            rows.append({
+                "document": ch["document"],
+                "section_number": ch["section_number"],
+                "section_name": ch["section_name"],
+                "specification": spec,
+                "pass": pn
+            })
     log.debug(f"[passes] extracted rows={len(rows)}")
     return rows

--- a/backend/pipeline/preprocess.py
+++ b/backend/pipeline/preprocess.py
@@ -1,6 +1,8 @@
+import asyncio
+import json
 import re
 import logging
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Iterable, Optional, Tuple
 
 from pypdf import PdfReader
 from docx import Document
@@ -9,6 +11,14 @@ log = logging.getLogger("FluidRAG.preprocess")
 
 HEADER_RX = re.compile(r"^\s*(\d+(?:\.\d+)*)\s*(?:[-:]|\s+)\s*(.+?)\s*$")
 ALT_HEADER_RX = re.compile(r"^\s*Section\s+(\d+(?:\.\d+)*)\s*[-:]?\s*(.+?)\s*$", re.IGNORECASE)
+
+APPROX_CHARS_PER_TOKEN = 4
+
+
+def approximate_tokens(text: str) -> int:
+    """Rough token estimate assuming ~4 characters per token."""
+    return max(1, len(text) // APPROX_CHARS_PER_TOKEN)
+
 
 def load_document_to_text_pages(path: str) -> List[str]:
     """Return list of page strings. Supports PDF, DOCX, TXT."""
@@ -31,6 +41,67 @@ def load_document_to_text_pages(path: str) -> List[str]:
         log.debug(f"[preprocess] TXT pseudo-pages={len(pages)}")
         return pages
 
+
+def standard_pre_chunks(pages: List[str], max_tokens: int = 4000, overlap_tokens: int = 400) -> List[Dict[str, Any]]:
+    """Return coarse-grained chunks prior to header detection."""
+    text = "\n".join(pages)
+    max_chars = max_tokens * APPROX_CHARS_PER_TOKEN
+    overlap_chars = overlap_tokens * APPROX_CHARS_PER_TOKEN
+    chunks: List[Dict[str, Any]] = []
+    start = 0
+    while start < len(text):
+        end = min(len(text), start + max_chars)
+        chunk_text = text[start:end]
+        if end < len(text):
+            nl = text.rfind("\n", start, end)
+            if nl != -1 and nl > start + 200:
+                chunk_text = text[start:nl]
+                end = nl
+        chunks.append({
+            "document": "Uploaded Document",
+            "section_number": "",
+            "section_name": "Pre-chunk",
+            "text": chunk_text.strip(),
+            "meta": {"approx_start": start, "approx_end": end}
+        })
+        if end >= len(text):
+            break
+        start = max(0, end - overlap_chars)
+    log.debug(f"[preprocess] standard pre-chunks={len(chunks)}")
+    return chunks
+
+
+def _chunk_text_for_headers(pages: List[str], max_tokens: int = 120_000) -> Iterable[Dict[str, Any]]:
+    """Yield chunks (joined pages) capped to the token budget for header detection."""
+    if not pages:
+        return []
+    chunks: List[Dict[str, Any]] = []
+    current_pages: List[str] = []
+    start_page = 0
+    for idx, page in enumerate(pages):
+        candidate_pages = current_pages + [page]
+        candidate_text = "\n".join(candidate_pages)
+        candidate_tokens = approximate_tokens(candidate_text)
+        if current_pages and candidate_tokens > max_tokens:
+            chunks.append({
+                "start_page": start_page,
+                "end_page": start_page + len(current_pages) - 1,
+                "text": "\n".join(current_pages)
+            })
+            current_pages = [page]
+            start_page = idx
+        else:
+            current_pages = candidate_pages
+    if current_pages:
+        chunks.append({
+            "start_page": start_page,
+            "end_page": start_page + len(current_pages) - 1,
+            "text": "\n".join(current_pages)
+        })
+    log.debug(f"[preprocess] header LLM chunks={len(chunks)}")
+    return chunks
+
+
 def _initial_header_spans(pages: List[str]):
     """First pass: use regex to locate section headings and spans."""
     headers = []
@@ -44,21 +115,85 @@ def _initial_header_spans(pages: List[str]):
     log.debug(f"[preprocess] detected headers via regex = {len(headers)}")
     return headers
 
-def detect_headers_and_sections(pages: List[str]):
-    """Return chunks as dicts: document, section_number, section_name, text, meta."""
-    heads = _initial_header_spans(pages)
-    chunks = []
-    for i, h in enumerate(heads):
+
+def _locate_heading_in_pages(pages: List[str], section_number: str, section_name: str, start_page: int, end_page: int) -> Optional[Tuple[int, int]]:
+    search_patterns = [
+        rf"\b{re.escape(section_number)}\b\s*[-:.]?\s*{re.escape(section_name)}",
+        rf"Section\s+{re.escape(section_number)}\s*[-:.]?\s*{re.escape(section_name)}",
+        rf"{re.escape(section_number)}\s+{re.escape(section_name)}"
+    ]
+    compiled = [re.compile(pat, re.IGNORECASE) for pat in search_patterns]
+    for pi in range(start_page, min(end_page + 1, len(pages))):
+        lines = pages[pi].splitlines()
+        for li, line in enumerate(lines):
+            for rx in compiled:
+                if rx.search(line.strip()):
+                    return pi, li
+    return None
+
+
+async def detect_headers_and_sections_async(pages: List[str], client, model: str) -> List[Dict[str, Any]]:
+    """Combine regex + LLM detected headers and return section chunks."""
+    regex_headers = _initial_header_spans(pages)
+
+    from ..prompts import HEADER_DETECTION_SYSTEM
+
+    llm_headers: List[Dict[str, Any]] = []
+    header_chunks = list(_chunk_text_for_headers(pages))
+    if header_chunks:
+        tasks = []
+        for chunk in header_chunks:
+            user = (
+                "You are given an excerpt from a technical document. "
+                "Identify every numbered section or subsection heading present. "
+                "Return JSON array [{\"section_number\":\"\", \"section_name\":\"\"}] with no prose.\n\nTEXT:\n"
+                + chunk["text"]
+            )
+            tasks.append(client.acomplete(model=model, system=HEADER_DETECTION_SYSTEM, user=user, temperature=0.0, max_tokens=800))
+
+        responses = await asyncio.gather(*tasks, return_exceptions=True)
+        for chunk, resp in zip(header_chunks, responses):
+            if isinstance(resp, Exception):
+                log.error("[preprocess] header LLM chunk %s failed: %s", chunk["start_page"], resp)
+                continue
+            try:
+                data = json.loads(resp)
+            except json.JSONDecodeError:
+                log.error("[preprocess] header LLM response not JSON: %s", resp)
+                continue
+            for item in data:
+                if not isinstance(item, dict):
+                    continue
+                section_number = str(item.get("section_number", "")).strip()
+                section_name = str(item.get("section_name", "")).strip()
+                if not section_number or not section_name:
+                    continue
+                loc = _locate_heading_in_pages(pages, section_number, section_name, chunk["start_page"], chunk["end_page"])
+                if loc is None:
+                    log.debug("[preprocess] unable to localize heading %s %s", section_number, section_name)
+                    continue
+                llm_headers.append({
+                    "page": loc[0],
+                    "line": loc[1],
+                    "section_number": section_number,
+                    "section_name": section_name
+                })
+
+    combined = {(h["page"], h["line"], h["section_number"], h["section_name"]): h for h in regex_headers}
+    for h in llm_headers:
+        combined[(h["page"], h["line"], h["section_number"], h["section_name"])] = h
+
+    headers = sorted(combined.values(), key=lambda h: (h["page"], h["line"]))
+    chunks: List[Dict[str, Any]] = []
+    for i, h in enumerate(headers):
         start_page = h["page"]
         start_line = h["line"]
-        end_page = heads[i+1]["page"] if i+1 < len(heads) else len(pages)-1
-        # gather text from start to next header
-        seg_lines = []
+        end_page = headers[i + 1]["page"] if i + 1 < len(headers) else len(pages) - 1
+        seg_lines: List[str] = []
         for pi in range(start_page, end_page + 1):
             lines = pages[pi].splitlines()
-            s = start_line if pi == start_page else 0
-            e = len(lines) if pi < end_page else len(lines)
-            seg_lines.extend(lines[s:e])
+            start_idx = start_line if pi == start_page else 0
+            seg_lines.extend(lines[start_idx:])
         text = "\n".join(seg_lines).strip()
         if not text:
             continue
@@ -69,7 +204,6 @@ def detect_headers_and_sections(pages: List[str]):
             "text": text,
             "meta": {"start_page": start_page, "end_page": end_page}
         })
-    # Fallback: if no headers, treat full doc as one chunk
     if not chunks:
         all_text = "\n".join(pages)
         chunks = [{
@@ -77,7 +211,7 @@ def detect_headers_and_sections(pages: List[str]):
             "section_number": "",
             "section_name": "Body",
             "text": all_text,
-            "meta": {"start_page": 0, "end_page": len(pages)-1}
+            "meta": {"start_page": 0, "end_page": len(pages) - 1}
         }]
-    log.debug(f"[preprocess] sections={len(chunks)}")
+    log.debug(f"[preprocess] sections={len(chunks)} (regex={len(regex_headers)} llm={len(llm_headers)})")
     return chunks

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -1,10 +1,13 @@
 :root{
-  --bg:#f7f7fb;
+  --bg:#f4f6fb;
   --card:#ffffff;
-  --text:#111827;
-  --muted:#6b7280;
-  --acc:#2563eb;
-  --border:#e5e7eb;
+  --text:#1a1c24;
+  --muted:#6f7787;
+  --accent:#2563eb;
+  --accent-soft:#e8f0ff;
+  --border:#d8deeb;
+  --success:#047857;
+  --warning:#b45309;
 }
 
 *{box-sizing:border-box;}
@@ -13,53 +16,109 @@ body{
   margin:0;
   background:var(--bg);
   color:var(--text);
-  font:15px/1.5 system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji","Segoe UI Emoji";
+  font:15px/1.6 "Segoe UI", "Helvetica Neue", Arial, sans-serif;
 }
 
 .app-header{
-  display:flex;align-items:center;justify-content:space-between;
-  padding:14px 20px;border-bottom:1px solid var(--border);
-  background:#fff;
-  position:sticky;top:0;z-index:10;
+  display:flex;
+  align-items:center;
+  justify-content:space-between;
+  padding:14px 24px;
+  border-bottom:1px solid var(--border);
+  background:linear-gradient(120deg,#fff, #f7f9ff);
+  position:sticky;
+  top:0;
+  z-index:10;
 }
-.brand{font-weight:700;font-size:18px;}
-.subtitle{color:var(--muted);}
+.brand{font-weight:700;font-size:19px;letter-spacing:0.4px;}
+.subtitle{color:var(--muted);font-size:13px;}
 
-.container{max-width:1100px;margin:18px auto;padding:0 16px;}
+.container{max-width:1180px;margin:24px auto;padding:0 20px;}
 
 .card{
   background:var(--card);
   border:1px solid var(--border);
-  border-radius:14px;
-  padding:16px 16px 10px;
-  margin-bottom:18px;
-  box-shadow:0 1px 2px rgba(0,0,0,.05);
+  border-radius:16px;
+  padding:18px 20px 16px;
+  margin-bottom:20px;
+  box-shadow:0 10px 30px rgba(15,23,42,0.08);
 }
-.card h2{margin:4px 0 12px 2px;font-size:16px;}
+.card h2{margin:4px 0 12px;font-size:16px;font-weight:600;}
 
-.grid{display:grid;grid-template-columns:1fr 2fr auto;gap:12px;align-items:end;}
+.grid{display:grid;gap:14px;align-items:end;}
+.grid-steps{grid-template-columns:2fr 1fr auto;}
+@media(max-width:900px){.grid-steps{grid-template-columns:1fr;} .form-row.right{align-items:flex-start;}}
+
 .form-row{display:flex;flex-direction:column;gap:6px;}
-.form-row.right{align-items:flex-end;}
-label{font-size:12px;color:var(--muted);}
+.form-row.right{align-items:flex-end;gap:10px;}
+label{font-size:12px;color:var(--muted);text-transform:uppercase;letter-spacing:0.05em;}
 input[type="file"], select, button{
-  padding:10px;border:1px solid var(--border);border-radius:10px;background:#fff;color:var(--text);
+  padding:11px 12px;
+  border:1px solid var(--border);
+  border-radius:12px;
+  background:#fff;
+  color:var(--text);
+  font-size:14px;
+  transition:all .15s ease;
 }
-button{background:var(--acc);color:#fff;border:none;cursor:pointer;padding:10px 16px;font-weight:600;}
-button:hover{opacity:.95}
+select{min-width:220px;}
 
-.status{color:var(--muted);padding:6px 4px 0 2px;}
+button{
+  background:var(--accent);
+  color:#fff;
+  border:none;
+  cursor:pointer;
+  font-weight:600;
+  box-shadow:0 4px 8px rgba(37,99,235,0.28);
+}
+button:hover{transform:translateY(-1px);box-shadow:0 6px 14px rgba(37,99,235,0.32);}
+button:disabled{background:#cbd5f5;color:#fff;cursor:not-allowed;box-shadow:none;transform:none;}
 
-.table-wrap{overflow:auto;border:1px solid var(--border);border-radius:10px;max-height:380px;}
+button.ghost{
+  background:var(--accent-soft);
+  color:var(--accent);
+  border:1px solid rgba(37,99,235,0.35);
+  box-shadow:none;
+}
+button.ghost:hover{background:#dbe5ff;box-shadow:none;}
+
+.actions{display:flex;gap:12px;flex-wrap:wrap;}
+
+.status{color:var(--muted);padding:6px 2px 0;font-size:13px;}
+.status.success{color:var(--success);}
+.status.warn{color:var(--warning);}
+
+.table-wrap{overflow:auto;border:1px solid var(--border);border-radius:12px;max-height:360px;margin-top:14px;background:#fff;}
 table{border-collapse:collapse;width:100%;}
-th, td{border-bottom:1px solid var(--border);padding:8px;text-align:left;font-size:13px;}
-th{background:#f3f4f6;position:sticky;top:0;z-index:1;}
+th,td{border-bottom:1px solid var(--border);padding:9px 10px;text-align:left;font-size:13px;}
+th{background:#f3f5fb;position:sticky;top:0;z-index:1;text-transform:uppercase;font-size:11px;letter-spacing:0.06em;color:#475569;}
+
+.preview-list{margin-top:10px;display:grid;gap:8px;}
+.preview-item{padding:10px 12px;border:1px solid var(--border);border-radius:10px;background:#f8faff;}
+.preview-item strong{display:block;font-size:13px;}
+.preview-item span{font-size:12px;color:var(--muted);}
 
 .log{
-  background:#0b1220;color:#dbeafe;border-radius:10px;
-  padding:12px;max-height:260px;overflow:auto;font-family:ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  background:#0b1220;
+  color:#dbeafe;
+  border-radius:12px;
+  padding:14px;
+  max-height:260px;
+  overflow:auto;
+  font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;
   font-size:12px;
 }
 
-.download-wrap{margin-top:10px;}
-.download-wrap a{display:inline-block;background:#10b981;color:white;padding:10px 12px;border-radius:10px;text-decoration:none;font-weight:600;}
+.download-wrap{margin-top:14px;}
+.download-wrap a{
+  display:inline-block;
+  background:#10b981;
+  color:white;
+  padding:11px 16px;
+  border-radius:12px;
+  text-decoration:none;
+  font-weight:600;
+  box-shadow:0 4px 12px rgba(16,185,129,0.35);
+}
 .hidden{display:none;}
+.empty{padding:16px;color:var(--muted);font-size:13px;}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8" />
@@ -9,40 +9,66 @@
 <body>
   <header class="app-header">
     <div class="brand">FluidRAG</div>
-    <div class="subtitle">Light theme • Copilot-inspired</div>
+    <div class="subtitle">Copilot-inspired light workspace for standard → Fluid → HEP</div>
   </header>
 
   <main class="container">
     <section class="card">
-      <h2>Run Extraction</h2>
-      <div class="grid">
+      <h2>1 · Document &amp; Model</h2>
+      <div class="grid grid-steps">
+        <div class="form-row">
+          <label for="file">Upload source document</label>
+          <input type="file" id="file" accept=".pdf,.docx,.txt" />
+        </div>
+        <div class="form-row">
+          <label for="provider">LLM provider</label>
+          <select id="provider"></select>
+        </div>
         <div class="form-row">
           <label for="model">Model</label>
           <select id="model"></select>
         </div>
-        <div class="form-row">
-          <label for="file">Document</label>
-          <input type="file" id="file" accept=".pdf,.docx,.txt"/>
-        </div>
         <div class="form-row right">
-          <button id="runBtn">Run</button>
+          <button id="uploadBtn">Upload</button>
+          <button id="testBtn" class="ghost">Test LLM</button>
         </div>
       </div>
-      <div id="status" class="status">Waiting…</div>
+      <div id="uploadStatus" class="status">Waiting for upload…</div>
     </section>
 
     <section class="card">
-      <h2>Preview</h2>
+      <h2>2 · Preprocess</h2>
+      <div class="actions">
+        <button id="preprocessBtn">Run standard chunking</button>
+      </div>
+      <div id="preprocessStatus" class="status">Pre-chunking pending…</div>
+    </section>
+
+    <section class="card">
+      <h2>3 · Determine Headers</h2>
+      <div class="actions">
+        <button id="headersBtn">Detect sections (≤120k tokens/request)</button>
+      </div>
+      <div id="headersStatus" class="status">Awaiting header detection…</div>
+      <div id="headersPreview" class="preview-list"></div>
+    </section>
+
+    <section class="card">
+      <h2>4 · Process Passes &amp; Review</h2>
+      <div class="actions">
+        <button id="processBtn">Run Mechanical · Electrical · Controls · Software · PM</button>
+      </div>
+      <div id="processStatus" class="status">Processing not started.</div>
       <div id="tableWrap" class="table-wrap"></div>
       <div id="downloadWrap" class="download-wrap hidden"></div>
     </section>
 
     <section class="card">
-      <h2>Logs</h2>
+      <h2>Activity Log</h2>
       <pre id="log" class="log"></pre>
     </section>
   </main>
 
-  <script type="module" src="/js/app.mjs"></script>
+  <script type="module" src="/js/app.mjs?v=20250219"></script>
 </body>
 </html>

--- a/frontend/js/api.mjs
+++ b/frontend/js/api.mjs
@@ -1,22 +1,100 @@
-export async function getModels(){
+function describeBody(body){
+  if(!body) return null;
+  if(body instanceof FormData){
+    const summary = {};
+    for(const [key, value] of body.entries()){
+      if(value instanceof File){
+        summary[key] = {
+          kind: "file",
+          name: value.name,
+          size: value.size,
+          type: value.type
+        };
+      }else{
+        summary[key] = {kind: "value", value};
+      }
+    }
+    return summary;
+  }
+  if(typeof body === "string"){
+    try{
+      return {kind:"json", value: JSON.parse(body)};
+    }catch{
+      return {kind:"text", value: body};
+    }
+  }
+  return body;
+}
+
+async function safeFetch(url, options){
+  const method = options?.method || "GET";
+  console.groupCollapsed(`[API] Request ${method} ${url}`);
+  if(options){
+    if(options.headers) console.log("Headers", options.headers);
+    if(Object.prototype.hasOwnProperty.call(options, "body")){
+      console.log("Body", describeBody(options.body));
+    }
+  }
+  console.groupEnd();
   try{
-    const r = await fetch("/api/models");
-    return await r.json();
-  }catch(e){
-    console.error("[API] models error", e);
-    return {ok:false, error:String(e)};
+    const res = await fetch(url, options);
+    let data;
+    try{
+      data = await res.json();
+    }catch(err){
+      console.warn(`[API] ${url} JSON parse error`, err);
+      data = {ok:false, error:"Invalid JSON response"};
+    }
+    data.httpStatus = res.status;
+    console.groupCollapsed(`[API] Response ${res.status} ${url}`);
+    console.log("Headers", Object.fromEntries(res.headers.entries()));
+    console.log("Body", data);
+    console.groupEnd();
+    return data;
+  }catch(err){
+    console.error(`[API] ${url} error`, err);
+    return {ok:false, error:String(err)};
   }
 }
 
-export async function processFile(file, model, onProgress){
+export async function getModels(){
+  return safeFetch("/api/models");
+}
+
+export async function uploadDocument(file){
   const fd = new FormData();
   fd.append("file", file);
-  fd.append("model", model);
-  try{
-    const r = await fetch("/api/process", { method:"POST", body: fd });
-    return await r.json();
-  }catch(e){
-    console.error("[API] process error", e);
-    return {ok:false, error:String(e)};
-  }
+  return safeFetch("/api/upload", {method:"POST", body:fd});
+}
+
+export async function preprocessDocument(sessionId, model, provider){
+  return safeFetch("/api/preprocess", {
+    method:"POST",
+    headers:{"Content-Type":"application/json"},
+    body:JSON.stringify({session_id:sessionId, model, provider})
+  });
+}
+
+export async function determineHeaders(sessionId, model, provider){
+  return safeFetch("/api/determine-headers", {
+    method:"POST",
+    headers:{"Content-Type":"application/json"},
+    body:JSON.stringify({session_id:sessionId, model, provider})
+  });
+}
+
+export async function processPasses(sessionId, model, provider){
+  return safeFetch("/api/process", {
+    method:"POST",
+    headers:{"Content-Type":"application/json"},
+    body:JSON.stringify({session_id:sessionId, model, provider})
+  });
+}
+
+export async function testLLM(model, provider){
+  return safeFetch("/api/llm-test", {
+    method:"POST",
+    headers:{"Content-Type":"application/json"},
+    body:JSON.stringify({model, provider})
+  });
 }

--- a/frontend/js/app.mjs
+++ b/frontend/js/app.mjs
@@ -1,7 +1,17 @@
-import { getModels, processFile } from "./api.mjs";
-import { renderTable } from "./ui.mjs";
+import { getModels, uploadDocument, preprocessDocument, determineHeaders, processPasses, testLLM } from "./api.mjs";
+import { renderTable, renderHeaderPreview } from "./ui.mjs";
 
 const el = (id)=>document.getElementById(id);
+const state = {
+  sessionId: null,
+  provider: null,
+  model: null,
+  hasPre: false,
+  hasHeaders: false,
+  rows: [],
+  providers: {}
+};
+
 const log = (msg)=>{
   const pre = el("log");
   const line = `[UI] ${new Date().toLocaleTimeString()} ${msg}`;
@@ -10,47 +20,323 @@ const log = (msg)=>{
   pre.scrollTop = pre.scrollHeight;
 };
 
-async function boot(){
-  log("Boot start");
-  const modelSel = el("model");
-  const { ok, models } = await getModels();
-  if(ok){
-    models.forEach(m=>{
-      const opt = document.createElement("option");
-      opt.value = m; opt.textContent = m;
-      modelSel.appendChild(opt);
-    });
-  }
-  log("Models loaded");
-  el("runBtn").addEventListener("click", onRun);
+function openGroup(label, collapsed=false){
+  if(collapsed) console.groupCollapsed(label);
+  else console.group(label);
+  return ()=>console.groupEnd();
 }
 
-async function onRun(){
-  const file = el("file").files[0];
-  const model = el("model").value;
-  if(!file){ alert("Pick a document first."); return; }
-  el("status").textContent = "Processing… please watch the log.";
-  log(`Begin process: ${file.name}, model=${model}`);
+function withGroup(label, fn, collapsed=false){
+  const end = openGroup(label, collapsed);
+  try{
+    fn();
+  }finally{
+    end();
+  }
+}
 
-  const res = await processFile(file, model, (pct)=>{});
-  if(!res.ok){
-    el("status").textContent = "Error: " + (res.error||"Unknown");
-    log("Process error: " + (res.error||"unknown"));
+function setStatus(node, message, tone){
+  node.textContent = message;
+  node.classList.remove("success","warn");
+  if(tone === "success") node.classList.add("success");
+  else if(tone === "warn") node.classList.add("warn");
+}
+
+function providerLabel(providerId = state.provider){
+  if(!providerId) return "provider";
+  const info = state.providers?.[providerId];
+  return info?.label || providerId;
+}
+
+function providerAuthHint(){
+  if(state.provider === "openrouter") return "set OPENROUTER_API_KEY";
+  if(state.provider === "llamacpp") return "ensure llama.cpp endpoint credentials are valid";
+  return "verify LLM credentials";
+}
+
+function refreshModelOptions(preferredModel = null){
+  const modelSel = el("model");
+  modelSel.innerHTML = "";
+  const providerId = state.provider;
+  const info = state.providers?.[providerId];
+  if(!info){
+    state.model = null;
+    console.warn("[State] Missing provider info; unable to populate models", {providerId});
     return;
   }
+  const models = Array.isArray(info.models) ? info.models : [];
+  models.forEach((m)=>{
+    const opt = document.createElement("option");
+    opt.value = m;
+    opt.textContent = m;
+    modelSel.appendChild(opt);
+  });
+  let selected = null;
+  if(preferredModel && models.includes(preferredModel)){
+    selected = preferredModel;
+  }else if(info.default_model && models.includes(info.default_model)){
+    selected = info.default_model;
+  }else if(models.length > 0){
+    selected = models[0];
+  }
+  if(selected){
+    modelSel.value = selected;
+    state.model = selected;
+  }else{
+    state.model = null;
+  }
+  console.debug("[State] Model options updated", {provider: providerId, model: state.model});
+}
 
-  el("status").textContent = `Done • rows=${res.rows.length} • total=${res.metrics_ms.total} ms`;
-  renderTable(el("tableWrap"), res.rows);
+function updateProvider(){
+  const providerSel = el("provider");
+  const newProvider = providerSel.value;
+  if(!newProvider) return;
+  if(!state.providers?.[newProvider]){
+    console.warn("[State] Unknown provider selected", {newProvider});
+    return;
+  }
+  state.provider = newProvider;
+  console.debug("[State] Provider updated", {provider: state.provider});
+  refreshModelOptions();
+  updateModel();
+}
 
-  const a = document.createElement("a");
-  const blob = b64ToBlob(res.csv_base64, "text/csv");
-  const url = URL.createObjectURL(blob);
-  a.href = url; a.download = res.filename;
-  a.textContent = "Download CSV";
-  const wrap = el("downloadWrap");
-  wrap.innerHTML = ""; wrap.appendChild(a); wrap.classList.remove("hidden");
+function dumpLLMDebug(debug){
+  if(!Array.isArray(debug) || debug.length === 0){
+    console.debug("[LLM] No debug entries to display");
+    return;
+  }
+  debug.forEach((entry, idx)=>{
+    const label = entry?.model || `LLM ${idx+1}`;
+    withGroup(`[LLM Debug] Entry ${idx+1}: ${label}`, ()=>{
+      withGroup("Request", ()=>{
+        console.log(entry?.request || {});
+      }, true);
+      withGroup("Response", ()=>{
+        console.log(entry?.response || {});
+      }, true);
+      if(entry?.error){
+        console.warn("Error", entry.error);
+      }
+    }, true);
+  });
+}
 
-  log("Process complete");
+function requireSession(){
+  if(!state.sessionId){
+    console.warn("[Guard] Session required but missing", {state});
+    alert("Upload a document first.");
+    return false;
+  }
+  return true;
+}
+
+function updateModel(){
+  const modelSel = el("model");
+  state.model = modelSel.value || null;
+  console.debug("[State] Model updated", {provider: state.provider, model: state.model});
+}
+
+function resetAfterUpload(){
+  state.hasPre = false;
+  state.hasHeaders = false;
+  state.rows = [];
+  renderTable(el("tableWrap"), []);
+  el("downloadWrap").classList.add("hidden");
+  el("headersPreview").innerHTML = "";
+  setStatus(el("preprocessStatus"), "Pre-chunking pending…");
+  setStatus(el("headersStatus"), "Awaiting header detection…");
+  setStatus(el("processStatus"), "Processing not started.");
+}
+
+async function onUpload(){
+  updateModel();
+  const end = openGroup("[Flow] Upload", false);
+  try{
+    const file = el("file").files[0];
+    if(!file){
+      console.warn("[Flow] Upload aborted: no file selected");
+      alert("Choose a .pdf, .docx, or .txt file first.");
+      return;
+    }
+    console.log("Selected file", {name:file.name, size:file.size, type:file.type});
+    console.log("State before upload", {...state});
+    setStatus(el("uploadStatus"), `Uploading ${file.name}…`);
+    log(`Uploading ${file.name}`);
+    const res = await uploadDocument(file);
+    withGroup("[Flow] Upload → API response", ()=>{
+      console.log(res);
+    }, true);
+    if(!res.ok){
+      const msg = res.error || "Upload failed";
+      setStatus(el("uploadStatus"), `Upload error: ${msg}`, "warn");
+      log(`Upload error: ${msg}`);
+      return;
+    }
+    state.sessionId = res.session_id;
+    resetAfterUpload();
+    setStatus(el("uploadStatus"), `Uploaded ${res.filename}. Session ${state.sessionId.slice(0,8)}…`, "success");
+    log(`Upload ok. session=${state.sessionId}`);
+    console.log("State after upload", {...state});
+  }finally{
+    end();
+  }
+}
+
+async function handleTestLLM(){
+  updateModel();
+  if(!state.provider){ alert("Select an LLM provider first."); return; }
+  if(!state.model){
+    alert("Select a model first.");
+    return;
+  }
+  const providerName = providerLabel();
+  const end = openGroup("[Flow] Test LLM", false);
+  try{
+    console.log("State before test", {...state});
+    log(`Testing ${providerName} connectivity via ${state.model}`);
+    withGroup("[Flow] Test LLM → Request payload", ()=>{
+      console.log({model: state.model, provider: state.provider});
+    }, true);
+    const res = await testLLM(state.model, state.provider);
+    withGroup(`[Flow] Test LLM → Raw response (${res.httpStatus ?? "?"})`, ()=>{
+      console.log(res);
+    }, true);
+    dumpLLMDebug(res.llm_debug);
+    if(!res.ok){
+      let msg = res.error || "LLM test failed";
+      if(res.needs_api_key) msg += ` — ${providerAuthHint()}`;
+      if(res.httpStatus) msg += ` (HTTP ${res.httpStatus})`;
+      setStatus(el("uploadStatus"), msg, "warn");
+      log(`LLM test error: ${msg}`);
+      return;
+    }
+    setStatus(el("uploadStatus"), `LLM connectivity confirmed (${providerName}): ${res.response?.status || "ok"}`, "success");
+    log(`LLM test succeeded via ${providerName}`);
+  }finally{
+    end();
+  }
+}
+
+async function onPreprocess(){
+  if(!requireSession()) return;
+  updateModel();
+  if(!state.provider){ alert("Select an LLM provider first."); return; }
+  if(!state.model){ alert("Select a model first."); return; }
+  const end = openGroup("[Flow] Preprocess", false);
+  try{
+    console.log("State before preprocess", {...state});
+    setStatus(el("preprocessStatus"), "Running standard chunking…");
+    log("Preprocess start");
+    withGroup("[Flow] Preprocess → Request payload", ()=>{
+      console.log({session_id: state.sessionId, model: state.model, provider: state.provider});
+    }, true);
+    const res = await preprocessDocument(state.sessionId, state.model, state.provider);
+    withGroup(`[Flow] Preprocess → Raw response (${res.httpStatus ?? "?"})`, ()=>{
+      console.log(res);
+    }, true);
+    if(!res.ok){
+      const msg = res.error || "Preprocess failed";
+      setStatus(el("preprocessStatus"), msg, "warn");
+      log(`Preprocess error: ${msg}`);
+      return;
+    }
+    state.hasPre = true;
+    setStatus(el("preprocessStatus"), `Pages=${res.pages}, pre-chunks=${res.pre_chunks}`, "success");
+    log(`Preprocess complete pages=${res.pages} chunks=${res.pre_chunks}`);
+    console.log("State after preprocess", {...state});
+  }finally{
+    end();
+  }
+}
+
+async function onHeaders(){
+  if(!requireSession()) return;
+  if(!state.hasPre){ alert("Run preprocess before header detection."); return; }
+  updateModel();
+  if(!state.provider){ alert("Select an LLM provider first."); return; }
+  if(!state.model){ alert("Select a model first."); return; }
+  const providerName = providerLabel();
+  const end = openGroup("[Flow] Header detection", false);
+  try{
+    console.log("State before header detection", {...state});
+    setStatus(el("headersStatus"), `Detecting headers via ${providerName}…`);
+    log(`Header detection start via ${providerName}`);
+    withGroup("[Flow] Header detection → Request payload", ()=>{
+      console.log({session_id: state.sessionId, model: state.model, provider: state.provider});
+    }, true);
+    const res = await determineHeaders(state.sessionId, state.model, state.provider);
+    withGroup(`[Flow] Header detection → Raw response (${res.httpStatus ?? "?"})`, ()=>{
+      console.log(res);
+    }, true);
+    dumpLLMDebug(res.llm_debug);
+    if(!res.ok){
+      let msg = res.error || "Header detection failed";
+      if(res.needs_api_key) msg += ` — ${providerAuthHint()}`;
+      if(res.httpStatus) msg += ` (HTTP ${res.httpStatus})`;
+      setStatus(el("headersStatus"), msg, "warn");
+      log(`Headers error: ${msg}`);
+      return;
+    }
+    state.hasHeaders = true;
+    setStatus(el("headersStatus"), `Sections detected: ${res.sections}`, "success");
+    renderHeaderPreview(el("headersPreview"), res.preview || []);
+    log(`Headers detected sections=${res.sections}`);
+    console.log("State after header detection", {...state});
+  }finally{
+    end();
+  }
+}
+
+async function onProcess(){
+  if(!requireSession()) return;
+  if(!state.hasHeaders){ alert("Detect headers before running the passes."); return; }
+  updateModel();
+  if(!state.provider){ alert("Select an LLM provider first."); return; }
+  if(!state.model){ alert("Select a model first."); return; }
+  const providerName = providerLabel();
+  const end = openGroup("[Flow] Pass processing", false);
+  try{
+    console.log("State before process", {...state});
+    setStatus(el("processStatus"), `Running asynchronous passes via ${providerName}…`);
+    log(`Passes start via ${providerName}`);
+    withGroup("[Flow] Pass processing → Request payload", ()=>{
+      console.log({session_id: state.sessionId, model: state.model, provider: state.provider});
+    }, true);
+    const res = await processPasses(state.sessionId, state.model, state.provider);
+    withGroup(`[Flow] Pass processing → Raw response (${res.httpStatus ?? "?"})`, ()=>{
+      console.log(res);
+    }, true);
+    dumpLLMDebug(res.llm_debug);
+    if(!res.ok){
+      let msg = res.error || "Process failed";
+      if(res.needs_api_key) msg += ` — ${providerAuthHint()}`;
+      if(res.httpStatus) msg += ` (HTTP ${res.httpStatus})`;
+      setStatus(el("processStatus"), msg, "warn");
+      log(`Process error: ${msg}`);
+      return;
+    }
+    state.rows = res.rows || [];
+    setStatus(el("processStatus"), `Rows=${state.rows.length} • total=${res.metrics_ms?.total ?? "?"} ms`, "success");
+    renderTable(el("tableWrap"), state.rows);
+    if(res.csv_base64){
+      const blob = b64ToBlob(res.csv_base64, "text/csv");
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = res.filename || "FluidRAG_results.csv";
+      link.textContent = "Download CSV";
+      const wrap = el("downloadWrap");
+      wrap.innerHTML = "";
+      wrap.appendChild(link);
+      wrap.classList.remove("hidden");
+    }
+    log("Process complete");
+    console.log("State after process", {...state});
+  }finally{
+    end();
+  }
 }
 
 function b64ToBlob(b64, mime){
@@ -58,6 +344,41 @@ function b64ToBlob(b64, mime){
   const arr = new Uint8Array(b.length);
   for(let i=0;i<b.length;i++) arr[i] = b.charCodeAt(i);
   return new Blob([arr], {type: mime});
+}
+
+async function boot(){
+  log("Boot start");
+  renderTable(el("tableWrap"), []);
+  const providerSel = el("provider");
+  const modelSel = el("model");
+  const models = await getModels();
+  if(models.ok && models.providers){
+    state.providers = models.providers;
+    const entries = Object.entries(state.providers);
+    entries.forEach(([id, info])=>{
+      const opt = document.createElement("option");
+      opt.value = id;
+      opt.textContent = info?.label || id;
+      providerSel.appendChild(opt);
+    });
+    const defaultProvider = (models.default_provider && state.providers[models.default_provider])
+      ? models.default_provider
+      : (entries.length ? entries[0][0] : null);
+    if(defaultProvider){
+      state.provider = defaultProvider;
+      providerSel.value = defaultProvider;
+      refreshModelOptions(state.providers[defaultProvider]?.default_model);
+      updateModel();
+    }
+  }
+  providerSel.addEventListener("change", updateProvider);
+  modelSel.addEventListener("change", updateModel);
+  el("uploadBtn").addEventListener("click", onUpload);
+  el("testBtn").addEventListener("click", handleTestLLM);
+  el("preprocessBtn").addEventListener("click", onPreprocess);
+  el("headersBtn").addEventListener("click", onHeaders);
+  el("processBtn").addEventListener("click", onProcess);
+  log("Boot complete");
 }
 
 boot();

--- a/frontend/js/ui.mjs
+++ b/frontend/js/ui.mjs
@@ -1,4 +1,8 @@
 export function renderTable(target, rows){
+  if(!Array.isArray(rows) || rows.length === 0){
+    target.innerHTML = '<div class="empty">No specifications yet. Run the passes to populate results.</div>';
+    return;
+  }
   const cols = ["Document","(Sub)Section #","(Sub)Section Name","Specification","Pass"];
   const table = document.createElement("table");
   const thead = document.createElement("thead");
@@ -22,4 +26,23 @@ export function renderTable(target, rows){
   table.appendChild(tbody);
   target.innerHTML = "";
   target.appendChild(table);
+}
+
+export function renderHeaderPreview(target, preview){
+  if(!Array.isArray(preview) || preview.length === 0){
+    target.innerHTML = "";
+    return;
+  }
+  target.innerHTML = "";
+  preview.forEach(item=>{
+    const div = document.createElement("div");
+    div.className = "preview-item";
+    const title = document.createElement("strong");
+    title.textContent = `${item.section_number || '—'} ${item.section_name || ''}`.trim();
+    const meta = document.createElement("span");
+    meta.textContent = `${item.chars || 0} chars`;
+    div.appendChild(title);
+    div.appendChild(meta);
+    target.appendChild(div);
+  });
 }


### PR DESCRIPTION
## Summary
- refactor the OpenRouter and llama.cpp async completion helpers to wrap the HTTP client usage in outer try/except blocks
- ensure debug record handling remains in a finally clause so request/response metadata is always captured

## Testing
- python -m compileall backend

------
https://chatgpt.com/codex/tasks/task_e_68cb4cc174188324a12b8da00a9035c9