### PR TITLE
Add RAG v2 pipeline scaffolding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## Unreleased
+- Refactored retrieval-augmented generation stages into the modular RAG v2 pipeline while keeping outbound payloads compatible. No public API changes; evidence selection is now entropy-aware.

--- a/backend/compat/__init__.py
+++ b/backend/compat/__init__.py
@@ -1,0 +1,5 @@
+"""Compatibility helpers for adapting new modules to legacy interfaces."""
+
+from .payload_adapter import to_legacy_llm_message
+
+__all__ = ["to_legacy_llm_message"]

--- a/backend/compat/payload_adapter.py
+++ b/backend/compat/payload_adapter.py
@@ -1,0 +1,46 @@
+"""Adapter that converts the new context buckets into the legacy message payload."""
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+
+def _format_bucket(title: str, entries: Iterable[Dict[str, object]]) -> str:
+    lines = [title]
+    for entry in entries:
+        chunk_id = entry.get("chunk_id", "")
+        section = entry.get("section") or ""
+        section_title = entry.get("section_title") or ""
+        pages = entry.get("pages")
+        prefix_parts = [part for part in [str(section).strip(), str(section_title).strip()] if part]
+        prefix = " — ".join(prefix_parts) if prefix_parts else ""
+        page_suffix = f" (pp. {pages[0]}-{pages[1]})" if isinstance(pages, (list, tuple)) else ""
+        text = entry.get("text", "")
+        lines.append(f"- {chunk_id}{': ' if prefix else ''}{prefix}{page_suffix}\n{text}".rstrip())
+    return "\n".join(lines).strip()
+
+
+def to_legacy_llm_message(context_buckets: Dict[str, List[Dict[str, object]]], question: str) -> Dict[str, object]:
+    standards = context_buckets.get("Standards", [])
+    project = context_buckets.get("ProjectSpec", [])
+    risk = context_buckets.get("Risk", [])
+    content_sections = [
+        _format_bucket("[Standards]", standards),
+        _format_bucket("[ProjectSpec]", project),
+        _format_bucket("[Risk]", risk),
+    ]
+    user_content = "\n\n".join(filter(None, content_sections))
+    return {
+        "messages": [
+            {
+                "role": "system",
+                "content": (
+                    "You are a technical standards extraction assistant. "
+                    "Return the requested JSON exactly."
+                ),
+            },
+            {
+                "role": "user",
+                "content": f"Question: {question}\n\n{user_content}".strip(),
+            },
+        ],
+    }

--- a/backend/ragV2/__init__.py
+++ b/backend/ragV2/__init__.py
@@ -1,0 +1,43 @@
+"""Version 2 retrieval augmented generation pipeline primitives."""
+
+from .config import CFG, RagV2Config
+from .types import Chunk, EvidenceScore, EvidenceBand, ExtractionField, ExtractionJSON
+from .retrieval import Retriever
+from .rerank import Reranker
+from .graph import GraphIndex
+from .agents import StandardAgent, FluidAgent, HEPAgent
+from .entropy import (
+    entropy_linear_band,
+    entropy_graph_band,
+    entropy_changepoint_band,
+)
+from .fusion import fuse_scores, intersect_or_tightest_band
+from .pack import pack_context
+from .prompts import EXTRACT_PROMPT, VERIFY_PROMPT, EDITION_ARBITER_PROMPT
+from .orchestrate import macro_pass
+
+__all__ = [
+    "CFG",
+    "RagV2Config",
+    "Chunk",
+    "EvidenceScore",
+    "EvidenceBand",
+    "ExtractionField",
+    "ExtractionJSON",
+    "Retriever",
+    "Reranker",
+    "GraphIndex",
+    "StandardAgent",
+    "FluidAgent",
+    "HEPAgent",
+    "entropy_linear_band",
+    "entropy_graph_band",
+    "entropy_changepoint_band",
+    "fuse_scores",
+    "intersect_or_tightest_band",
+    "pack_context",
+    "EXTRACT_PROMPT",
+    "VERIFY_PROMPT",
+    "EDITION_ARBITER_PROMPT",
+    "macro_pass",
+]

