### PR TITLE
Improve header preview debug output

### DIFF
--- a/backend/pipeline/preprocess.py
+++ b/backend/pipeline/preprocess.py
@@ -107,10 +107,14 @@ def _sections_from_detected_headers(
             {
                 "title": "Preamble",
                 "id": "0",
+                "section_number": "0",
                 "content": pre_lines,
                 "page_start": 1,
                 "page_end": pre_last_page + 1,
                 "heading_level": 1,
+                "source_page": 1,
+                "source_line_idx": 0,
+                "sequence_index": 0,
             }
         )
 
@@ -153,10 +157,14 @@ def _sections_from_detected_headers(
             {
                 "title": header_text or f"Section {section_number}",
                 "id": section_number,
+                "section_number": section_number,
                 "content": content_lines,
                 "page_start": entry["page"],
                 "page_end": max(entry["page"], last_page + 1),
                 "heading_level": entry.get("level"),
+                "source_page": entry["page"],
+                "source_line_idx": entry["line_idx"],
+                "sequence_index": idx,
             }
         )
 

--- a/backend/routes/headers.py
+++ b/backend/routes/headers.py
@@ -1,17 +1,28 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-import os, time, asyncio, json
-from math import ceil
+import os, time, asyncio, json, re
 from flask import Blueprint, request, jsonify, make_response
 
-from ..pipeline.preprocess import extract_pages_with_layout
+from ..pipeline.preprocess import extract_pages_with_layout, _sections_from_detected_headers
 from ..pipeline.llm import create_llm_client
 from ..parse.header_page_mode import select_candidates, build_adjudication_prompt
 from ..parse.header_config import CONFIG
 from ..state import get_state
 
 bp = Blueprint("headers", __name__)
+
+_SECTION_NUMBER_RE = re.compile(r"\d+")
+
+
+def _section_sort_key(section: dict) -> tuple:
+    page = int(section.get("page_start") or section.get("source_page") or 0)
+    number = str(section.get("section_number") or section.get("id") or "")
+    number_parts = tuple(int(part) for part in _SECTION_NUMBER_RE.findall(number))
+    has_number = 0 if number_parts else 1
+    sequence_index = int(section.get("sequence_index") or 0)
+    line_idx = int(section.get("source_line_idx") or 0)
+    return (page, has_number, number_parts, sequence_index, line_idx)
 
 def _json_ok(data, code=200):
     resp = jsonify(data)
@@ -165,20 +176,37 @@ def determine_headers():
             if session_state is not None:
                 session_state.headers = results
 
-        # Legacy "preview" for UI
         preview = []
-        for page_entry in results:
-            for h in page_entry.get("headers", []):
-                preview.append({
-                    "chars": len(h.get("text") or ""),
-                    "section_name": h.get("text") or "",
-                    "section_number": h.get("section_number") or "",
-                    "page_found": page_entry.get("page"),
-                })
-                if len(preview) >= 5:
-                    break
-            if len(preview) >= 5:
-                break
+        detected_sections = _sections_from_detected_headers(pages_lines, results)
+        for section in sorted(detected_sections, key=_section_sort_key):
+            # Skip the preamble helper bucket – callers are interested in explicit headers only.
+            if section.get("id") == "0" and (section.get("title") or "").lower() == "preamble":
+                continue
+
+            content_lines = section.get("content") or []
+            if not content_lines:
+                continue
+
+            text_lines = [line.rstrip("\n") for line in content_lines if isinstance(line, str)]
+            if not text_lines:
+                continue
+
+            header_text = section.get("title") or text_lines[0].strip()
+            body_lines = text_lines[1:]
+            body_text = "\n".join(body_lines).strip("\n")
+            full_text = "\n".join(text_lines).strip("\n")
+
+            preview.append(
+                {
+                    "chars": len(full_text),
+                    "section_name": header_text,
+                    "section_number": section.get("section_number") or section.get("id") or "",
+                    "page_found": section.get("page_start"),
+                    "page_start": section.get("page_start"),
+                    "heading_level": section.get("heading_level"),
+                    "content": body_text,
+                }
+            )
 
         return _json_ok({
             "ok": True,

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -100,6 +100,20 @@ th{background:#f3f5fb;position:sticky;top:0;z-index:1;text-transform:uppercase;f
 .preview-item{padding:10px 12px;border:1px solid var(--border);border-radius:10px;background:#f8faff;}
 .preview-item strong{display:block;font-size:13px;}
 .preview-item span{font-size:12px;color:var(--muted);}
+.preview-item pre{
+  margin:6px 0 0;
+  padding:8px 10px;
+  background:#fff;
+  border:1px solid var(--border);
+  border-radius:8px;
+  font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;
+  font-size:12px;
+  line-height:1.45;
+  white-space:pre-wrap;
+  max-height:200px;
+  overflow:auto;
+  color:var(--text);
+}
 
 .log{
   background:#0b1220;

--- a/frontend/js/ui.mjs
+++ b/frontend/js/ui.mjs
@@ -42,14 +42,19 @@ export function renderHeaderPreview(target, preview){
     const title = document.createElement("strong");
     title.textContent = `${item.section_number || '—'} ${item.section_name || ''}`.trim();
     const meta = document.createElement("span");
-    const pageLabel = item.page_start ?? item.page_found;
-    if(pageLabel){
-      meta.textContent = `p.${pageLabel} • ${item.chars || 0} chars`;
-    }else{
-      meta.textContent = `${item.chars || 0} chars`;
-    }
+    const bits = [];
+    const pageLabel = item.page_start ?? item.page_found ?? item.page;
+    if(pageLabel) bits.push(`p.${pageLabel}`);
+    if(item.heading_level) bits.push(`L${item.heading_level}`);
+    bits.push(`${item.chars || 0} chars`);
+    meta.textContent = bits.join(" • ");
     div.appendChild(title);
     div.appendChild(meta);
+    if(item.content !== undefined){
+      const pre = document.createElement("pre");
+      pre.textContent = item.content || "(no captured content)";
+      div.appendChild(pre);
+    }
     target.appendChild(div);
   });
 


### PR DESCRIPTION
## Summary
- add richer metadata to section reconstruction so debug previews can surface source ordering information
- expand header preview API to sort by page and section numbers and return full chunk character counts plus inter-header content
- update frontend preview rendering to display all headers with detailed metadata and inline section text for debugging

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cecee5e55c83248ccfd1048080b114