### PR TITLE
Implement LLM pass orchestration with chunk batching

### DIFF
--- a/backend/pipeline/passes.py
+++ b/backend/pipeline/passes.py
@@ -1,29 +1,296 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
-from typing import Dict, Any
+from __future__ import annotations
+
+import base64
+import csv
+import io
+import os
+import time
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from ..llm.errors import LLMAuthError, LLMError
+from ..llm.factory import create_llm_client, provider_default_model
+from ..prompts import PASS_PROMPTS
+from ..state import get_state
+from .fluid import fluid_refine_chunks
+from .hep_cluster import hep_cluster_chunks
 
 # Be resilient to missing helpers during upgrades
-try:
-    from .preprocess import approximate_tokens
-except Exception:
+try:  # pragma: no cover - compatibility shim
+    from .preprocess import (
+        approximate_tokens,
+        section_bounded_chunks_from_pdf,
+    )
+except Exception:  # pragma: no cover - compatibility shim
     def approximate_tokens(text: str) -> int:
         """Local fallback (~4 chars/token) if preprocess.approximate_tokens is unavailable."""
+
         if not text:
             return 0
         return max(1, len(text) // 4)
 
-# (your other imports here)
-# e.g., from .preprocess import extract_pages_with_layout, section_bounded_chunks_from_pdf, ...
+
+    def section_bounded_chunks_from_pdf(
+        pdf_path: str,
+        sidecar_dir: Optional[str] = None,
+        tok_budget_chars: int = 6400,
+        overlap_lines: int = 3,
+        session_id: Optional[str] = None,
+    ) -> Iterable[Dict[str, Any]]:
+        raise RuntimeError("section_bounded_chunks_from_pdf unavailable")
+
+
+CHUNK_GROUP_TOKEN_LIMIT = 12000
+CSV_COLUMNS = ["Document", "(Sub)Section #", "(Sub)Section Name", "Specification", "Pass"]
+
+
+def _ensure_chunks(session_id: str) -> List[Dict[str, Any]]:
+    state = get_state(session_id)
+    if state is None:
+        raise ValueError("Unknown session; upload and preprocess the document first.")
+
+    if state.pre_chunks is not None and state.pre_chunks:
+        chunks = [dict(chunk) for chunk in state.pre_chunks]
+    else:
+        pdf_path = state.file_path
+        if not pdf_path or not os.path.exists(pdf_path):
+            uploads_dir = os.getenv("UPLOAD_FOLDER", "uploads")
+            pdf_path = os.path.join(uploads_dir, f"{session_id}.pdf")
+        sidecar_dir = os.path.join("sidecars", session_id)
+        chunks = [
+            dict(chunk)
+            for chunk in section_bounded_chunks_from_pdf(
+                pdf_path,
+                sidecar_dir=sidecar_dir,
+                session_id=session_id,
+            )
+        ]
+
+    document_name = state.filename or "Document"
+    for chunk in chunks:
+        chunk.setdefault("document", document_name)
+        chunk.setdefault("section_number", chunk.get("section_id") or "")
+        chunk.setdefault("section_name", chunk.get("section_title") or "")
+        chunk.setdefault("page_start", chunk.get("page_start") or chunk.get("page") or 1)
+        chunk.setdefault("page_end", chunk.get("page_end") or chunk.get("page") or chunk.get("page_start") or 1)
+        chunk.setdefault("text", chunk.get("text", ""))
+        chunk.setdefault("meta", {})
+
+    refined = fluid_refine_chunks(chunks)
+    enriched = hep_cluster_chunks(refined)
+    state.refined_chunks = refined
+    state.clustered_chunks = enriched
+    return enriched
+
+
+def _chunk_token_len(chunk: Dict[str, Any]) -> int:
+    return approximate_tokens(chunk.get("text") or "")
+
+
+def _build_groups(chunks: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    groups: List[Dict[str, Any]] = []
+    current: List[Dict[str, Any]] = []
+    current_tokens = 0
+    for chunk in chunks:
+        tokens = max(1, _chunk_token_len(chunk))
+        if current and current_tokens + tokens > CHUNK_GROUP_TOKEN_LIMIT:
+            groups.append({
+                "chunks": current,
+                "token_estimate": current_tokens,
+            })
+            current = []
+            current_tokens = 0
+        current.append(chunk)
+        current_tokens += tokens
+    if current:
+        groups.append({
+            "chunks": current,
+            "token_estimate": current_tokens,
+        })
+    return groups
+
+
+def _format_chunk_for_prompt(chunk: Dict[str, Any], idx: int, total: int) -> str:
+    doc = chunk.get("document") or "Document"
+    sec_num = str(chunk.get("section_number") or chunk.get("section_id") or "").strip()
+    sec_name = str(chunk.get("section_name") or chunk.get("section_title") or "").strip()
+    page_start = chunk.get("page_start") or chunk.get("page") or 1
+    page_end = chunk.get("page_end") or page_start
+    body = (chunk.get("text") or "").strip()
+    header_bits = [f"Document: {doc}"]
+    if sec_num or sec_name:
+        section_label = " ".join(bit for bit in [sec_num, sec_name] if bit).strip()
+        header_bits.append(f"Section: {section_label}")
+    header_bits.append(f"Pages: {page_start}-{page_end}")
+    header = " \u2022 ".join(header_bits)
+    return f"<<<CHUNK {idx+1} OF {total}>>>\n{header}\n{body}\n<<<END CHUNK {idx+1}>>>"
+
+
+def _build_user_prompt(metadata: Dict[str, Any], group: Dict[str, Any], batch_index: int, batch_total: int) -> str:
+    chunk_texts = [
+        _format_chunk_for_prompt(chunk, idx, len(group["chunks"]))
+        for idx, chunk in enumerate(group["chunks"])
+        if (chunk.get("text") or "").strip()
+    ]
+    document = metadata.get("document") or "Document"
+    lines = [
+        f"DOCUMENT_METADATA:\n- Document: {document}\n- Session: {metadata.get('session_id', '')}",
+        f"BATCH_INFO: batch {batch_index + 1} of {batch_total}; approx {group.get('token_estimate', 0)} tokens",
+        "DOCUMENT_TEXT:",
+        "\n\n".join(chunk_texts) if chunk_texts else "(no text)",
+        "Return results exactly as instructed in the system prompt. Do not omit CSV or JSON sections.",
+    ]
+    return "\n\n".join(lines).strip()
+
+
+def _parse_pass_response(text: str, pass_name: str) -> Tuple[List[Dict[str, str]], Optional[str], Optional[str]]:
+    if not text:
+        return [], None, None
+    csv_block: Optional[str] = None
+    json_block: Optional[str] = None
+    lower = text.lower()
+    if "===csv===" in lower:
+        split_csv = text.split("===CSV===", 1)[1]
+    else:
+        split_csv = text
+    if "===JSON===" in split_csv:
+        csv_part, json_part = split_csv.split("===JSON===", 1)
+        csv_block = csv_part.strip()
+        json_block = json_part.strip()
+    else:
+        csv_block = split_csv.strip()
+
+    rows: List[Dict[str, str]] = []
+    if csv_block:
+        reader = csv.DictReader(io.StringIO(csv_block))
+        for row in reader:
+            if not any(row.values()):
+                continue
+            normalized = {col: row.get(col, "").strip() for col in CSV_COLUMNS}
+            if not normalized["Pass"]:
+                normalized["Pass"] = pass_name
+            rows.append(normalized)
+    return rows, csv_block, json_block
+
+
+async def _run_pass(
+    pass_name: str,
+    system_prompt: str,
+    groups: List[Dict[str, Any]],
+    provider: str,
+    model: str,
+    metadata: Dict[str, Any],
+) -> Tuple[List[Dict[str, str]], List[Dict[str, Any]], List[str]]:
+    client = create_llm_client(provider)
+    pass_rows: List[Dict[str, str]] = []
+    csv_segments: List[str] = []
+    errors: List[Dict[str, Any]] = []
+
+    for batch_index, group in enumerate(groups):
+        prompt = _build_user_prompt(metadata, group, batch_index, len(groups))
+        try:
+            content = await client.acomplete(
+                model=model,
+                system=system_prompt,
+                user=prompt,
+                temperature=0.0,
+                max_tokens=4096,
+            )
+        except (LLMAuthError, LLMError) as exc:
+            errors.append({"batch": batch_index, "error": str(exc), "pass": pass_name})
+            break
+        except Exception as exc:
+            errors.append({"batch": batch_index, "error": str(exc), "pass": pass_name})
+            break
+        else:
+            rows, csv_block, _json_block = _parse_pass_response(content, pass_name)
+            if rows:
+                pass_rows.extend(rows)
+            if csv_block:
+                csv_segments.append(csv_block)
+
+    debug_records = client.drain_debug_records()
+    for record in debug_records:
+        record.setdefault("pass", pass_name)
+        record.setdefault("model", model)
+
+    if errors:
+        for record in debug_records:
+            record.setdefault("errors", []).extend(errors)
+    return pass_rows, debug_records, csv_segments
+
+
+def _encode_rows_to_csv(rows: List[Dict[str, str]]) -> str:
+    buffer = io.StringIO()
+    writer = csv.DictWriter(buffer, fieldnames=CSV_COLUMNS, extrasaction="ignore")
+    writer.writeheader()
+    for row in rows:
+        writer.writerow({col: row.get(col, "") for col in CSV_COLUMNS})
+    return buffer.getvalue()
+
 
 async def run_all_passes_async(payload: Dict[str, Any]) -> Dict[str, Any]:
-    """
-    Placeholder orchestrator that demonstrates using approximate_tokens and other passes.
-    Replace/extend with your actual passes pipeline as needed.
-    """
-    text = (payload or {}).get("text", "")
-    toks = approximate_tokens(text)
+    payload = payload or {}
+    session_id = payload.get("session_id") or payload.get("session")
+    if not session_id:
+        return {"ok": False, "httpStatus": 400, "error": "session_id is required"}
+
+    provider = (payload.get("provider") or os.getenv("LLM_PROVIDER", "openrouter")).strip()
+    model = (payload.get("model") or provider_default_model(provider) or os.getenv("LLM_MODEL", "gpt-4o-mini")).strip()
+
+    state = get_state(session_id)
+    if state is None:
+        return {"ok": False, "httpStatus": 404, "error": "Unknown session. Upload the document again."}
+
+    state.provider = provider
+    state.model = model
+
+    try:
+        chunks = _ensure_chunks(session_id)
+    except Exception as exc:
+        return {"ok": False, "httpStatus": 500, "error": f"Failed to prepare chunks: {exc}"}
+
+    if not chunks:
+        return {"ok": True, "rows": [], "csv_base64": None, "llm_debug": [], "metrics_ms": {"total": 0}}
+
+    groups = _build_groups(chunks)
+    metadata = {"document": state.filename or "Document", "session_id": session_id}
+
+    rows: List[Dict[str, str]] = []
+    csv_segments: List[str] = []
+    llm_debug: List[Dict[str, Any]] = []
+    metrics: Dict[str, float] = {}
+
+    total_start = time.perf_counter()
+    for pass_name, system_prompt in PASS_PROMPTS.items():
+        start = time.perf_counter()
+        pass_rows, debug_records, pass_csv_segments = await _run_pass(
+            pass_name,
+            system_prompt,
+            groups,
+            provider,
+            model,
+            metadata,
+        )
+        elapsed_ms = round((time.perf_counter() - start) * 1000, 1)
+        metrics[pass_name] = elapsed_ms
+        rows.extend(pass_rows)
+        csv_segments.extend(pass_csv_segments)
+        llm_debug.extend(debug_records)
+
+    metrics["total"] = round((time.perf_counter() - total_start) * 1000, 1)
+
+    csv_text = _encode_rows_to_csv(rows)
+    csv_base64 = base64.b64encode(csv_text.encode("utf-8")).decode("ascii") if rows else None
+
     return {
         "ok": True,
-        "token_estimate": toks,
-        "meta": {"passes": ["token_estimate"]},
+        "rows": rows,
+        "csv_base64": csv_base64,
+        "csv_text": csv_text if rows else None,
+        "llm_debug": llm_debug,
+        "metrics_ms": metrics,
+        "chunk_groups": len(groups),
+        "chunk_count": len(chunks),
     }

--- a/backend/pipeline/preprocess.py
+++ b/backend/pipeline/preprocess.py
@@ -107,10 +107,14 @@ def _sections_from_detected_headers(
             {
                 "title": "Preamble",
                 "id": "0",
+                "section_number": "0",
                 "content": pre_lines,
                 "page_start": 1,
                 "page_end": pre_last_page + 1,
                 "heading_level": 1,
+                "source_page": 1,
+                "source_line_idx": 0,
+                "sequence_index": 0,
             }
         )
 
@@ -153,10 +157,14 @@ def _sections_from_detected_headers(
             {
                 "title": header_text or f"Section {section_number}",
                 "id": section_number,
+                "section_number": section_number,
                 "content": content_lines,
                 "page_start": entry["page"],
                 "page_end": max(entry["page"], last_page + 1),
                 "heading_level": entry.get("level"),
+                "source_page": entry["page"],
+                "source_line_idx": entry["line_idx"],
+                "sequence_index": idx,
             }
         )
 

--- a/backend/routes/headers.py
+++ b/backend/routes/headers.py
@@ -1,17 +1,28 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-import os, time, asyncio, json
-from math import ceil
+import os, time, asyncio, json, re
 from flask import Blueprint, request, jsonify, make_response
 
-from ..pipeline.preprocess import extract_pages_with_layout
+from ..pipeline.preprocess import extract_pages_with_layout, _sections_from_detected_headers
 from ..pipeline.llm import create_llm_client
 from ..parse.header_page_mode import select_candidates, build_adjudication_prompt
 from ..parse.header_config import CONFIG
 from ..state import get_state
 
 bp = Blueprint("headers", __name__)
+
+_SECTION_NUMBER_RE = re.compile(r"\d+")
+
+
+def _section_sort_key(section: dict) -> tuple:
+    page = int(section.get("page_start") or section.get("source_page") or 0)
+    number = str(section.get("section_number") or section.get("id") or "")
+    number_parts = tuple(int(part) for part in _SECTION_NUMBER_RE.findall(number))
+    has_number = 0 if number_parts else 1
+    sequence_index = int(section.get("sequence_index") or 0)
+    line_idx = int(section.get("source_line_idx") or 0)
+    return (page, has_number, number_parts, sequence_index, line_idx)
 
 def _json_ok(data, code=200):
     resp = jsonify(data)
@@ -165,20 +176,37 @@ def determine_headers():
             if session_state is not None:
                 session_state.headers = results
 
-        # Legacy "preview" for UI
         preview = []
-        for page_entry in results:
-            for h in page_entry.get("headers", []):
-                preview.append({
-                    "chars": len(h.get("text") or ""),
-                    "section_name": h.get("text") or "",
-                    "section_number": h.get("section_number") or "",
-                    "page_found": page_entry.get("page"),
-                })
-                if len(preview) >= 5:
-                    break
-            if len(preview) >= 5:
-                break
+        detected_sections = _sections_from_detected_headers(pages_lines, results)
+        for section in sorted(detected_sections, key=_section_sort_key):
+            # Skip the preamble helper bucket – callers are interested in explicit headers only.
+            if section.get("id") == "0" and (section.get("title") or "").lower() == "preamble":
+                continue
+
+            content_lines = section.get("content") or []
+            if not content_lines:
+                continue
+
+            text_lines = [line.rstrip("\n") for line in content_lines if isinstance(line, str)]
+            if not text_lines:
+                continue
+
+            header_text = section.get("title") or text_lines[0].strip()
+            body_lines = text_lines[1:]
+            body_text = "\n".join(body_lines).strip("\n")
+            full_text = "\n".join(text_lines).strip("\n")
+
+            preview.append(
+                {
+                    "chars": len(full_text),
+                    "section_name": header_text,
+                    "section_number": section.get("section_number") or section.get("id") or "",
+                    "page_found": section.get("page_start"),
+                    "page_start": section.get("page_start"),
+                    "heading_level": section.get("heading_level"),
+                    "content": body_text,
+                }
+            )
 
         return _json_ok({
             "ok": True,

--- a/backend/routes/process.py
+++ b/backend/routes/process.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 from flask import Blueprint, request, jsonify, make_response
+
 from ..pipeline.passes import run_all_passes_async
 
 bp = Blueprint("process", __name__)
@@ -24,9 +25,13 @@ def process_route():
         finally:
             loop.close()
 
-        response = jsonify({"ok": True, "httpStatus": 200, "result": out})
+        status = 200 if out.get("ok", False) else out.get("httpStatus", 500)
+        if "httpStatus" not in out:
+            out["httpStatus"] = status
+
+        response = jsonify(out)
         response.headers["Access-Control-Allow-Origin"] = "*"
-        return response, 200
+        return response, status
 
     except Exception as e:
         return jsonify({"ok": False, "httpStatus": 500, "error": str(e)}), 500

--- a/frontend/css/style.css
+++ b/frontend/css/style.css
@@ -100,6 +100,20 @@ th{background:#f3f5fb;position:sticky;top:0;z-index:1;text-transform:uppercase;f
 .preview-item{padding:10px 12px;border:1px solid var(--border);border-radius:10px;background:#f8faff;}
 .preview-item strong{display:block;font-size:13px;}
 .preview-item span{font-size:12px;color:var(--muted);}
+.preview-item pre{
+  margin:6px 0 0;
+  padding:8px 10px;
+  background:#fff;
+  border:1px solid var(--border);
+  border-radius:8px;
+  font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,"Liberation Mono","Courier New",monospace;
+  font-size:12px;
+  line-height:1.45;
+  white-space:pre-wrap;
+  max-height:200px;
+  overflow:auto;
+  color:var(--text);
+}
 
 .log{
   background:#0b1220;

--- a/frontend/js/ui.mjs
+++ b/frontend/js/ui.mjs
@@ -42,14 +42,19 @@ export function renderHeaderPreview(target, preview){
     const title = document.createElement("strong");
     title.textContent = `${item.section_number || '—'} ${item.section_name || ''}`.trim();
     const meta = document.createElement("span");
-    const pageLabel = item.page_start ?? item.page_found;
-    if(pageLabel){
-      meta.textContent = `p.${pageLabel} • ${item.chars || 0} chars`;
-    }else{
-      meta.textContent = `${item.chars || 0} chars`;
-    }
+    const bits = [];
+    const pageLabel = item.page_start ?? item.page_found ?? item.page;
+    if(pageLabel) bits.push(`p.${pageLabel}`);
+    if(item.heading_level) bits.push(`L${item.heading_level}`);
+    bits.push(`${item.chars || 0} chars`);
+    meta.textContent = bits.join(" • ");
     div.appendChild(title);
     div.appendChild(meta);
+    if(item.content !== undefined){
+      const pre = document.createElement("pre");
+      pre.textContent = item.content || "(no captured content)";
+      div.appendChild(pre);
+    }
     target.appendChild(div);
   });
 


### PR DESCRIPTION
## Summary
- orchestrate the pass pipeline to batch section chunks, build per-pass prompts, call the configured LLM, and aggregate CSV outputs
- persist refined/chunked state with debug metadata, encode downloadable CSV results, and surface timing metrics with chunk batch counts
- update the process route to return the pipeline response directly with appropriate HTTP status handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cecee5e55c83248ccfd1048080b114