--- a/backend/ragV2/agents.py
+++ b/backend/ragV2/agents.py
@@ -1,0 +1,105 @@
+"""Micro-agent scoring models used by the RAG v2 pipeline."""
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter
+from typing import Dict, Iterable
+
+from .config import CFG
+from .graph import GraphIndex
+from .types import Chunk
+
+
+def _normalize(scores: Dict[str, float]) -> Dict[str, float]:
+    if not scores:
+        return {}
+    values = list(scores.values())
+    min_v = min(values)
+    max_v = max(values)
+    if math.isclose(max_v, min_v):
+        return {cid: 0.5 for cid in scores}
+    scale = max_v - min_v
+    return {cid: (score - min_v) / scale for cid, score in scores.items()}
+
+
+class StandardAgent:
+    """Compute hybrid retrieval scores with optional cross-encoder signals."""
+
+    def score(self, query: str, pool: Iterable[Chunk]) -> Dict[str, float]:
+        scores: Dict[str, float] = {}
+        for chunk in pool:
+            dense = float(chunk.meta.get("dense_score", 0.0))
+            bm25 = float(chunk.meta.get("bm25_score", chunk.bm25 or 0.0))
+            regex_hits = float(chunk.meta.get("regex_hits", chunk.regex_hits or 0))
+            base = (0.6 * dense) + (0.3 * bm25) + (0.1 * regex_hits)
+            cross = float(chunk.meta.get("crossenc_score", 0.0))
+            if cross:
+                base = 0.7 * base + 0.3 * cross
+            scores[chunk.chunk_id] = base
+        return _normalize(scores)
+
+
+class FluidAgent:
+    """Diffusion-based smoothing of the standard agent scores across a similarity graph."""
+
+    def __init__(self, lam: float = 0.85, steps: int = 4) -> None:
+        self._lam = lam
+        self._steps = steps
+
+    def score(self, query: str, pool: Iterable[Chunk], graph: GraphIndex) -> Dict[str, float]:
+        base = {chunk.chunk_id: float(chunk.meta.get("hybrid_score", 0.5)) for chunk in pool}
+        if not base:
+            return {}
+        ids = list(base.keys())
+        rank = {cid: base[cid] for cid in ids}
+        for _ in range(self._steps):
+            updated: Dict[str, float] = {}
+            for cid in ids:
+                neighbors = graph.neighbors(cid, CFG.max_neighbors)
+                if not neighbors:
+                    updated[cid] = base[cid]
+                    continue
+                total = 0.0
+                weight_sum = 0.0
+                for nid, weight in neighbors:
+                    weight_sum += weight
+                    total += weight * rank.get(nid, base.get(nid, 0.0))
+                neighbor_avg = total / weight_sum if weight_sum else base[cid]
+                updated[cid] = (self._lam * neighbor_avg) + ((1 - self._lam) * base[cid])
+            rank = updated
+        return _normalize(rank)
+
+
+class HEPAgent:
+    """High-entropy precision agent scoring information dense passages."""
+
+    _number_re = re.compile(r"[-+]?(?:\d+\.?\d*|\.\d+)")
+    _unit_re = re.compile(r"\b(?:mm|cm|m|in|ft|hz|khz|°c|°f|psi|bar|nm|kw|ma|vdc)\b", re.I)
+
+    def score(self, query: str, pool: Iterable[Chunk]) -> Dict[str, float]:
+        scores: Dict[str, float] = {}
+        facets = [token.lower() for token in query.split() if len(token) > 3]
+        for chunk in pool:
+            text = chunk.text
+            numbers = len(self._number_re.findall(text))
+            units = len(self._unit_re.findall(text))
+            std_ids = len(chunk.meta.get("std_ids", []))
+            density = (
+                (CFG.w_num * numbers)
+                + (CFG.w_unit * units)
+                + (CFG.w_stdID * std_ids)
+            )
+            tokens = [token.lower() for token in re.findall(r"\w+", text)]
+            total = len(tokens) or 1
+            counts = Counter(tokens)
+            entropy = 0.0
+            for count in counts.values():
+                p = count / total
+                entropy -= p * math.log(max(p, 1e-6))
+            entropy /= math.log(total + 1)
+            window = " ".join(tokens[: CFG.facet_window_tokens])
+            collisions = sum(1 for facet in facets if facet in window)
+            score = density * (1.0 + CFG.hep_entropy_kappa * entropy) + (0.1 * collisions)
+            scores[chunk.chunk_id] = score
+        return _normalize(scores)

