### PR TITLE
Move rechunk control to preprocess step

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -43,6 +43,7 @@
       <h2>2 · Preprocess</h2>
       <div class="actions">
         <button id="preprocessBtn">Run standard chunking</button>
+        <button id="preprocessRechunkBtn" class="ghost">Re-run chunking (ignore caches)</button>
       </div>
       <div id="preprocessStatus" class="status">Pre-chunking pending…</div>
     </section>
@@ -54,7 +55,6 @@
 
         <button id="headersBtn">Detect headers (LLM)</button>
         <button id="headersRerunBtn" class="ghost">Re-run header detection (ignore cache)</button>
-        <button id="headersRechunkBtn" class="ghost">Re-chunk &amp; detect headers (ignore caches)</button>
       </div>
       <div id="headersStatus" class="status">Header detection pending…</div>
       <div class="grid-headers">

--- a/frontend/js/app.mjs
+++ b/frontend/js/app.mjs
@@ -14,7 +14,7 @@ import {
   onPreprocess,
   onHeaders,
   onHeadersRerun,
-  onHeadersRechunk,
+  onPreprocessRechunk,
   onLocalHeaders,
   onProcess,
   onProcessRerunAll
@@ -61,14 +61,14 @@ async function boot() {
   if (testBtn) testBtn.addEventListener("click", handleTestLLM);
   const preprocessBtn = el("preprocessBtn");
   if (preprocessBtn) preprocessBtn.addEventListener("click", onPreprocess);
+  const preprocessRechunkBtn = el("preprocessRechunkBtn");
+  if (preprocessRechunkBtn) preprocessRechunkBtn.addEventListener("click", onPreprocessRechunk);
   const localHeadersBtn = el("localHeadersBtn");
   if (localHeadersBtn) localHeadersBtn.addEventListener("click", onLocalHeaders);
   const headersBtn = el("headersBtn");
   if (headersBtn) headersBtn.addEventListener("click", onHeaders);
   const headersRerunBtn = el("headersRerunBtn");
   if (headersRerunBtn) headersRerunBtn.addEventListener("click", onHeadersRerun);
-  const headersRechunkBtn = el("headersRechunkBtn");
-  if (headersRechunkBtn) headersRechunkBtn.addEventListener("click", onHeadersRechunk);
   const processBtn = el("processBtn");
   if (processBtn) processBtn.addEventListener("click", onProcess);
   const rerunBtn = el("processRerunBtn");

--- a/frontend/js/flows.mjs
+++ b/frontend/js/flows.mjs
@@ -448,18 +448,8 @@ export function onHeadersRerun() {
   return onHeaders({ forceRefresh: true });
 }
 
-export async function onHeadersRechunk() {
-  const end = openGroup("[Flow] Re-chunk before headers", false);
-  try {
-    const preOk = await onPreprocess({ forceRefresh: true });
-    if (!preOk) {
-      log("Re-chunk before headers aborted: preprocess failed");
-      return;
-    }
-    await onHeaders({ forceRefresh: true });
-  } finally {
-    end();
-  }
+export function onPreprocessRechunk() {
+  return onPreprocess({ forceRefresh: true });
 }
 
 export async function onProcess(options = {}) {


### PR DESCRIPTION
## Summary
- move the re-chunk action into the preprocess step UI and remove it from header detection
- wire a dedicated preprocess re-chunk handler so the action only re-runs chunking with fresh metadata
- keep header detection controls focused on rerunning the LLM-based header search

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d4908dcb048324ac26cd422bba28ef