### PR TITLE
Fix pass CSV normalization and add tests

### DIFF
--- a/backend/pipeline/passes/responses.py
+++ b/backend/pipeline/passes/responses.py
@@ -7,7 +7,18 @@ from typing import Dict, List, Optional, Tuple
 
 from backend.utils.strings import s
 
-from .constants import CSV_COLUMNS
+from .constants import ALL_PASSES, CSV_COLUMNS
+
+
+VALID_PASS_LOOKUP = {pass_name.lower(): pass_name for pass_name in [*ALL_PASSES, "Header"]}
+
+
+def _normalize_pass(value: str) -> Optional[str]:
+    """Return the canonical pass name if the supplied value is valid."""
+
+    if not value:
+        return None
+    return VALID_PASS_LOOKUP.get(value.lower())
 
 
 def parse_pass_response(text: str, pass_name: str) -> Tuple[List[Dict[str, str]], Optional[str], Optional[str]]:
@@ -30,14 +41,25 @@ def parse_pass_response(text: str, pass_name: str) -> Tuple[List[Dict[str, str]]
         csv_block = split_csv.strip()
 
     rows: List[Dict[str, str]] = []
+    last_valid_pass = _normalize_pass(pass_name) or pass_name
     if csv_block:
         reader = csv.DictReader(io.StringIO(csv_block))
         for row in reader:
             if not any(row.values()):
                 continue
             normalized = {col: s(row.get(col)) for col in CSV_COLUMNS}
-            if not normalized["Pass"]:
-                normalized["Pass"] = pass_name
+            spec = normalized.get("Specification", "")
+            raw_pass = normalized.get("Pass", "")
+            canonical_pass = _normalize_pass(raw_pass)
+            if canonical_pass:
+                normalized["Pass"] = canonical_pass
+                last_valid_pass = canonical_pass
+            else:
+                if raw_pass:
+                    normalized["Specification"] = ", ".join(
+                        fragment for fragment in (spec, raw_pass) if fragment
+                    )
+                normalized["Pass"] = last_valid_pass or pass_name
             rows.append(normalized)
     return rows, csv_block, json_block
 
@@ -46,7 +68,12 @@ def encode_rows_to_csv(rows: List[Dict[str, str]]) -> str:
     """Serialise rows for download."""
 
     buffer = io.StringIO()
-    writer = csv.DictWriter(buffer, fieldnames=CSV_COLUMNS, extrasaction="ignore")
+    writer = csv.DictWriter(
+        buffer,
+        fieldnames=CSV_COLUMNS,
+        extrasaction="ignore",
+        quoting=csv.QUOTE_MINIMAL,
+    )
     writer.writeheader()
     for row in rows:
         writer.writerow({col: row.get(col, "") for col in CSV_COLUMNS})

--- a/tests/test_pass_responses.py
+++ b/tests/test_pass_responses.py
@@ -1,0 +1,41 @@
+"""Tests for parsing and exporting pass responses."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from backend.pipeline.passes.responses import encode_rows_to_csv, parse_pass_response
+
+
+def test_parse_pass_response_recovers_spilled_pass_column() -> None:
+    csv_text = (
+        "Document,(Sub)Section #,(Sub)Section Name,Specification,Pass\n"
+        "Doc,1,Intro,Seal joints, RH 30-70%,Mechanical\n"
+        "Doc,2,Intro,Use UL-listed hardware,,\n"
+    )
+    rows, csv_block, json_block = parse_pass_response(csv_text, "Mechanical")
+
+    assert csv_block is not None
+    assert json_block is None
+    assert len(rows) == 2
+    assert rows[0]["Specification"] == "Seal joints, RH 30-70%"
+    assert rows[0]["Pass"] == "Mechanical"
+    # Second row should inherit the last valid pass value.
+    assert rows[1]["Pass"] == "Mechanical"
+
+
+def test_encode_rows_quotes_comma_fields() -> None:
+    rows = [
+        {
+            "Document": "Doc",
+            "(Sub)Section #": "1",
+            "(Sub)Section Name": "Intro",
+            "Specification": "Seal joints, RH 30-70%",
+            "Pass": "Mechanical",
+        }
+    ]
+
+    csv_output = encode_rows_to_csv(rows)
+    assert '"Seal joints, RH 30-70%"' in csv_output


### PR DESCRIPTION
## Summary
- canonicalize parsed pass values and reattach stray specification fragments when CSV outputs spill over the pass column
- ensure CSV exports quote comma-containing specification fields
- add regression tests covering the pass response parser and CSV encoder

## Testing
- pytest tests/test_pass_responses.py

------
https://chatgpt.com/codex/tasks/task_e_68d47a51e7c08324a5d610129b46059d