--- a/backend/ragV2/config.py
+++ b/backend/ragV2/config.py
@@ -1,0 +1,172 @@
+"""Configuration helpers for the RAG v2 pipeline."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+def _bool(value: Any, default: bool) -> bool:
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"", "0", "false", "no", "off", "none"}:
+            return False
+        if normalized in {"1", "true", "yes", "on"}:
+            return True
+        return default
+    return bool(value) if value is not None else default
+
+
+def _float(value: Any, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return float(default)
+
+
+def _int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return int(default)
+
+
+@dataclass
+class RagV2Config:
+    """Mutable configuration shared across the RAG v2 modules."""
+
+    rag_v2_enabled: bool = True
+    k_dense: int = 40
+    k_sparse: int = 40
+    k_regex: int = 20
+    topK_for_synthesis: int = 10
+
+    w_std: float = 0.50
+    w_flu: float = 0.30
+    w_hep: float = 0.20
+
+    tau_sim_edge: float = 0.78
+    max_neighbors: int = 16
+
+    entropy_window_chunks: int = 3
+    tau_entropy_abs: float = 0.75
+    tau_entropy_grad: float = 0.10
+    entropy_buffer_chunks: int = 1
+
+    w_num: float = 1.0
+    w_unit: float = 1.2
+    w_stdID: float = 1.5
+    hep_entropy_kappa: float = 0.25
+    facet_window_tokens: int = 64
+
+    min_confidence: float = 0.70
+    max_refine_loops: int = 1
+
+    tau_entropy_frontier: float = 0.80
+    section_diversity: int = 3
+
+    telemetry_enabled: bool = True
+
+    def update_from_env(self, env: Dict[str, Any]) -> None:
+        """Update the configuration in-place using an environment-like mapping."""
+
+        if not isinstance(env, dict):
+            return
+        if "RAG_V2_ENABLED" in env:
+            self.rag_v2_enabled = _bool(env.get("RAG_V2_ENABLED"), self.rag_v2_enabled)
+        if "RAG_V2_K_DENSE" in env:
+            self.k_dense = _int(env.get("RAG_V2_K_DENSE"), self.k_dense)
+        if "RAG_V2_K_SPARSE" in env:
+            self.k_sparse = _int(env.get("RAG_V2_K_SPARSE"), self.k_sparse)
+        if "RAG_V2_K_REGEX" in env:
+            self.k_regex = _int(env.get("RAG_V2_K_REGEX"), self.k_regex)
+        if "RAG_V2_TOPK_SYNTH" in env:
+            self.topK_for_synthesis = _int(
+                env.get("RAG_V2_TOPK_SYNTH"), self.topK_for_synthesis
+            )
+        if "RAG_V2_W_STD" in env:
+            self.w_std = _float(env.get("RAG_V2_W_STD"), self.w_std)
+        if "RAG_V2_W_FLU" in env:
+            self.w_flu = _float(env.get("RAG_V2_W_FLU"), self.w_flu)
+        if "RAG_V2_W_HEP" in env:
+            self.w_hep = _float(env.get("RAG_V2_W_HEP"), self.w_hep)
+        if "RAG_V2_TAU_SIM" in env:
+            self.tau_sim_edge = _float(env.get("RAG_V2_TAU_SIM"), self.tau_sim_edge)
+        if "RAG_V2_MAX_NEIGH" in env:
+            self.max_neighbors = _int(env.get("RAG_V2_MAX_NEIGH"), self.max_neighbors)
+        if "RAG_V2_ENTROPY_WIN" in env:
+            self.entropy_window_chunks = _int(
+                env.get("RAG_V2_ENTROPY_WIN"), self.entropy_window_chunks
+            )
+        if "RAG_V2_TAU_ENTROPY_ABS" in env:
+            self.tau_entropy_abs = _float(
+                env.get("RAG_V2_TAU_ENTROPY_ABS"), self.tau_entropy_abs
+            )
+        if "RAG_V2_TAU_ENTROPY_GRAD" in env:
+            self.tau_entropy_grad = _float(
+                env.get("RAG_V2_TAU_ENTROPY_GRAD"), self.tau_entropy_grad
+            )
+        if "RAG_V2_ENTROPY_BUFFER" in env:
+            self.entropy_buffer_chunks = _int(
+                env.get("RAG_V2_ENTROPY_BUFFER"), self.entropy_buffer_chunks
+            )
+        if "RAG_V2_W_NUM" in env:
+            self.w_num = _float(env.get("RAG_V2_W_NUM"), self.w_num)
+        if "RAG_V2_W_UNIT" in env:
+            self.w_unit = _float(env.get("RAG_V2_W_UNIT"), self.w_unit)
+        if "RAG_V2_W_STDID" in env:
+            self.w_stdID = _float(env.get("RAG_V2_W_STDID"), self.w_stdID)
+        if "RAG_V2_HEP_KAPPA" in env:
+            self.hep_entropy_kappa = _float(
+                env.get("RAG_V2_HEP_KAPPA"), self.hep_entropy_kappa
+            )
+        if "RAG_V2_FACET_WINDOW" in env:
+            self.facet_window_tokens = _int(
+                env.get("RAG_V2_FACET_WINDOW"), self.facet_window_tokens
+            )
+        if "RAG_V2_MIN_CONF" in env:
+            self.min_confidence = _float(
+                env.get("RAG_V2_MIN_CONF"), self.min_confidence
+            )
+        if "RAG_V2_MAX_REFINE" in env:
+            self.max_refine_loops = _int(
+                env.get("RAG_V2_MAX_REFINE"), self.max_refine_loops
+            )
+        if "RAG_V2_SECTION_DIVERSITY" in env:
+            self.section_diversity = _int(
+                env.get("RAG_V2_SECTION_DIVERSITY"), self.section_diversity
+            )
+        if "RAG_V2_TELEMETRY" in env:
+            self.telemetry_enabled = _bool(
+                env.get("RAG_V2_TELEMETRY"), self.telemetry_enabled
+            )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "rag_v2_enabled": self.rag_v2_enabled,
+            "k_dense": self.k_dense,
+            "k_sparse": self.k_sparse,
+            "k_regex": self.k_regex,
+            "topK_for_synthesis": self.topK_for_synthesis,
+            "w_std": self.w_std,
+            "w_flu": self.w_flu,
+            "w_hep": self.w_hep,
+            "tau_sim_edge": self.tau_sim_edge,
+            "max_neighbors": self.max_neighbors,
+            "entropy_window_chunks": self.entropy_window_chunks,
+            "tau_entropy_abs": self.tau_entropy_abs,
+            "tau_entropy_grad": self.tau_entropy_grad,
+            "entropy_buffer_chunks": self.entropy_buffer_chunks,
+            "w_num": self.w_num,
+            "w_unit": self.w_unit,
+            "w_stdID": self.w_stdID,
+            "hep_entropy_kappa": self.hep_entropy_kappa,
+            "facet_window_tokens": self.facet_window_tokens,
+            "min_confidence": self.min_confidence,
+            "max_refine_loops": self.max_refine_loops,
+            "tau_entropy_frontier": self.tau_entropy_frontier,
+            "section_diversity": self.section_diversity,
+            "telemetry_enabled": self.telemetry_enabled,
+        }
+
+
+CFG = RagV2Config()

--- a/backend/ragV2/entropy.py
+++ b/backend/ragV2/entropy.py
@@ -1,0 +1,156 @@
+"""Entropy based evidence band selection strategies."""
+from __future__ import annotations
+
+import math
+import re
+from typing import Dict, Iterable, List, Sequence
+
+from .config import CFG
+from .graph import GraphIndex
+from .types import Chunk, EvidenceBand
+
+_token_re = re.compile(r"\w+")
+
+
+def _window_entropy(chunks: Sequence[Chunk]) -> float:
+    tokens: List[str] = []
+    for chunk in chunks:
+        tokens.extend(token.lower() for token in _token_re.findall(chunk.text))
+    if not tokens:
+        return 0.0
+    total = len(tokens)
+    counts: Dict[str, int] = {}
+    for token in tokens:
+        counts[token] = counts.get(token, 0) + 1
+    entropy = 0.0
+    for count in counts.values():
+        p = count / total
+        entropy -= p * math.log(max(p, 1e-9))
+    return entropy / math.log(total + 1)
+
+
+def _collect_window(ordered: Sequence[Chunk], start: int, end: int) -> List[Chunk]:
+    start = max(0, start)
+    end = min(len(ordered), end)
+    return list(ordered[start:end])
+
+
+def entropy_linear_band(seed_idx: int, ordered: Sequence[Chunk]) -> EvidenceBand:
+    window = CFG.entropy_window_chunks
+    entropy_left: List[float] = []
+    entropy_right: List[float] = []
+    left = seed_idx
+    right = seed_idx + 1
+    prev_entropy = 0.0
+    while left > 0:
+        left -= 1
+        series = _collect_window(ordered, left, left + window)
+        value = _window_entropy(series)
+        entropy_left.append(value)
+        if value > CFG.tau_entropy_abs or abs(value - prev_entropy) > CFG.tau_entropy_grad:
+            left += 1
+            break
+        prev_entropy = value
+    prev_entropy = 0.0
+    while right < len(ordered):
+        series = _collect_window(ordered, right - window + 1, right + 1)
+        value = _window_entropy(series)
+        entropy_right.append(value)
+        if value > CFG.tau_entropy_abs or abs(value - prev_entropy) > CFG.tau_entropy_grad:
+            right -= 1
+            break
+        prev_entropy = value
+        right += 1
+    right = min(len(ordered) - 1, max(right, seed_idx))
+    band_ids = [chunk.chunk_id for chunk in ordered[left : right + 1]]
+    avg_entropy = 0.0
+    if entropy_left or entropy_right:
+        avg_entropy = sum(entropy_left + entropy_right) / max(
+            len(entropy_left + entropy_right), 1
+        )
+    confidence = max(0.35, 1.0 - avg_entropy)
+    return EvidenceBand(
+        seed_chunk_id=ordered[seed_idx].chunk_id,
+        start_idx=left,
+        end_idx=right,
+        confidence=confidence,
+        entropy_trace_left=entropy_left,
+        entropy_trace_right=entropy_right,
+        method="linear_entropy",
+        band_chunk_ids=band_ids,
+    )
+
+
+def entropy_graph_band(
+    seed_chunk: Chunk, pool: Sequence[Chunk], graph: GraphIndex
+) -> EvidenceBand:
+    visited = {seed_chunk.chunk_id}
+    frontier = [(seed_chunk.chunk_id, 1.0)]
+    band_ids = [seed_chunk.chunk_id]
+    entropy_trace: List[float] = []
+    while frontier:
+        current, weight = frontier.pop(0)
+        neighbors = graph.neighbors(current, CFG.max_neighbors)
+        for neighbor, sim in neighbors:
+            if neighbor in visited:
+                continue
+            visited.add(neighbor)
+            frontier.append((neighbor, sim))
+            chunk = next((c for c in pool if c.chunk_id == neighbor), None)
+            if chunk is None:
+                continue
+            candidate_band = band_ids + [neighbor]
+            chunks = [c for c in pool if c.chunk_id in candidate_band]
+            value = _window_entropy(chunks)
+            entropy_trace.append(value)
+            if value > CFG.tau_entropy_frontier:
+                continue
+            band_ids.append(neighbor)
+    idx_map = {chunk.chunk_id: idx for idx, chunk in enumerate(pool)}
+    positions = [idx_map.get(cid, 0) for cid in band_ids]
+    start = min(positions)
+    end = max(positions)
+    confidence = max(0.4, 1.0 - (sum(entropy_trace) / (len(entropy_trace) or 1)))
+    return EvidenceBand(
+        seed_chunk_id=seed_chunk.chunk_id,
+        start_idx=start,
+        end_idx=end,
+        confidence=confidence,
+        entropy_trace_left=entropy_trace,
+        entropy_trace_right=[],
+        method="graph_diffusion_entropy",
+        band_chunk_ids=band_ids,
+    )
+
+
+def entropy_changepoint_band(seed_idx: int, ordered: Sequence[Chunk]) -> EvidenceBand:
+    window = max(1, CFG.entropy_window_chunks)
+    entropies = [
+        _window_entropy(_collect_window(ordered, idx, idx + window))
+        for idx in range(len(ordered))
+    ]
+    left = seed_idx
+    right = seed_idx
+    while left > 0:
+        if abs(entropies[left] - entropies[left - 1]) > CFG.tau_entropy_grad:
+            break
+        left -= 1
+    while right < len(ordered) - 1:
+        if abs(entropies[right + 1] - entropies[right]) > CFG.tau_entropy_grad:
+            break
+        right += 1
+    left = max(0, left - CFG.entropy_buffer_chunks)
+    right = min(len(ordered) - 1, right + CFG.entropy_buffer_chunks)
+    band_ids = [chunk.chunk_id for chunk in ordered[left : right + 1]]
+    avg = sum(entropies[left : right + 1]) / max(1, (right - left + 1))
+    confidence = max(0.4, 1.0 - avg)
+    return EvidenceBand(
+        seed_chunk_id=ordered[seed_idx].chunk_id,
+        start_idx=left,
+        end_idx=right,
+        confidence=confidence,
+        entropy_trace_left=entropies[: seed_idx],
+        entropy_trace_right=entropies[seed_idx + 1 :],
+        method="entropy_changepoint",
+        band_chunk_ids=band_ids,
+    )

--- a/backend/ragV2/fusion.py
+++ b/backend/ragV2/fusion.py
@@ -1,0 +1,73 @@
+"""Score fusion and evidence band selection helpers."""
+from __future__ import annotations
+
+import math
+from typing import Dict, Iterable, List
+
+from .config import CFG
+from .types import EvidenceBand, EvidenceScore
+
+
+def zscore(values: Dict[str, float]) -> Dict[str, float]:
+    if not values:
+        return {}
+    series = list(values.values())
+    mean = sum(series) / len(series)
+    variance = sum((value - mean) ** 2 for value in series) / len(series)
+    stddev = math.sqrt(max(variance, 1e-8))
+    return {key: (value - mean) / stddev for key, value in values.items()}
+
+
+def fuse_scores(
+    std: Dict[str, float], flu: Dict[str, float], hep: Dict[str, float]
+) -> Dict[str, EvidenceScore]:
+    std_z = zscore(std)
+    flu_z = zscore(flu)
+    hep_z = zscore(hep)
+    fused: Dict[str, EvidenceScore] = {}
+    keys = set(std_z) | set(flu_z) | set(hep_z)
+    for cid in keys:
+        final = (
+            CFG.w_std * std_z.get(cid, 0.0)
+            + CFG.w_flu * flu_z.get(cid, 0.0)
+            + CFG.w_hep * hep_z.get(cid, 0.0)
+        )
+        fused[cid] = EvidenceScore(
+            standard=std.get(cid, 0.0),
+            fluid=flu.get(cid, 0.0),
+            hep=hep.get(cid, 0.0),
+            final=final,
+            signals={
+                "z_std": std_z.get(cid, 0.0),
+                "z_flu": flu_z.get(cid, 0.0),
+                "z_hep": hep_z.get(cid, 0.0),
+            },
+        )
+    return fused
+
+
+def intersect_or_tightest_band(
+    bands: Iterable[EvidenceBand], ordered: Iterable
+) -> EvidenceBand:
+    bands = list(bands)
+    if not bands:
+        raise ValueError("No bands provided")
+    if len(bands) == 1:
+        return bands[0]
+    intersection = set(bands[0].band_chunk_ids)
+    for band in bands[1:]:
+        intersection &= set(band.band_chunk_ids)
+    if intersection:
+        covering = [
+            band
+            for band in bands
+            if intersection.issubset(set(band.band_chunk_ids))
+        ]
+        if covering:
+            covering.sort(key=lambda band: (len(band.band_chunk_ids), -band.confidence))
+            return covering[0]
+    ranked = sorted(
+        bands,
+        key=lambda band: (len(band.band_chunk_ids), -band.confidence),
+    )
+    return ranked[0]

--- a/backend/ragV2/graph.py
+++ b/backend/ragV2/graph.py
@@ -1,0 +1,47 @@
+"""Similarity graph structures used by Fluid agent and entropy carving."""
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Dict, Iterable, List, Tuple
+
+from .config import CFG
+
+
+class GraphIndex:
+    """Lightweight adjacency list representation of chunk similarity."""
+
+    def __init__(self) -> None:
+        self._adjacency: Dict[str, List[Tuple[str, float]]] = defaultdict(list)
+
+    def add_edge(self, source: str, target: str, weight: float) -> None:
+        if source == target:
+            return
+        if weight < CFG.tau_sim_edge:
+            return
+        self._adjacency[source].append((target, float(weight)))
+
+    def add_bidirectional(self, a: str, b: str, weight: float) -> None:
+        self.add_edge(a, b, weight)
+        self.add_edge(b, a, weight)
+
+    def neighbors(self, chunk_id: str, top: int | None = None) -> List[Tuple[str, float]]:
+        candidates = list(self._adjacency.get(chunk_id, ()))
+        candidates.sort(key=lambda item: item[1], reverse=True)
+        if top is not None and top > 0:
+            candidates = candidates[:top]
+        return candidates
+
+    def degree(self, chunk_id: str) -> int:
+        return len(self._adjacency.get(chunk_id, ()))
+
+    def build_from_edges(
+        self, edges: Iterable[Tuple[str, str, float]], *, bidirectional: bool = True
+    ) -> None:
+        for source, target, weight in edges:
+            if bidirectional:
+                self.add_bidirectional(source, target, weight)
+            else:
+                self.add_edge(source, target, weight)
+
+    def as_dict(self) -> Dict[str, List[Tuple[str, float]]]:
+        return {node: list(neighbors) for node, neighbors in self._adjacency.items()}

--- a/backend/ragV2/orchestrate.py
+++ b/backend/ragV2/orchestrate.py
@@ -1,0 +1,134 @@
+"""High level orchestration for the RAG v2 pipeline."""
+from __future__ import annotations
+
+import logging
+from typing import Dict, Iterable, List, Optional
+
+from backend.compat import to_legacy_llm_message
+
+from .agents import FluidAgent, HEPAgent, StandardAgent
+from .config import CFG
+from .entropy import (
+    entropy_changepoint_band,
+    entropy_graph_band,
+    entropy_linear_band,
+)
+from .fusion import fuse_scores, intersect_or_tightest_band
+from .graph import GraphIndex
+from .pack import pack_context
+from .retrieval import Retriever
+from .rerank import Reranker
+from .types import Chunk, EvidenceBand, EvidenceScore, ExtractionJSON
+
+log = logging.getLogger("FluidRAG.rag_v2")
+
+
+def _order_chunks(chunks: Iterable[Chunk]) -> List[Chunk]:
+    return sorted(
+        chunks,
+        key=lambda chunk: (
+            chunk.doc_id,
+            chunk.section_no or "",
+            chunk.page_range[0],
+            chunk.chunk_id,
+        ),
+    )
+
+
+def _seed_band(
+    ordered: List[Chunk], fused: Dict[str, EvidenceScore], graph: GraphIndex
+) -> EvidenceBand:
+    if not ordered:
+        raise ValueError("Cannot compute bands without chunks")
+    top_chunk_id = max(fused.items(), key=lambda item: item[1].final)[0]
+    seed_idx = next(
+        (idx for idx, chunk in enumerate(ordered) if chunk.chunk_id == top_chunk_id),
+        0,
+    )
+    band_a = entropy_linear_band(seed_idx, ordered)
+    band_b = entropy_graph_band(ordered[seed_idx], ordered, graph)
+    band_c = entropy_changepoint_band(seed_idx, ordered)
+    return intersect_or_tightest_band([band_a, band_b, band_c], ordered)
+
+
+def _default_extraction() -> ExtractionJSON:
+    return ExtractionJSON()
+
+
+def macro_pass(
+    question: str,
+    domain: str,
+    edition_filters: Optional[Dict[str, str]] = None,
+    *,
+    retriever: Optional[Retriever] = None,
+    reranker: Optional[Reranker] = None,
+    graph: Optional[GraphIndex] = None,
+) -> ExtractionJSON:
+    if not CFG.rag_v2_enabled:
+        log.info("[rag_v2] feature flag disabled; returning empty extraction")
+        return _default_extraction()
+
+    retriever = retriever or Retriever()
+    reranker = reranker or Reranker()
+    graph = graph or GraphIndex()
+
+    pool = retriever.search(question, domain, edition_filters or {})
+    pool = reranker.rerank(question, pool)
+
+    standard_agent = StandardAgent()
+    std_scores = standard_agent.score(question, pool)
+    for chunk in pool:
+        chunk.meta.setdefault("hybrid_score", std_scores.get(chunk.chunk_id, 0.0))
+    fluid_agent = FluidAgent()
+    flu_scores = fluid_agent.score(question, pool, graph)
+    hep_agent = HEPAgent()
+    hep_scores = hep_agent.score(question, pool)
+
+    fused = fuse_scores(std_scores, flu_scores, hep_scores)
+    ordered = _order_chunks(pool)
+    if not ordered:
+        result = _default_extraction()
+        result.provenance = {
+            "question": question,
+            "domain": domain,
+            "pool": 0,
+            "rag_v2_enabled": True,
+        }
+        return result
+
+    try:
+        band = _seed_band(ordered, fused, graph)
+    except Exception:  # pragma: no cover - defensive
+        log.exception("[rag_v2] failed to compute entropy band; falling back to seed chunk")
+        top_chunk = ordered[0]
+        band = EvidenceBand(
+            seed_chunk_id=top_chunk.chunk_id,
+            start_idx=0,
+            end_idx=0,
+            confidence=0.5,
+            entropy_trace_left=[],
+            entropy_trace_right=[],
+            method="fallback",
+            band_chunk_ids=[top_chunk.chunk_id],
+        )
+
+    chunk_map = {chunk.chunk_id: chunk for chunk in ordered}
+    context = pack_context(band, chunk_map)
+    message = to_legacy_llm_message(context, question)
+
+    extraction = _default_extraction()
+    extraction.provenance = {
+        "question": question,
+        "domain": domain,
+        "pool": len(pool),
+        "fused_scores": {cid: score.final for cid, score in fused.items()},
+        "band": {
+            "seed": band.seed_chunk_id,
+            "method": band.method,
+            "size": len(band.band_chunk_ids),
+        },
+        "context": context,
+        "llm_message": message,
+    }
+    extraction.confidence = max(score.final for score in fused.values()) if fused else 0.0
+    return extraction

--- a/backend/ragV2/pack.py
+++ b/backend/ragV2/pack.py
@@ -1,0 +1,44 @@
+"""Context packing utilities to match the legacy LLM payload shape."""
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .types import Chunk, EvidenceBand
+
+
+def _chunk_payload(chunk: Chunk) -> Dict[str, object]:
+    payload = {
+        "chunk_id": chunk.chunk_id,
+        "doc_id": chunk.doc_id,
+        "section": chunk.section_no,
+        "section_title": chunk.section_title,
+        "pages": chunk.page_range,
+        "text": chunk.text,
+    }
+    payload.update({f"meta_{key}": value for key, value in (chunk.meta or {}).items()})
+    return payload
+
+
+def pack_context(
+    band: EvidenceBand, chunks_by_id: Dict[str, Chunk]
+) -> Dict[str, List[Dict[str, object]]]:
+    standards: List[Dict[str, object]] = []
+    project_spec: List[Dict[str, object]] = []
+    risk: List[Dict[str, object]] = []
+    for cid in band.band_chunk_ids:
+        chunk = chunks_by_id.get(cid)
+        if chunk is None:
+            continue
+        bucket = chunk.meta.get("bucket") if chunk.meta else None
+        payload = _chunk_payload(chunk)
+        if bucket == "Standards" or chunk.meta.get("standard_info"):
+            standards.append(payload)
+        elif bucket == "Risk" or chunk.meta.get("risk"):
+            risk.append(payload)
+        else:
+            project_spec.append(payload)
+    return {
+        "Standards": standards,
+        "ProjectSpec": project_spec,
+        "Risk": risk,
+    }

--- a/backend/ragV2/prompts.py
+++ b/backend/ragV2/prompts.py
@@ -1,0 +1,31 @@
+"""Prompt constants used by the RAG v2 orchestrator."""
+
+EXTRACT_PROMPT = """You extract technical specs from standards and project docs.
+Use ONLY the provided passages. Every field MUST include a cite = passage_id.
+
+Buckets:
+[Standards]: authoritative clauses (ISO/NFPA/RIA/OSHA) with {standard, year, clause}.
+[ProjectSpec]: RFQ/spec requirements, thresholds, acceptance criteria.
+[Risk]: notes, exceptions, options.
+
+Task: Fill this JSON exactly:
+{"requirements":[],"thresholds":[],"units":[],"standards":[],"exceptions":[],"acceptance_criteria":[]}
+
+Rules:
+- Quote numbers/units exactly from a passage; you may paraphrase surrounding text.
+- Keep dual-units if present (e.g., "18 in (457 mm)").
+- If edition or clause is ambiguous, add to "exceptions" and set "edition_ambiguous": true.
+- If a field lacks evidence, do not guess; leave it out and add the field name to a top-level "missing":[...] array.
+Return ONLY the final JSON."""
+
+VERIFY_PROMPT = """You verify an extracted JSON against the provided passages.
+List fields lacking a directly supporting span or with mismatched numbers/units.
+Propose the MINIMAL follow-up query to fix each gap.
+
+Return:
+{"missing_fields":[...], "followups":[ "...", "..." ], "weak_citations":[{"field":"...","reason":"..."}]}"""
+
+EDITION_ARBITER_PROMPT = """Multiple editions appear. Decide the governing edition using policy:
+- Prefer the latest edition unless a specific edition is pinned in [ProjectSpec].
+Return JSON:
+{"governing":{"NFPA 79":"2024", ...}, "reasons":[ "...", "..." ]}"""

--- a/backend/ragV2/rerank.py
+++ b/backend/ragV2/rerank.py
@@ -1,0 +1,30 @@
+"""Cross-encoder and LLM based reranking utilities."""
+from __future__ import annotations
+
+from typing import Callable, Iterable, List, Optional
+
+from .types import Chunk
+
+ScoreFn = Callable[[str, Chunk], float]
+
+
+class Reranker:
+    """Simple reranker wrapper that keeps meta-data about scores."""
+
+    def __init__(self, scorer: Optional[ScoreFn] = None, top_k: Optional[int] = None) -> None:
+        self._scorer = scorer
+        self._top_k = top_k
+
+    def rerank(self, query: str, candidates: Iterable[Chunk]) -> List[Chunk]:
+        chunks = list(candidates or [])
+        if not self._scorer or not chunks:
+            return chunks
+        scored = []
+        for chunk in chunks:
+            score = float(self._scorer(query, chunk))
+            chunk.meta.setdefault("crossenc_score", score)
+            scored.append((chunk, score))
+        scored.sort(key=lambda item: item[1], reverse=True)
+        if self._top_k is not None and self._top_k > 0:
+            scored = scored[: self._top_k]
+        return [chunk for chunk, _score in scored]

--- a/backend/ragV2/retrieval.py
+++ b/backend/ragV2/retrieval.py
@@ -1,0 +1,142 @@
+"""Hybrid retrieval utilities used by the RAG v2 orchestrator."""
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from .config import CFG
+from .types import Chunk
+
+Candidate = Tuple[Chunk, float]
+SearchFn = Callable[[str, str, Dict[str, str], int], Iterable[Candidate]]
+
+
+@dataclass
+class QueryExpansion:
+    """Lightweight expander used to surface acronyms or units present in the query."""
+
+    expansions: Dict[str, Sequence[str]]
+
+    def expand(self, query: str) -> List[str]:
+        tokens = [token.strip() for token in query.split() if token.strip()]
+        results = set(tokens)
+        for token in tokens:
+            key = token.lower()
+            if key in self.expansions:
+                for value in self.expansions[key]:
+                    results.add(value)
+        return list(results)
+
+
+def _as_candidates(items: Iterable[Candidate | Chunk]) -> List[Candidate]:
+    normalized: List[Candidate] = []
+    for item in items or []:
+        if isinstance(item, tuple) and len(item) == 2 and isinstance(item[1], (int, float)):
+            chunk, score = item
+        else:
+            chunk, score = item, 1.0  # type: ignore[assignment]
+        if not isinstance(chunk, Chunk):
+            continue
+        normalized.append((chunk, float(score)))
+    return normalized
+
+
+class Retriever:
+    """Hybrid retriever that combines dense, sparse and regex driven candidates."""
+
+    def __init__(
+        self,
+        *,
+        dense_search: Optional[SearchFn] = None,
+        sparse_search: Optional[SearchFn] = None,
+        regex_search: Optional[SearchFn] = None,
+        query_expander: Optional[QueryExpansion] = None,
+        section_diversity: Optional[int] = None,
+    ) -> None:
+        self._dense = dense_search
+        self._sparse = sparse_search
+        self._regex = regex_search
+        self._expander = query_expander or QueryExpansion({})
+        self._section_diversity = (
+            int(section_diversity)
+            if section_diversity is not None
+            else CFG.section_diversity
+        )
+
+    def _filter_by_edition(
+        self, candidates: List[Candidate], filters: Dict[str, str]
+    ) -> List[Candidate]:
+        if not filters:
+            return candidates
+        result: List[Candidate] = []
+        for chunk, score in candidates:
+            meta = chunk.meta or {}
+            edition_map = meta.get("editions")
+            jurisdiction = meta.get("jurisdiction")
+            if filters.get("jurisdiction") and jurisdiction:
+                if jurisdiction != filters["jurisdiction"]:
+                    continue
+            if isinstance(edition_map, dict):
+                skip = False
+                for key, desired in filters.items():
+                    if key == "jurisdiction":
+                        continue
+                    have = edition_map.get(key)
+                    if have is not None and desired and have != desired:
+                        skip = True
+                        break
+                if skip:
+                    continue
+            result.append((chunk, score))
+        return result
+
+    @staticmethod
+    def _diversify(candidates: List[Candidate], limit: int) -> List[Candidate]:
+        if limit <= 0:
+            return candidates
+        seen_per_section: Dict[Tuple[str, Optional[str]], int] = defaultdict(int)
+        diversified: List[Candidate] = []
+        for chunk, score in candidates:
+            key = (chunk.doc_id, chunk.section_no)
+            if seen_per_section[key] >= limit:
+                continue
+            diversified.append((chunk, score))
+            seen_per_section[key] += 1
+        return diversified
+
+    def _merge(self, pools: Sequence[List[Candidate]]) -> List[Candidate]:
+        ranked: Dict[str, Tuple[Chunk, float]] = {}
+        for priority, pool in enumerate(pools):
+            for chunk, score in pool:
+                existing = ranked.get(chunk.chunk_id)
+                boost = 1.0 + (0.05 * (len(pools) - priority))
+                composite = float(score) * boost
+                if existing is None or composite > existing[1]:
+                    ranked[chunk.chunk_id] = (chunk, composite)
+        ordered = sorted(ranked.values(), key=lambda item: item[1], reverse=True)
+        return ordered
+
+    def search(
+        self, query: str, domain: str, edition_filters: Optional[Dict[str, str]] = None
+    ) -> List[Chunk]:
+        edition_filters = dict(edition_filters or {})
+        expanded_terms = self._expander.expand(query)
+        pools: List[List[Candidate]] = []
+        for searcher, limit in (
+            (self._dense, CFG.k_dense),
+            (self._sparse, CFG.k_sparse),
+            (self._regex, CFG.k_regex),
+        ):
+            if searcher is None or limit <= 0:
+                continue
+            term = " ".join(expanded_terms)
+            candidates = _as_candidates(searcher(term, domain, edition_filters, limit))
+            pools.append(candidates)
+        merged = self._merge(pools)
+        filtered = self._filter_by_edition(merged, edition_filters)
+        diversified = self._diversify(filtered, self._section_diversity)
+        ordered_chunks = [chunk for chunk, _score in diversified]
+        for idx, chunk in enumerate(ordered_chunks):
+            chunk.meta.setdefault("retrieval_rank", idx)
+        return ordered_chunks

--- a/backend/ragV2/types.py
+++ b/backend/ragV2/types.py
@@ -1,0 +1,111 @@
+"""Data structures shared across the RAG v2 pipeline."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+try:  # pragma: no cover - optional dependency
+    import numpy as np  # type: ignore
+except Exception:  # pragma: no cover - fallback when numpy is unavailable
+    np = None  # type: ignore
+
+
+EmbedT = Optional["np.ndarray"] if np is not None else Optional[Sequence[float]]
+
+
+@dataclass
+class Chunk:
+    """A slice of source material considered during retrieval and synthesis."""
+
+    chunk_id: str
+    doc_id: str
+    section_no: Optional[str]
+    section_title: Optional[str]
+    page_range: Tuple[int, int]
+    text: str
+    embed: EmbedT = None
+    bm25: Optional[float] = None
+    regex_hits: int = 0
+    meta: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        self.meta = dict(self.meta or {})
+
+
+@dataclass
+class EvidenceScore:
+    """Score contributions from each micro-agent plus the fused score."""
+
+    standard: float = 0.0
+    fluid: float = 0.0
+    hep: float = 0.0
+    final: float = 0.0
+    signals: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class EvidenceBand:
+    """A contiguous (or virtual contiguous) evidence window around a seed chunk."""
+
+    seed_chunk_id: str
+    start_idx: int
+    end_idx: int
+    confidence: float
+    entropy_trace_left: List[float]
+    entropy_trace_right: List[float]
+    method: str
+    band_chunk_ids: List[str]
+
+    def __post_init__(self) -> None:
+        self.entropy_trace_left = list(self.entropy_trace_left)
+        self.entropy_trace_right = list(self.entropy_trace_right)
+        self.band_chunk_ids = list(self.band_chunk_ids)
+
+
+@dataclass
+class ExtractionField:
+    """Single extracted field with citation information."""
+
+    text: str
+    cite: str
+    value: Optional[Any] = None
+
+
+@dataclass
+class ExtractionJSON:
+    """Structured extraction payload returned by the orchestrator."""
+
+    requirements: List[ExtractionField] = field(default_factory=list)
+    thresholds: List[ExtractionField] = field(default_factory=list)
+    units: List[ExtractionField] = field(default_factory=list)
+    standards: List[Dict[str, Any]] = field(default_factory=list)
+    exceptions: List[ExtractionField] = field(default_factory=list)
+    acceptance_criteria: List[ExtractionField] = field(default_factory=list)
+    conflicts: List[Dict[str, Any]] = field(default_factory=list)
+    missing: List[str] = field(default_factory=list)
+    confidence: float = 0.0
+    provenance: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to a dictionary useful for logging or JSON encoding."""
+
+        def _serialize_field(item: ExtractionField) -> Dict[str, Any]:
+            data: Dict[str, Any] = {"text": item.text, "cite": item.cite}
+            if item.value is not None:
+                data["value"] = item.value
+            return data
+
+        return {
+            "requirements": [_serialize_field(f) for f in self.requirements],
+            "thresholds": [_serialize_field(f) for f in self.thresholds],
+            "units": [_serialize_field(f) for f in self.units],
+            "standards": list(self.standards),
+            "exceptions": [_serialize_field(f) for f in self.exceptions],
+            "acceptance_criteria": [
+                _serialize_field(f) for f in self.acceptance_criteria
+            ],
+            "conflicts": list(self.conflicts),
+            "missing": list(self.missing),
+            "confidence": self.confidence,
+            "provenance": dict(self.provenance),
+        }

--- a/tests/test_payload_parity.py
+++ b/tests/test_payload_parity.py
@@ -1,0 +1,34 @@
+from backend.compat.payload_adapter import to_legacy_llm_message
+
+
+def test_payload_structure_parity():
+    ctx = {
+        "Standards": [
+            {
+                "chunk_id": "s1",
+                "doc_id": "docA",
+                "section": "1",
+                "section_title": "Scope",
+                "pages": (1, 2),
+                "text": "Clause text",
+            }
+        ],
+        "ProjectSpec": [
+            {
+                "chunk_id": "p1",
+                "doc_id": "docB",
+                "section": "2",
+                "section_title": "Requirements",
+                "pages": (3, 3),
+                "text": "Project requirement",
+            }
+        ],
+        "Risk": [],
+    }
+    question = "What are the requirements?"
+    payload = to_legacy_llm_message(ctx, question)
+    assert list(payload.keys()) == ["messages"]
+    assert payload["messages"][0]["role"] == "system"
+    assert "[Standards]" in payload["messages"][1]["content"]
+    assert "[ProjectSpec]" in payload["messages"][1]["content"]
+    assert "Project requirement" in payload["messages"][1]["content"]

--- a/tests/test_ragV2_entropy.py
+++ b/tests/test_ragV2_entropy.py
@@ -1,0 +1,47 @@
+from backend.ragV2.config import CFG
+from backend.ragV2.entropy import (
+    entropy_changepoint_band,
+    entropy_graph_band,
+    entropy_linear_band,
+)
+from backend.ragV2.graph import GraphIndex
+from backend.ragV2.types import Chunk
+
+
+def _chunk(idx: int, text: str) -> Chunk:
+    return Chunk(
+        chunk_id=f"c{idx}",
+        doc_id="d1",
+        section_no="1",
+        section_title="Intro",
+        page_range=(idx, idx + 1),
+        text=text,
+    )
+
+
+def test_entropy_linear_band_stops_on_high_entropy():
+    ordered = [_chunk(i, "low variance text") for i in range(3)]
+    ordered.append(_chunk(3, "diverse tokens alpha beta gamma"))
+    band = entropy_linear_band(0, ordered)
+    assert band.end_idx < len(ordered) - 1
+
+
+def test_entropy_graph_band_collects_neighbors():
+    ordered = [_chunk(i, f"node {i} data") for i in range(3)]
+    graph = GraphIndex()
+    graph.build_from_edges([
+        ("c0", "c1", 0.9),
+        ("c1", "c2", 0.85),
+    ])
+    band = entropy_graph_band(ordered[0], ordered, graph)
+    assert set(band.band_chunk_ids) >= {"c0", "c1"}
+
+
+def test_entropy_changepoint_band_respects_change():
+    ordered = [
+        _chunk(0, "repeat repeat repeat"),
+        _chunk(1, "repeat repeat repeat"),
+        _chunk(2, "new tokens appear everywhere"),
+    ]
+    band = entropy_changepoint_band(0, ordered)
+    assert band.end_idx <= 1

--- a/tests/test_ragV2_fusion.py
+++ b/tests/test_ragV2_fusion.py
@@ -1,0 +1,35 @@
+import pytest
+
+from backend.ragV2.config import CFG
+from backend.ragV2.fusion import fuse_scores, intersect_or_tightest_band, zscore
+from backend.ragV2.types import EvidenceBand
+
+
+def test_fuse_scores_weights():
+    std = {"a": 0.8, "b": 0.2, "c": 0.5}
+    flu = {"a": 0.3, "b": 0.4, "c": 0.5}
+    hep = {"a": 0.1, "b": 0.9, "c": 0.5}
+    fused = fuse_scores(std, flu, hep)
+    std_z = zscore(std)
+    flu_z = zscore(flu)
+    hep_z = zscore(hep)
+    expected_a = (
+        CFG.w_std * std_z["a"] + CFG.w_flu * flu_z["a"] + CFG.w_hep * hep_z["a"]
+    )
+    assert fused["a"].final == pytest.approx(expected_a)
+    assert fused["a"].final > fused["b"].final
+
+
+def test_intersect_or_tightest_band_prefers_intersection():
+    band_a = EvidenceBand("seed", 0, 2, 0.9, [], [], "A", ["1", "2", "3"])
+    band_b = EvidenceBand("seed", 1, 3, 0.8, [], [], "B", ["2", "3", "4"])
+    band_c = EvidenceBand("seed", 0, 1, 0.7, [], [], "C", ["2"])
+    chosen = intersect_or_tightest_band([band_a, band_b, band_c], [])
+    assert chosen.method == "C"
+
+
+def test_intersect_or_tightest_band_uses_tightest_when_no_overlap():
+    band_a = EvidenceBand("seed", 0, 3, 0.6, [], [], "A", ["1", "2", "3", "4"])
+    band_b = EvidenceBand("seed", 0, 1, 0.8, [], [], "B", ["5", "6"])
+    chosen = intersect_or_tightest_band([band_a, band_b], [])
+    assert chosen.method == "B"


### PR DESCRIPTION
## Summary
- add a configurable ragV2 package covering retrieval, scoring agents, entropy band carving, context packing, and orchestration
- expose a compatibility payload adapter that preserves the legacy LLM message envelope while using new context buckets
- document the migration in CHANGELOG.md and provide unit tests for score fusion, entropy bands, and payload parity

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d343f1b6688324bc317e396f0d4820