### PR TITLE
Add session-based local header endpoint and UI toggle

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -11,6 +11,7 @@ from .routes import models as models_route      # noqa: F401
 from .routes import upload as upload_route      # noqa: F401
 from .routes import preprocess as preprocess_route  # noqa: F401
 from .routes import headers as headers_route    # noqa: F401
+from .routes import pdf_headers as pdf_headers_route  # noqa: F401
 from .routes import process as process_route    # noqa: F401
 from .routes import llm_test as llm_test_route  # noqa: F401
 
@@ -39,6 +40,7 @@ def create_app() -> Flask:
     app.register_blueprint(upload_route.bp)
     app.register_blueprint(preprocess_route.bp)
     app.register_blueprint(headers_route.bp)
+    app.register_blueprint(pdf_headers_route.bp)
     app.register_blueprint(process_route.bp)
     app.register_blueprint(llm_test_route.bp)
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ scikit-learn==1.5.1
 nltk==3.9.1
 pypdf==4.3.1
 python-docx==1.1.2
+PyMuPDF==1.24.9

--- a/backend/routes/pdf_headers.py
+++ b/backend/routes/pdf_headers.py
@@ -1,0 +1,263 @@
+"""Deterministic PDF header extraction without LLM dependencies."""
+from __future__ import annotations
+
+import base64
+import logging
+import os
+import re
+from statistics import median
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from flask import Blueprint, jsonify, request
+
+try:
+    import fitz  # type: ignore[attr-defined]
+except ImportError as exc:  # pragma: no cover - dependency error surfaced at runtime
+    raise RuntimeError("PyMuPDF (fitz) is required for /api/pdf/headers") from exc
+
+bp = Blueprint("pdf_headers", __name__)
+log = logging.getLogger(__name__)
+
+_NUMBERED_RE = re.compile(r"^\s*(\d+(?:\.\d+)*)\s+(.+)$")
+_ALL_CAPS_RE = re.compile(r"^[A-Z0-9][A-Z0-9 \-–—:&/()]+$")
+
+
+def _load_session_pdf(session_id: str, pdf_path: Optional[str] = None) -> bytes:
+    """Return PDF bytes for an uploaded session or explicit path."""
+    if not session_id and not pdf_path:
+        raise ValueError("Session id or pdf_path required for session extraction")
+
+    if pdf_path:
+        candidate = str(pdf_path)
+    else:
+        uploads_dir = os.getenv("UPLOAD_FOLDER", "uploads")
+        candidate = os.path.join(uploads_dir, f"{session_id}.pdf")
+
+    if not os.path.isfile(candidate):
+        raise ValueError(f"PDF not found at {candidate}")
+
+    with open(candidate, "rb") as handle:
+        data = handle.read()
+    log.info("/api/pdf/headers loaded session file '%s' (%d bytes)", candidate, len(data))
+    return data
+
+
+def _decode_pdf_bytes(*, allow_session: bool = False) -> bytes:
+    """Return raw PDF bytes from multipart upload, JSON data URL, or session id."""
+    if "file" in request.files:
+        upload = request.files["file"]
+        data = upload.read()
+        log.info(
+            "/api/pdf/headers received multipart file '%s' (%d bytes)",
+            getattr(upload, "filename", "upload.pdf"),
+            len(data),
+        )
+        return data
+
+    payload = request.get_json(silent=True)
+    if isinstance(payload, dict):
+        data_url = payload.get("file_data")
+        if isinstance(data_url, str) and data_url.startswith("data:application/pdf;base64,"):
+            b64 = data_url.split(",", 1)[1]
+            data = base64.b64decode(b64)
+            log.info("/api/pdf/headers received base64 data URL (%d bytes)", len(data))
+            return data
+
+        if allow_session:
+            session_id = str(payload.get("session_id") or payload.get("session") or "")
+            pdf_path = payload.get("pdf_path") or payload.get("path")
+            if session_id or pdf_path:
+                return _load_session_pdf(session_id=session_id, pdf_path=pdf_path)
+
+    raise ValueError("No PDF provided. Use multipart 'file' or JSON body with 'file_data'.")
+
+
+def _get_toc(doc: "fitz.Document") -> List[Dict[str, Any]]:
+    toc_entries: List[Dict[str, Any]] = []
+    try:
+        for level, page, title in doc.get_toc(simple=True) or []:
+            toc_entries.append({"level": int(level), "page": int(page), "text": title or ""})
+    except Exception as exc:  # pragma: no cover - PyMuPDF behaviour varies by file
+        log.warning("Reading PDF outline failed: %s", exc)
+    return toc_entries
+
+
+def _span_is_bold(span: Dict[str, Any]) -> bool:
+    flags = int(span.get("flags", 0))
+    font = (span.get("font") or "").lower()
+    bold_flag = bool(flags & 2)
+    name_hint = any(token in font for token in ("bold", "black", "heavy", "semibold"))
+    return bold_flag or name_hint
+
+
+def _collect_page_lines(page: "fitz.Page") -> List[Dict[str, Any]]:
+    blocks = page.get_text("dict").get("blocks", [])
+    spans: List[Dict[str, Any]] = []
+    for block in blocks:
+        if block.get("type") != 0:
+            continue
+        for line in block.get("lines", []):
+            bbox = line.get("bbox", block.get("bbox", [0, 0, 0, 0]))
+            for span in line.get("spans", []):
+                text = (span.get("text") or "").strip()
+                if not text:
+                    continue
+                spans.append(
+                    {
+                        "text": text,
+                        "font_size": float(span.get("size", 0.0)),
+                        "font_name": span.get("font") or "",
+                        "is_bold": _span_is_bold(span),
+                        "x": float(bbox[0]),
+                        "y": float(bbox[1]),
+                    }
+                )
+    spans.sort(key=lambda rec: (rec["y"], rec["x"]))
+    return spans
+
+
+def _rank_font_sizes(pages: Sequence[Sequence[Dict[str, Any]]]) -> Dict[float, int]:
+    sizes = sorted({round(line["font_size"], 2) for page in pages for line in page}, reverse=True)
+    return {size: index + 1 for index, size in enumerate(sizes)}
+
+
+def _is_heading_like(text: str) -> bool:
+    if not text or len(text) > 160 or text.endswith("."):
+        return False
+    if _ALL_CAPS_RE.match(text):
+        return True
+    uppercase = sum(1 for char in text if char.isupper())
+    if uppercase >= max(1, len(text) // 3):
+        return True
+    words = len(text.split())
+    return 1 <= words <= 14
+
+
+def _numbering_depth(text: str) -> int:
+    match = _NUMBERED_RE.match(text)
+    if not match:
+        return 0
+    segments = match.group(1).split(".")
+    return min(6, len(segments))
+
+
+def _choose_level(font_rank: int, numbered_level: int) -> int:
+    if numbered_level:
+        return max(1, min(6, numbered_level))
+    return max(1, min(6, font_rank))
+
+
+def _filter_headers(pages: Sequence[Sequence[Dict[str, Any]]]) -> Tuple[List[Dict[str, Any]], float, Dict[float, int]]:
+    if not pages:
+        return [], 0.0, {}
+
+    font_rank = _rank_font_sizes(pages)
+    if font_rank:
+        log.info("Ranked font sizes (largest=1): %s", font_rank)
+
+    all_sizes = [line["font_size"] for page in pages for line in page]
+    size_median = median(all_sizes) if all_sizes else 0.0
+    log.info("Global font-size median: %.2f", size_median)
+
+    headers: List[Dict[str, Any]] = []
+    for page_number, page_lines in enumerate(pages, start=1):
+        for line in page_lines:
+            text = line["text"].strip()
+            if not text:
+                continue
+
+            size = round(line["font_size"], 2)
+            rank = font_rank.get(size, 999)
+            numbered_depth = _numbering_depth(text)
+            looks_big = size >= size_median + 0.01
+            looks_bold = bool(line["is_bold"])
+            heading_like = _is_heading_like(text)
+
+            if not (looks_big or looks_bold or numbered_depth or heading_like):
+                continue
+
+            level_font = min(rank, 6) if rank != 999 else 6
+            level_number = numbered_depth
+            level = _choose_level(level_font, level_number)
+
+            headers.append(
+                {
+                    "text": text,
+                    "page": page_number,
+                    "y": round(line["y"], 2),
+                    "font_size": size,
+                    "font_name": line["font_name"],
+                    "is_bold": looks_bold,
+                    "level_font": level_font,
+                    "level_numbering": level_number,
+                    "level": level,
+                }
+            )
+
+    deduped: List[Dict[str, Any]] = []
+    last_key: Tuple[int, str] | None = None
+    for header in headers:
+        key = (header["page"], header["text"].lower())
+        if key != last_key:
+            deduped.append(header)
+        last_key = key
+
+    log.info("Detected %d candidate headers after heuristics", len(deduped))
+    return deduped, size_median, font_rank
+
+
+def extract_headers(pdf_bytes: bytes) -> Dict[str, Any]:
+    with fitz.open(stream=pdf_bytes, filetype="pdf") as doc:
+        pages: List[List[Dict[str, Any]]] = []
+        for page_index in range(doc.page_count):
+            page = doc.load_page(page_index)
+            pages.append(_collect_page_lines(page))
+
+        headers, size_median, font_rank = _filter_headers(pages)
+        toc = _get_toc(doc)
+
+    font_rank_list = [{"size": size, "rank": rank} for size, rank in sorted(font_rank.items(), key=lambda item: item[1])]
+
+    return {
+        "ok": True,
+        "count": len(headers),
+        "headers": headers,
+        "toc": toc,
+        "notes": {
+            "extraction": "PyMuPDF deterministic (no LLM).",
+            "thresholds": {
+                "size_median": size_median,
+                "font_ranks": font_rank_list,
+            },
+        },
+    }
+
+
+@bp.post("/api/pdf/headers")
+def api_pdf_headers():
+    try:
+        pdf_bytes = _decode_pdf_bytes()
+    except ValueError as exc:
+        return jsonify({"ok": False, "error": str(exc)}), 400
+
+    try:
+        result = extract_headers(pdf_bytes)
+        return jsonify(result)
+    except Exception as exc:  # pragma: no cover - runtime parsing errors
+        log.exception("Deterministic header extraction failed")
+        return jsonify({"ok": False, "error": str(exc)}), 500
+
+
+@bp.post("/api/pdf/headers/session")
+def api_pdf_headers_session():
+    try:
+        pdf_bytes = _decode_pdf_bytes(allow_session=True)
+    except ValueError as exc:
+        return jsonify({"ok": False, "error": str(exc)}), 400
+
+    try:
+        result = extract_headers(pdf_bytes)
+        return jsonify(result)
+    except Exception as exc:  # pragma: no cover - runtime parsing errors
+        log.exception("Deterministic header extraction failed")
+        return jsonify({"ok": False, "error": str(exc)}), 500

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -51,8 +51,11 @@
 
       <h2>3 · Determine Headers</h2>
       <div class="actions">
-        <button id="headersBtn">Detect sections (≤120k tokens/request)</button>
+        <button id="localHeadersBtn" class="ghost">Detect headers locally (no LLM)</button>
+        <button id="headersBtn">Detect sections with LLM (≤120k tokens/request)</button>
       </div>
+      <div id="localHeadersStatus" class="status">Local header detection pending…</div>
+      <div id="localHeadersPreview" class="preview-list"></div>
       <div id="headersStatus" class="status">Awaiting header detection…</div>
       <div id="headersPreview" class="preview-list"></div>
     </section>

--- a/frontend/js/api.mjs
+++ b/frontend/js/api.mjs
@@ -86,6 +86,14 @@ export async function determineHeaders(sessionId, model, provider){
   });
 }
 
