### PR TITLE
Align OpenRouter request format with reference service

### DIFF
--- a/backend/pipeline/llm.py
+++ b/backend/pipeline/llm.py
@@ -8,7 +8,7 @@ import httpx
 log = logging.getLogger("FluidRAG.llm")
 
 OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
-_DEFAULT_REFERER = "https://localhost/"
+_DEFAULT_REFERER = "http://localhost:5142"
 _DEFAULT_APP_TITLE = "FluidRAG"
 
 
@@ -48,6 +48,14 @@ class OpenRouterAuthError(LLMAuthError):
     """Compatibility alias for existing OpenRouter-specific handling."""
 
 
+def _format_prompt_for_log(messages) -> str:
+    """Return a debug-friendly string representation of chat messages."""
+
+    return "\n\n".join(
+        f"{message['role']}: {message['content'].strip()}" for message in messages
+    )
+
+
 class BaseLLMClient:
     def __init__(self):
         self._debug_records = []
@@ -56,18 +64,6 @@ class BaseLLMClient:
         data = list(self._debug_records)
         self._debug_records.clear()
         return data
-
-
-
-
-def _concat_old_style(system: Optional[str], user: str) -> str:
-    """Return a single-string prompt where role and message are concatenated."""
-    parts = []
-    if system:
-        parts.append(f"system: {system.strip()}")
-    parts.append(f"user: {user.strip()}")
-    return "\n\n".join(parts)
-
 class OpenRouterClient(BaseLLMClient):
     def __init__(self, api_key: Optional[str] = None):
         super().__init__()
@@ -85,7 +81,12 @@ class OpenRouterClient(BaseLLMClient):
         return data
 
     async def acomplete(self, model: str, system: Optional[str], user: str, **kwargs) -> str:
-        prompt = _concat_old_style(system, user)
+        if system:
+            merged = f"{system.strip()}\n\n{user}" if user else system
+        else:
+            merged = user
+        messages = [{"role": "user", "content": merged}]
+        prompt = _format_prompt_for_log(messages)
         timestamp = time.time()
         base_record = {
             "model": model,
@@ -97,15 +98,17 @@ class OpenRouterClient(BaseLLMClient):
         }
         payload = {
             "model": model,
-            "messages": [
-                {"role": "user", "content": prompt}
-            ],
-            "temperature": kwargs.get("temperature", 0.2),
-            "max_tokens": kwargs.get("max_tokens", 512)
+            "messages": messages,
+            "temperature": kwargs.get("temperature", 0.6),
+            "stream": kwargs.get("stream", False),
         }
+        max_tokens = kwargs.get("max_tokens")
+        if max_tokens is not None:
+            payload["max_tokens"] = max_tokens
         headers_log = {
             "HTTP-Referer": self.http_referer,
             "X-Title": self.app_title,
+            "Content-Type": "application/json",
         }
         if self._auth_error_message:
             record = dict(base_record)
@@ -134,6 +137,7 @@ class OpenRouterClient(BaseLLMClient):
             "Authorization": f"Bearer {self.api_key}",
             "HTTP-Referer": self.http_referer,
             "X-Title": self.app_title,
+            "Content-Type": "application/json",
         }
         timeout = httpx.Timeout(60.0, connect=20.0)
         headers_log = {**headers_log, "Authorization": "***"}
@@ -201,7 +205,13 @@ class LlamaCppClient(BaseLLMClient):
         self._auth_error_message: Optional[str] = None
 
     async def acomplete(self, model: str, system: Optional[str], user: str, **kwargs) -> str:
-        prompt = _concat_old_style(system, user)
+        messages = []
+        if system:
+            messages.append({"role": "system", "content": system})
+        elif system is not None:
+            messages.append({"role": "system", "content": ""})
+        messages.append({"role": "user", "content": user})
+        prompt = _format_prompt_for_log(messages)
         timestamp = time.time()
         base_record = {
             "model": model,
@@ -214,10 +224,7 @@ class LlamaCppClient(BaseLLMClient):
 
         payload = {
             "model": model,
-            "messages": [
-                {"role": "system", "content": system or ""},
-                {"role": "user", "content": user}
-            ],
+            "messages": messages,
             "temperature": kwargs.get("temperature", 0.2),
             "max_tokens": kwargs.get("max_tokens", 512)
         }


### PR DESCRIPTION
## Summary
- merge system content into the single user message OpenRouter payload used by the reference service
- set the OpenRouter temperature field with the service's default of 0.6 while still allowing overrides via kwargs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cddd76dffc8324ab8329fe12116d79