### PR TITLE
Add UI control to force re-chunking before header detection

### DIFF
--- a/backend/routes/preprocess.py
+++ b/backend/routes/preprocess.py
@@ -31,8 +31,9 @@ def preprocess_route():
 
         state = get_state(session_id) if session_id else None
         file_hash = getattr(state, "file_hash", None) if state else None
+        force_refresh = bool(data.get("force_refresh"))
 
-        cached = get_preprocess_cache(file_hash)
+        cached = get_preprocess_cache(file_hash) if not force_refresh else None
         if cached:
             cached_chunks = [dict(chunk) for chunk in cached.get("chunks", [])]
             if state is not None:

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -54,6 +54,7 @@
 
         <button id="headersBtn">Detect headers (LLM)</button>
         <button id="headersRerunBtn" class="ghost">Re-run header detection (ignore cache)</button>
+        <button id="headersRechunkBtn" class="ghost">Re-chunk &amp; detect headers (ignore caches)</button>
       </div>
       <div id="headersStatus" class="status">Header detection pending…</div>
       <div class="grid-headers">

--- a/frontend/js/api.mjs
+++ b/frontend/js/api.mjs
@@ -80,11 +80,15 @@ export async function uploadDocument(file){
 }
 
 
-export async function preprocessDocument(sessionId, model, provider){
+export async function preprocessDocument(sessionId, model, provider, options={}){
+  const payload = {session_id:sessionId, model, provider};
+  if(options && options.forceRefresh){
+    payload.force_refresh = true;
+  }
   return safeFetch("/api/preprocess", {
     method:"POST",
     headers:{"Content-Type":"application/json"},
-    body:JSON.stringify({session_id:sessionId, model, provider})
+    body:JSON.stringify(payload)
   });
 }
 

--- a/frontend/js/app.mjs
+++ b/frontend/js/app.mjs
@@ -14,6 +14,7 @@ import {
   onPreprocess,
   onHeaders,
   onHeadersRerun,
+  onHeadersRechunk,
   onLocalHeaders,
   onProcess,
   onProcessRerunAll
@@ -66,6 +67,8 @@ async function boot() {
   if (headersBtn) headersBtn.addEventListener("click", onHeaders);
   const headersRerunBtn = el("headersRerunBtn");
   if (headersRerunBtn) headersRerunBtn.addEventListener("click", onHeadersRerun);
+  const headersRechunkBtn = el("headersRechunkBtn");
+  if (headersRechunkBtn) headersRechunkBtn.addEventListener("click", onHeadersRechunk);
   const processBtn = el("processBtn");
   if (processBtn) processBtn.addEventListener("click", onProcess);
   const rerunBtn = el("processRerunBtn");

--- a/frontend/js/flows.mjs
+++ b/frontend/js/flows.mjs
@@ -262,26 +262,46 @@ export async function handleTestLLM() {
   }
 }
 
-export async function onPreprocess() {
-  if (!requireSession()) return;
+export async function onPreprocess(options = {}) {
+  if (!requireSession()) return false;
   updateModel();
   if (!state.provider) {
     alert("Select an LLM provider first.");
-    return;
+    return false;
   }
   if (!state.model) {
     alert("Select a model first.");
-    return;
+    return false;
   }
-  const end = openGroup("[Flow] Preprocess", false);
+  const forceRefresh = Boolean(options?.forceRefresh);
+  const end = openGroup(forceRefresh ? "[Flow] Preprocess (force)" : "[Flow] Preprocess", false);
+  let success = false;
   try {
     console.log("State before preprocess", { ...state });
-    updateStatus("preprocessStatus", "Running standard chunking…");
-    log("Preprocess start");
+    if (forceRefresh) {
+      state.hasHeaders = false;
+      state.cacheInfo.headers = false;
+      state.hasLocalHeaders = false;
+      state.localHeaders = [];
+      const previewTarget = el("headersPreview");
+      if (previewTarget) renderHeaderPreview(previewTarget, []);
+      const localPreviewTarget = el("headersLocalPreview");
+      if (localPreviewTarget) renderLocalHeaders(localPreviewTarget, []);
+      const headerStatus = el("headersStatus");
+      if (headerStatus) setStatus(headerStatus, "Header detection pending…");
+    }
+    const statusLabel = forceRefresh ? "Re-running standard chunking…" : "Running standard chunking…";
+    updateStatus("preprocessStatus", statusLabel);
+    log(forceRefresh ? "Preprocess rerun start" : "Preprocess start");
     withGroup("[Flow] Preprocess → Request payload", () => {
-      console.log({ session_id: state.sessionId, model: state.model, provider: state.provider });
+      console.log({
+        session_id: state.sessionId,
+        model: state.model,
+        provider: state.provider,
+        force_refresh: forceRefresh || undefined
+      });
     }, true);
-    const res = await preprocessDocument(state.sessionId, state.model, state.provider);
+    const res = await preprocessDocument(state.sessionId, state.model, state.provider, { forceRefresh });
     withGroup(`[Flow] Preprocess → Raw response (${res.httpStatus ?? "?"})`, () => {
       console.log(res);
     }, true);
@@ -289,11 +309,11 @@ export async function onPreprocess() {
       const msg = res.error || "Preprocess failed";
       updateStatus("preprocessStatus", msg, "warn");
       log(`Preprocess error: ${msg}`);
-      return;
+      return false;
     }
     state.hasPre = true;
     state.cacheInfo.preprocess = true;
-    const cacheTag = res.cache?.hit ? " [cached]" : "";
+    const cacheTag = res.cache?.hit ? " [cached]" : forceRefresh ? " [refreshed]" : "";
     updateStatus(
       "preprocessStatus",
       `Pages=${res.pages}, pre-chunks=${res.pre_chunks}${cacheTag}`,
@@ -301,13 +321,17 @@ export async function onPreprocess() {
     );
     if (res.cache?.hit) {
       log("Preprocess complete via cache");
+    } else if (forceRefresh) {
+      log(`Preprocess rerun complete pages=${res.pages} chunks=${res.pre_chunks}`);
     } else {
       log(`Preprocess complete pages=${res.pages} chunks=${res.pre_chunks}`);
     }
     console.log("State after preprocess", { ...state });
+    success = true;
   } finally {
     end();
   }
+  return success;
 }
 
 export async function onLocalHeaders() {
@@ -422,6 +446,20 @@ export async function onHeaders(options = {}) {
 
 export function onHeadersRerun() {
   return onHeaders({ forceRefresh: true });
+}
+
+export async function onHeadersRechunk() {
+  const end = openGroup("[Flow] Re-chunk before headers", false);
+  try {
+    const preOk = await onPreprocess({ forceRefresh: true });
+    if (!preOk) {
+      log("Re-chunk before headers aborted: preprocess failed");
+      return;
+    }
+    await onHeaders({ forceRefresh: true });
+  } finally {
+    end();
+  }
 }
 
 export async function onProcess(options = {}) {


### PR DESCRIPTION
## Summary
- allow the preprocess endpoint to skip cached chunks when a force_refresh flag is provided
- update the frontend flows to reset headers, call preprocess with force refresh, and chain a re-run of header detection
- expose a "Re-chunk & detect headers" UI control that bypasses caches when pressed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4891734188324b1787f638e02d7b3