+export async function determineLocalHeaders(sessionId){
+  return safeFetch("/api/pdf/headers/session", {
+    method:"POST",
+    headers:{"Content-Type":"application/json"},
+    body:JSON.stringify({session_id:sessionId})
+  });
+}
+
 export async function processPasses(sessionId, model, provider){
   return safeFetch("/api/process", {
     method:"POST",

--- a/frontend/js/app.mjs
+++ b/frontend/js/app.mjs
@@ -1,5 +1,5 @@
-import { getModels, uploadDocument, preprocessDocument, determineHeaders, processPasses, testLLM } from "./api.mjs";
-import { renderTable, renderHeaderPreview } from "./ui.mjs";
+import { getModels, uploadDocument, preprocessDocument, determineHeaders, determineLocalHeaders, processPasses, testLLM } from "./api.mjs";
+import { renderTable, renderHeaderPreview, renderLocalHeaderPreview } from "./ui.mjs";
 
 const el = (id)=>document.getElementById(id);
 const state = {
@@ -8,8 +8,10 @@ const state = {
   provider: null,
   model: null,
   hasPre: false,
+  hasLocalHeaders: false,
   hasHeaders: false,
   rows: [],
+  localHeaders: [],
   providers: {}
 
 };
@@ -148,14 +150,49 @@ function updateModel(){
 
 function resetAfterUpload(){
   state.hasPre = false;
+  state.hasLocalHeaders = false;
   state.hasHeaders = false;
   state.rows = [];
+  state.localHeaders = [];
   renderTable(el("tableWrap"), []);
   el("downloadWrap").classList.add("hidden");
+  el("localHeadersPreview").innerHTML = "";
   el("headersPreview").innerHTML = "";
   setStatus(el("preprocessStatus"), "Pre-chunking pending…");
+  setStatus(el("localHeadersStatus"), "Local header detection pending…");
   setStatus(el("headersStatus"), "Awaiting header detection…");
   setStatus(el("processStatus"), "Processing not started.");
+}
+
+async function onLocalHeaders(){
+  if(!requireSession()) return;
+  const end = openGroup("[Flow] Local header detection", false);
+  try{
+    console.log("State before local header detection", {...state});
+    setStatus(el("localHeadersStatus"), "Detecting headers locally…");
+    log("Local header detection start");
+    withGroup("[Flow] Local headers → Request payload", ()=>{
+      console.log({session_id: state.sessionId});
+    }, true);
+    const res = await determineLocalHeaders(state.sessionId);
+    withGroup(`[Flow] Local headers → Raw response (${res.httpStatus ?? "?"})`, ()=>{
+      console.log(res);
+    }, true);
+    if(!res.ok){
+      const msg = res.error || "Local header detection failed";
+      setStatus(el("localHeadersStatus"), msg, "warn");
+      log(`Local headers error: ${msg}`);
+      return;
+    }
+    const headers = Array.isArray(res.headers) ? res.headers : [];
+    state.localHeaders = headers;
+    state.hasLocalHeaders = headers.length > 0;
+    setStatus(el("localHeadersStatus"), `Detected ${headers.length} header${headers.length === 1 ? "" : "s"} locally`, "success");
+    renderLocalHeaderPreview(el("localHeadersPreview"), headers);
+    log(`Local headers detected count=${headers.length}`);
+  }finally{
+    end();
+  }
 }
 
 async function onUpload(){
@@ -386,6 +423,7 @@ async function boot(){
   el("testBtn").addEventListener("click", handleTestLLM);
 
   el("preprocessBtn").addEventListener("click", onPreprocess);
+  el("localHeadersBtn").addEventListener("click", onLocalHeaders);
   el("headersBtn").addEventListener("click", onHeaders);
   el("processBtn").addEventListener("click", onProcess);
   log("Boot complete");

--- a/frontend/js/ui.mjs
+++ b/frontend/js/ui.mjs
@@ -46,3 +46,26 @@ export function renderHeaderPreview(target, preview){
     target.appendChild(div);
   });
 }
+
+export function renderLocalHeaderPreview(target, headers){
+  if(!Array.isArray(headers) || headers.length === 0){
+    target.innerHTML = "";
+    return;
+  }
+  target.innerHTML = "";
+  headers.slice(0, 10).forEach((item)=>{
+    const div = document.createElement("div");
+    div.className = "preview-item";
+    const title = document.createElement("strong");
+    title.textContent = item.text || "(untitled)";
+    const meta = document.createElement("span");
+    const parts = [];
+    if(typeof item.page === "number") parts.push(`Page ${item.page}`);
+    if(typeof item.level === "number") parts.push(`Level ${item.level}`);
+    if(typeof item.font_size === "number") parts.push(`${item.font_size.toFixed(2)} pt`);
+    meta.textContent = parts.join(" • ");
+    div.appendChild(title);
+    div.appendChild(meta);
+    target.appendChild(div);
+  });
+}


### PR DESCRIPTION
## Summary
- allow the deterministic PDF header extractor to load uploaded session files and expose a session-oriented `/api/pdf/headers/session` endpoint
- extend the Determine Headers step with a dedicated "local" button, status, and preview that call the new API without hitting the LLM
- wire up frontend helpers for the local header call and preview rendering to keep UI feedback consistent

## Testing
- pytest backend/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68ceb5539cb8832491272a5fa3bdc086