### PR TITLE
Fix syntax errors blocking model provider loading

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -60,7 +60,6 @@ ALLOWED_EXT = {".pdf", ".docx", ".txt"}
 
 
 OPENROUTER_FREE_MODELS: List[str] = [
-n
     "deepseek/deepseek-chat:free",
     "deepseek/deepseek-r1:free",
     "mistralai/mistral-7b-instruct:free",

--- a/frontend/js/app.mjs
+++ b/frontend/js/app.mjs
@@ -67,7 +67,6 @@ function refreshModelOptions(preferredModel = null){
     state.model = null;
     console.warn("[State] Missing provider info; unable to populate models", {providerId});
     return;
-<
   }
   const models = Array.isArray(info.models) ? info.models : [];
   models.forEach((m)=>{


### PR DESCRIPTION
## Summary
- remove a stray `<` so the frontend can populate model options without crashing
- drop the rogue character in the backend model list so the Flask app loads

## Testing
- python -m compileall backend/app.py frontend/js/app.mjs

------
https://chatgpt.com/codex/tasks/task_e_68ccad52988c8324a21743c25c969969