### PR TITLE
Add microchunk indexing and hybrid retrieval pipeline

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,3 +12,6 @@ python-docx==1.1.2
 PyMuPDF==1.24.9
 jsonschema==4.23.0
 rapidfuzz>=3.0.0
+pyarrow>=16.0.0
+rank-bm25>=0.2
+regex>=2024.5.15

--- a/index/__init__.py
+++ b/index/__init__.py
@@ -1,0 +1,6 @@
+"""Index backends for hybrid microchunk retrieval."""
+
+from .embedding_store import EmbeddingStore
+from .bm25_store import BM25Store
+
+__all__ = ["EmbeddingStore", "BM25Store"]

--- a/index/bm25_store.py
+++ b/index/bm25_store.py
@@ -1,0 +1,71 @@
+"""Lightweight BM25 index for lexical microchunk retrieval."""
+from __future__ import annotations
+
+import pickle
+from pathlib import Path
+from typing import List, Optional, Sequence, Tuple
+
+import regex as re
+from rank_bm25 import BM25Okapi
+
+from ingest.microchunker import MicroChunk
+
+_TOKEN_SPLIT = re.compile(r"\p{L}[\p{L}\p{Mn}\p{Mc}\p{Pd}\p{Pc}\p{Nd}]*|\p{N}+", re.UNICODE)
+
+
+def _tokenize(text: str) -> List[str]:
+    return [tok.lower() for tok in _TOKEN_SPLIT.findall(text)]
+
+
+class BM25Store:
+    """Wrapper around :class:`rank_bm25.BM25Okapi` with persistence."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = Path(path)
+        self._bm25: Optional[BM25Okapi] = None
+        self._micro_ids: List[str] = []
+
+    def load(self) -> None:
+        if self._bm25 is not None:
+            return
+        if not self.path.exists():
+            return
+        with self.path.open("rb") as handle:
+            payload = pickle.load(handle)
+        self._bm25 = payload["bm25"]
+        self._micro_ids = payload["micro_ids"]
+
+    def save(self) -> None:
+        if self._bm25 is None:
+            return
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {"bm25": self._bm25, "micro_ids": self._micro_ids}
+        with self.path.open("wb") as handle:
+            pickle.dump(payload, handle)
+
+    def build(self, microchunks: Sequence[MicroChunk]) -> None:
+        docs = []
+        ids = []
+        for micro in microchunks:
+            text = micro.get("norm_text") or micro.get("text") or ""
+            docs.append(_tokenize(text))
+            ids.append(micro["micro_id"])
+        if not docs:
+            self._bm25 = None
+            self._micro_ids = []
+            return
+        self._bm25 = BM25Okapi(docs)
+        self._micro_ids = ids
+        self.save()
+
+    def search(self, query: str, k: int = 20) -> List[Tuple[str, float]]:
+        self.load()
+        if self._bm25 is None:
+            return []
+        tokens = _tokenize(query)
+        scores = self._bm25.get_scores(tokens)
+        order = scores.argsort()[::-1][:k]
+        return [(self._micro_ids[idx], float(scores[idx])) for idx in order]
+
+
+__all__ = ["BM25Store"]

--- a/index/embedding_store.py
+++ b/index/embedding_store.py
@@ -1,0 +1,125 @@
+"""Lightweight embedding store backed by Parquet for microchunks."""
+from __future__ import annotations
+
+import hashlib
+import pickle
+from pathlib import Path
+from typing import Iterable, List, Mapping, Optional, Sequence, Tuple
+
+import numpy as np
+import pandas as pd
+from sklearn.feature_extraction.text import TfidfVectorizer
+
+from ingest.microchunker import MicroChunk
+
+
+class EmbeddingStore:
+    """Persist and query embedding vectors for microchunks."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = Path(path)
+        self.vectorizer_path = self.path.with_suffix(".vectorizer.pkl")
+        self._df: Optional[pd.DataFrame] = None
+        self._vectorizer: Optional[TfidfVectorizer] = None
+
+    # ------------------------------------------------------------------
+    # Loading / persistence helpers
+    # ------------------------------------------------------------------
+    def load(self) -> None:
+        if self._df is not None:
+            return
+        if self.path.exists():
+            self._df = pd.read_parquet(self.path)
+        else:
+            self._df = pd.DataFrame(columns=["micro_id", "doc_id", "content_hash", "vector"])
+        if self.vectorizer_path.exists():
+            with self.vectorizer_path.open("rb") as handle:
+                self._vectorizer = pickle.load(handle)
+
+    def save(self) -> None:
+        if self._df is None:
+            return
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._df.to_parquet(self.path, index=False)
+        if self._vectorizer is not None:
+            with self.vectorizer_path.open("wb") as handle:
+                pickle.dump(self._vectorizer, handle)
+
+    # ------------------------------------------------------------------
+    # Index construction
+    # ------------------------------------------------------------------
+    def build(self, microchunks: Sequence[MicroChunk], *, vectorizer: Optional[TfidfVectorizer] = None) -> None:
+        """Construct a fresh embedding index from ``microchunks``."""
+
+        self.load()
+        texts: List[str] = []
+        ids: List[str] = []
+        doc_ids: List[str] = []
+        hashes: List[str] = []
+        for micro in microchunks:
+            text = micro.get("norm_text") or micro.get("text") or ""
+            texts.append(text)
+            ids.append(micro["micro_id"])
+            doc_ids.append(micro.get("doc_id", "doc-unknown"))
+            hashes.append(hashlib.sha1(text.encode("utf-8")).hexdigest())
+
+        if vectorizer is None:
+            vectorizer = TfidfVectorizer(min_df=1, ngram_range=(1, 2))
+            matrix = vectorizer.fit_transform(texts)
+        else:
+            matrix = vectorizer.transform(texts)
+        vectors = matrix.toarray().astype(np.float32)
+
+        self._df = pd.DataFrame(
+            {
+                "micro_id": ids,
+                "doc_id": doc_ids,
+                "content_hash": hashes,
+                "vector": [vec.tolist() for vec in vectors],
+            }
+        )
+        self._vectorizer = vectorizer
+        self.save()
+
+    # ------------------------------------------------------------------
+    # Query helpers
+    # ------------------------------------------------------------------
+    def vector(self, micro_id: str) -> Optional[np.ndarray]:
+        self.load()
+        if self._df is None:
+            return None
+        row = self._df.loc[self._df["micro_id"] == micro_id]
+        if row.empty:
+            return None
+        vector = row.iloc[0]["vector"]
+        return np.asarray(vector, dtype=np.float32)
+
+    def batch_vectors(self, micro_ids: Sequence[str]) -> List[np.ndarray]:
+        return [self.vector(mid) for mid in micro_ids if self.vector(mid) is not None]
+
+    def ensure_vectorizer(self) -> TfidfVectorizer:
+        self.load()
+        if self._vectorizer is None:
+            raise RuntimeError("EmbeddingStore has not been initialised with a vectorizer")
+        return self._vectorizer
+
+    def search(self, query: str, k: int = 20) -> List[Tuple[str, float]]:
+        """Return the top ``k`` micro_ids ranked by cosine similarity."""
+
+        vectorizer = self.ensure_vectorizer()
+        query_vec = vectorizer.transform([query]).toarray().astype(np.float32)[0]
+        self.load()
+        if self._df is None or self._df.empty:
+            return []
+        stacked = np.vstack(self._df["vector"].apply(np.asarray).to_numpy())
+        norms = np.linalg.norm(stacked, axis=1) * np.linalg.norm(query_vec)
+        norms[norms == 0.0] = 1.0
+        scores = stacked @ query_vec / norms
+        top_idx = np.argsort(scores)[::-1][:k]
+        return [
+            (self._df.iloc[idx]["micro_id"], float(scores[idx]))
+            for idx in top_idx
+        ]
+
+
+__all__ = ["EmbeddingStore"]

--- a/ingest/__init__.py
+++ b/ingest/__init__.py
@@ -1,0 +1,12 @@
+"""Utilities for building FluidRAG microchunk and section artifacts."""
+
+from .microchunker import MicroChunk, microchunk_text
+from .section_grouper import Section, build_sections, assign_micro_to_sections
+
+__all__ = [
+    "MicroChunk",
+    "Section",
+    "microchunk_text",
+    "build_sections",
+    "assign_micro_to_sections",
+]

--- a/ingest/microchunker.py
+++ b/ingest/microchunker.py
@@ -1,0 +1,297 @@
+"""Token-aware microchunking utilities used by the FluidRAG pipeline."""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Mapping, MutableSequence, Optional, Sequence, Tuple, TypedDict
+
+import regex as re
+
+# Default chunk configuration (matches the prompt instructions)
+DEFAULT_CHUNK_SIZE = 386
+DEFAULT_OVERLAP = 96
+BOUNDARY_WINDOW = 32
+
+
+class MicroChunk(TypedDict, total=False):
+    """Structured metadata emitted for every microchunk."""
+
+    doc_id: str
+    micro_id: str
+    text: str
+    norm_text: str
+    token_count: int
+    page: Optional[int]
+    char_span: Optional[Tuple[int, int]]
+    para_id: Optional[str]
+    header_anchor: Optional[str]
+    section_id: Optional[str]
+    section_title: Optional[str]
+
+
+@dataclass
+class _Token:
+    """Internal representation of a token with offsets and source mapping."""
+
+    text: str
+    start: int
+    end: int
+    part_index: int
+
+
+_TOKEN_PATTERN = re.compile(r"\p{L}[\p{L}\p{Mn}\p{Mc}\p{Pd}\p{Pc}\p{Nd}]*|\p{N}+|[^\s]", re.UNICODE)
+_SENTENCE_END_RE = re.compile(r"""[.!?]+['")]{0,1}\s*$""")
+_BULLET_RE = re.compile(r"^\s*(?:[-*\u2022\u2023\u2043]|\d+\.|\d+\))\s+")
+_WHITESPACE_RE = re.compile(r"\s+")
+_DEHYPHEN_RE = re.compile(r"(?<=\w)[-\u2010\u2011\u2012\u2013\u2014\u2212]\n(?=\w)")
+
+
+def _normalize_text(text: str) -> str:
+    """Return a normalised representation used for hashing and retrieval."""
+
+    if not text:
+        return ""
+    cleaned = _DEHYPHEN_RE.sub("", text)
+    cleaned = cleaned.replace("\u2013", "-").replace("\u2014", "-").replace("\u2212", "-")
+    cleaned = cleaned.replace("\xa0", " ")
+    cleaned = _WHITESPACE_RE.sub(" ", cleaned)
+    return cleaned.strip()
+
+
+def _tokenize(text: str) -> Iterable[re.Match[str]]:
+    return _TOKEN_PATTERN.finditer(text)
+
+
+def _build_tokens(parts: Sequence[Mapping[str, Any]]) -> Tuple[str, List[_Token], List[Tuple[int, int, int]]]:
+    """Return the combined document text, tokens, and part spans."""
+
+    fragments: List[str] = []
+    offsets: List[Tuple[int, int, int]] = []
+    running = 0
+    for idx, part in enumerate(parts):
+        fragment = str(part.get("text") or "")
+        fragments.append(fragment)
+        start = running
+        running += len(fragment)
+        offsets.append((start, running, idx))
+        if idx + 1 < len(parts):
+            fragments.append("\n")
+            running += 1
+    doc_text = "".join(fragments)
+
+    tokens: List[_Token] = []
+    part_pointer = 0
+    part_bounds = list(offsets)
+    for match in _tokenize(doc_text):
+        start, end = match.span()
+        while (
+            part_pointer + 1 < len(part_bounds)
+            and start >= part_bounds[part_pointer][1]
+        ):
+            part_pointer += 1
+        tokens.append(
+            _Token(
+                text=match.group(0),
+                start=start,
+                end=end,
+                part_index=part_bounds[part_pointer][2] if part_bounds else 0,
+            )
+        )
+    return doc_text, tokens, offsets
+
+
+def _candidate_boundaries(doc_text: str, tokens: Sequence[_Token], offsets: Sequence[Tuple[int, int, int]]) -> List[int]:
+    """Return token indices that represent soft boundaries."""
+
+    boundaries = {0, len(tokens)}
+    for idx in range(1, len(tokens)):
+        prev_token = tokens[idx - 1]
+        gap = doc_text[prev_token.end : tokens[idx].start]
+        if not gap:
+            continue
+        if "\n" in gap and gap.count("\n") >= 2:
+            boundaries.add(idx)
+            continue
+        if _BULLET_RE.match(gap.lstrip()):
+            boundaries.add(idx)
+            continue
+        prev_text = doc_text[: prev_token.end]
+        if _SENTENCE_END_RE.search(prev_text[-8:]):
+            boundaries.add(idx)
+            continue
+        # Part boundary alignment
+        for start, end, part_idx in offsets:
+            if prev_token.end <= end <= tokens[idx].start:
+                boundaries.add(idx)
+                break
+    return sorted(boundaries)
+
+
+def _choose_boundary(target: int, candidates: Sequence[int], lower: int, upper: int) -> int:
+    """Select the best boundary near the ``target`` token index."""
+
+    if target >= upper:
+        return upper
+    window_low = max(lower + 1, target - BOUNDARY_WINDOW)
+    window_high = min(upper, target + BOUNDARY_WINDOW)
+    best = None
+    best_gap = None
+    candidate_set = set(candidates)
+    for idx in range(window_low, window_high + 1):
+        if idx not in candidate_set:
+            continue
+        gap = abs(idx - target)
+        if best is None or gap < best_gap:
+            best = idx
+            best_gap = gap
+    if best is None:
+        # Fallback to the next available boundary after the target
+        for idx in candidates:
+            if idx > target:
+                return idx
+        return upper
+    return min(max(best, lower + 1), upper)
+
+
+def _select_metadata(parts: Sequence[Mapping[str, Any]], indices: Sequence[int], key: str) -> Optional[str]:
+    values: List[str] = []
+    for idx in indices:
+        value = parts[idx].get(key)
+        if value:
+            values.append(str(value))
+    if not values:
+        return None
+    # Prefer the most frequent non-empty value, falling back to the first
+    counts: Dict[str, int] = {}
+    first_seen: Dict[str, int] = {}
+    for idx, value in enumerate(values):
+        counts[value] = counts.get(value, 0) + 1
+        first_seen.setdefault(value, idx)
+    ordered = sorted(values, key=lambda item: (-counts[item], first_seen[item]))
+    return ordered[0]
+
+
+def _microchunk_from_window(
+    *,
+    doc_id: str,
+    doc_text: str,
+    parts: Sequence[Mapping[str, Any]],
+    tokens: Sequence[_Token],
+    token_indices: Tuple[int, int],
+) -> MicroChunk:
+    start_idx, end_idx = token_indices
+    window_tokens = tokens[start_idx:end_idx]
+    if not window_tokens:
+        raise ValueError("microchunk windows must contain at least one token")
+
+    start_char = window_tokens[0].start
+    end_char = window_tokens[-1].end
+    raw_text = doc_text[start_char:end_char]
+    norm_text = _normalize_text(raw_text)
+    micro_id = hashlib.sha1(norm_text.encode("utf-8")).hexdigest()[:10]
+
+    part_indices = sorted({token.part_index for token in window_tokens})
+    page = None
+    for idx in part_indices:
+        part = parts[idx]
+        page = part.get("page") or part.get("page_start") or part.get("page_end")
+        if page:
+            try:
+                page = int(page)
+            except (TypeError, ValueError):
+                page = None
+            break
+
+    para_id = _select_metadata(parts, part_indices, "chunk_id") or _select_metadata(
+        parts, part_indices, "para_id"
+    )
+
+    chunk: MicroChunk = {
+        "doc_id": doc_id,
+        "micro_id": micro_id,
+        "text": raw_text.strip(),
+        "norm_text": norm_text,
+        "token_count": end_idx - start_idx,
+        "page": page,
+        "char_span": (start_char, end_char),
+        "para_id": para_id,
+        "header_anchor": _select_metadata(parts, part_indices, "header_anchor"),
+        "section_id": _select_metadata(parts, part_indices, "section_id"),
+        "section_title": _select_metadata(parts, part_indices, "section_title"),
+    }
+    return chunk
+
+
+def microchunk_text(
+    parts: Sequence[Mapping[str, Any]],
+    *,
+    size: int = DEFAULT_CHUNK_SIZE,
+    overlap: int = DEFAULT_OVERLAP,
+    boundary_align: bool = True,
+) -> List[MicroChunk]:
+    """Microchunk source ``parts`` into overlapping token windows.
+
+    Parameters
+    ----------
+    parts:
+        Sequence of ordered document segments.  Each part must provide a ``text``
+        field and may include optional metadata such as ``doc_id`` or ``section``
+        information.  The function treats the provided order as canonical.
+    size:
+        Target number of tokens per microchunk.
+    overlap:
+        Number of tokens to retain between adjacent windows.
+    boundary_align:
+        When ``True`` the splitter nudges window ends towards natural sentence or
+        bullet boundaries within ±32 tokens of the target size.
+    """
+
+    if size <= 0:
+        raise ValueError("size must be positive")
+    if overlap < 0:
+        raise ValueError("overlap must be non-negative")
+    if not parts:
+        return []
+
+    doc_id = str(parts[0].get("doc_id") or parts[0].get("document_id") or parts[0].get("source") or "doc-unknown")
+    doc_text, tokens, offsets = _build_tokens(parts)
+    if not tokens:
+        return []
+
+    boundaries = _candidate_boundaries(doc_text, tokens, offsets) if boundary_align else list(range(len(tokens) + 1))
+
+    microchunks: List[MicroChunk] = []
+    total_tokens = len(tokens)
+    start_idx = 0
+    step = max(1, size - overlap)
+
+    while start_idx < total_tokens:
+        target_end = start_idx + size
+        upper_bound = total_tokens
+        if boundary_align:
+            end_idx = _choose_boundary(target_end, boundaries, start_idx, upper_bound)
+        else:
+            end_idx = min(target_end, total_tokens)
+        if end_idx <= start_idx:
+            end_idx = min(start_idx + size, total_tokens)
+            if end_idx <= start_idx:
+                end_idx = min(start_idx + 1, total_tokens)
+        microchunks.append(
+            _microchunk_from_window(
+                doc_id=doc_id,
+                doc_text=doc_text,
+                parts=parts,
+                tokens=tokens,
+                token_indices=(start_idx, end_idx),
+            )
+        )
+        if end_idx >= total_tokens:
+            break
+        next_start = end_idx - overlap
+        if next_start <= start_idx:
+            next_start = start_idx + step
+        start_idx = max(0, next_start)
+    return microchunks
+
+
+__all__ = ["MicroChunk", "microchunk_text"]

--- a/ingest/section_grouper.py
+++ b/ingest/section_grouper.py
@@ -1,0 +1,162 @@
+"""Section helpers for grouping microchunks by detected headings."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple, TypedDict
+
+from .microchunker import MicroChunk
+
+
+class Section(TypedDict, total=False):
+    doc_id: str
+    section_id: str
+    section_title: str
+    header_anchor: Optional[str]
+    char_start: Optional[int]
+    char_end: Optional[int]
+    page_start: Optional[int]
+    page_end: Optional[int]
+
+
+@dataclass
+class _ChunkLike:
+    section_id: str
+    section_title: str
+    header_anchor: Optional[str]
+    text: str
+    page_start: Optional[int]
+    page_end: Optional[int]
+
+
+def _iter_chunks(doc: Mapping[str, object]) -> Iterable[_ChunkLike]:
+    chunks = doc.get("chunks")
+    if isinstance(chunks, Mapping):
+        chunks = chunks.get("items")
+    if not isinstance(chunks, Sequence):
+        return []
+    results: List[_ChunkLike] = []
+    for entry in chunks:
+        if not isinstance(entry, Mapping):
+            continue
+        section_id = str(entry.get("section_id") or "").strip()
+        section_title = str(entry.get("section_title") or "").strip()
+        header_anchor = entry.get("header_anchor")
+        text = str(entry.get("text") or "")
+        page_start = entry.get("page_start")
+        page_end = entry.get("page_end")
+        results.append(
+            _ChunkLike(
+                section_id=section_id,
+                section_title=section_title,
+                header_anchor=header_anchor,
+                text=text,
+                page_start=int(page_start) if isinstance(page_start, (int, float)) else None,
+                page_end=int(page_end) if isinstance(page_end, (int, float)) else None,
+            )
+        )
+    return results
+
+
+def build_sections(doc: Mapping[str, object]) -> List[Section]:
+    """Build ordered section descriptors from a parsed document payload."""
+
+    doc_id = str(doc.get("doc_id") or doc.get("document_id") or "doc-unknown")
+    sections: List[Section] = []
+    running = 0
+    current: Optional[Section] = None
+
+    for chunk in _iter_chunks(doc):
+        text_length = len(chunk.text)
+        section_id = chunk.section_id
+        section_title = chunk.section_title
+
+        if section_id and (current is None or current["section_id"] != section_id):
+            if current is not None:
+                current["char_end"] = running
+                sections.append(current)
+            current = Section(
+                doc_id=doc_id,
+                section_id=section_id,
+                section_title=section_title or f"Section {section_id}",
+                header_anchor=chunk.header_anchor,
+                char_start=running,
+                char_end=running + text_length,
+                page_start=chunk.page_start,
+                page_end=chunk.page_end,
+            )
+        elif current is None and section_id:
+            current = Section(
+                doc_id=doc_id,
+                section_id=section_id,
+                section_title=section_title or f"Section {section_id}",
+                header_anchor=chunk.header_anchor,
+                char_start=running,
+                char_end=running + text_length,
+                page_start=chunk.page_start,
+                page_end=chunk.page_end,
+            )
+        elif current is not None:
+            # Extend the current section window
+            current["char_end"] = running + text_length
+            if chunk.page_end:
+                current["page_end"] = chunk.page_end
+        running += text_length + 1  # Keep alignment with the microchunk concatenation
+
+    if current is not None:
+        current["char_end"] = running
+        sections.append(current)
+
+    return sections
+
+
+def _section_by_char(sections: Sequence[Section], char_index: int) -> Optional[Section]:
+    for section in sections:
+        start = section.get("char_start")
+        end = section.get("char_end")
+        if start is None or end is None:
+            continue
+        if start <= char_index < end:
+            return section
+    return None
+
+
+def _section_by_page(sections: Sequence[Section], page: Optional[int]) -> Optional[Section]:
+    if page is None:
+        return None
+    for section in sections:
+        start_page = section.get("page_start")
+        end_page = section.get("page_end") or start_page
+        if start_page is None:
+            continue
+        if start_page <= page <= (end_page or start_page):
+            return section
+    return None
+
+
+def assign_micro_to_sections(
+    micros: Sequence[MicroChunk],
+    sections: Sequence[Section],
+) -> Dict[str, List[str]]:
+    """Assign microchunks to the nearest section definition."""
+
+    mapping: Dict[str, List[str]] = {section["section_id"]: [] for section in sections if section.get("section_id")}
+
+    for micro in micros:
+        section_id = str(micro.get("section_id") or "").strip()
+        target_section: Optional[Section] = None
+        if section_id:
+            target_section = next((s for s in sections if s.get("section_id") == section_id), None)
+        if target_section is None and micro.get("char_span"):
+            start_char = micro["char_span"][0]
+            target_section = _section_by_char(sections, start_char)
+        if target_section is None:
+            target_section = _section_by_page(sections, micro.get("page"))
+        if target_section is None and sections:
+            target_section = sections[-1]
+        if not target_section or not target_section.get("section_id"):
+            continue
+        mapping.setdefault(target_section["section_id"], []).append(micro["micro_id"])
+    return mapping
+
+
+__all__ = ["Section", "build_sections", "assign_micro_to_sections"]

--- a/retrieval/__init__.py
+++ b/retrieval/__init__.py
@@ -1,0 +1,5 @@
+"""Hybrid retrieval utilities for FluidRAG microchunks."""
+
+from .hybrid import HybridRetriever, rerank_by_section_density
+
+__all__ = ["HybridRetriever", "rerank_by_section_density"]

--- a/retrieval/hybrid.py
+++ b/retrieval/hybrid.py
@@ -1,0 +1,157 @@
+"""Hybrid retrieval pipeline that fuses lexical and embedding scores."""
+from __future__ import annotations
+
+import json
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
+
+from ingest.microchunker import MicroChunk
+from index import BM25Store, EmbeddingStore
+
+RRF_K = 60
+
+
+class HybridRetriever:
+    """Combine embedding and lexical rankings using reciprocal rank fusion."""
+
+    def __init__(
+        self,
+        *,
+        embeddings: EmbeddingStore,
+        bm25: BM25Store,
+        micro_index: Mapping[str, MicroChunk],
+        section_map: Optional[Mapping[str, Sequence[str]]] = None,
+        log_path: Optional[Path] = None,
+    ) -> None:
+        self.embeddings = embeddings
+        self.bm25 = bm25
+        self.micro_index = dict(micro_index)
+        self.section_for_micro: Dict[str, Optional[str]] = {}
+        for micro_id, micro in self.micro_index.items():
+            self.section_for_micro[micro_id] = micro.get("section_id")
+        if section_map:
+            for section_id, micro_ids in section_map.items():
+                for micro_id in micro_ids:
+                    self.section_for_micro.setdefault(micro_id, section_id)
+        self.log_path = Path(log_path) if log_path else None
+
+    def _rrf(self, rankings: Sequence[Sequence[str]], k: int) -> List[str]:
+        scores: MutableMapping[str, float] = defaultdict(float)
+        for ranking in rankings:
+            for rank, micro_id in enumerate(ranking):
+                scores[micro_id] += 1.0 / (RRF_K + rank + 1)
+        ordered = sorted(scores.items(), key=lambda item: item[1], reverse=True)
+        return [mid for mid, _ in ordered[:k]]
+
+    def search(self, query: str, k: int = 40) -> List[str]:
+        embedding_hits = [mid for mid, _ in self.embeddings.search(query, k)]
+        bm25_hits = [mid for mid, _ in self.bm25.search(query, k)]
+        rankings = [hits for hits in (embedding_hits, bm25_hits) if hits]
+        if not rankings:
+            return []
+        fused = self._rrf(rankings, k)
+        self._log(query, fused[:k])
+        return fused[:k]
+
+    def _log(self, query: str, micro_ids: Sequence[str]) -> None:
+        if not self.log_path:
+            return
+        record = {
+            "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "query": query,
+            "micro_ids": list(micro_ids),
+        }
+        self.log_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.log_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def rerank_by_section_density(
+    micro_ids: Sequence[str],
+    sections: Mapping[str, Mapping[str, Sequence[str]] | Sequence[str]] | Sequence[Mapping[str, object]],
+    *,
+    topk: int = 12,
+    mmr_lambda: float = 0.3,
+) -> List[str]:
+    """Re-rank ``micro_ids`` such that dense sections rise to the top."""
+
+    if not micro_ids:
+        return []
+
+    section_map: Dict[str, List[str]] = {}
+    if isinstance(sections, Mapping):
+        iterable: Iterable[tuple[str, Mapping[str, Sequence[str]] | Sequence[str]]] = sections.items()  # type: ignore[assignment]
+    else:
+        iterable = ((str(entry.get("section_id")), entry) for entry in sections if isinstance(entry, Mapping))
+
+    for section_id, payload in iterable:
+        if not section_id:
+            continue
+        if isinstance(payload, Mapping):
+            micro_list = payload.get("micro_ids")
+        else:
+            micro_list = payload
+        if not micro_list:
+            continue
+        section_map[str(section_id)] = [str(mid) for mid in micro_list]
+
+    micro_to_section: Dict[str, str] = {}
+    for section_id, micro_list in section_map.items():
+        for micro_id in micro_list:
+            micro_to_section[micro_id] = section_id
+
+    density = Counter()
+    for micro_id in micro_ids:
+        section_id = micro_to_section.get(micro_id)
+        if section_id:
+            density[section_id] += 1
+    total_density = sum(density.values()) or 1
+
+    selected: List[str] = []
+    seen: set[str] = set()
+    if density:
+        primary_section, _ = density.most_common(1)[0]
+        primary_candidates = [mid for mid in micro_ids if micro_to_section.get(mid) == primary_section]
+        if primary_candidates:
+            first_primary = primary_candidates[0]
+            selected.append(first_primary)
+            seen.add(first_primary)
+            for candidate in primary_candidates[1:]:
+                if len(selected) >= topk:
+                    break
+                selected.append(candidate)
+                seen.add(candidate)
+
+    base_scores = {micro_id: 1.0 / (idx + 1) for idx, micro_id in enumerate(micro_ids)}
+    section_weight = {
+        section_id: count / total_density
+        for section_id, count in density.items()
+    }
+
+    while len(selected) < min(topk, len(micro_ids)):
+        best_id = None
+        best_score = float("-inf")
+        for micro_id in micro_ids:
+            if micro_id in seen:
+                continue
+            base = base_scores[micro_id]
+            section_id = micro_to_section.get(micro_id)
+            dens = section_weight.get(section_id, 0.0)
+            novelty = 1.0
+            if selected and section_id:
+                overlap = sum(1 for chosen in selected if micro_to_section.get(chosen) == section_id)
+                novelty = 1.0 / (1 + overlap)
+            score = (1.0 - mmr_lambda) * base * novelty + mmr_lambda * dens
+            if score > best_score:
+                best_id = micro_id
+                best_score = score
+        if best_id is None:
+            break
+        selected.append(best_id)
+        seen.add(best_id)
+    return selected
+
+
+__all__ = ["HybridRetriever", "rerank_by_section_density"]

--- a/stages/__init__.py
+++ b/stages/__init__.py
@@ -1,0 +1,5 @@
+"""Stage assembly helpers for FluidRAG."""
+
+from .build_stages import StageBuildResult, build_stage_payload
+
+__all__ = ["StageBuildResult", "build_stage_payload"]

--- a/stages/build_stages.py
+++ b/stages/build_stages.py
@@ -1,0 +1,65 @@
+"""Augment existing stage payloads with microchunk and section metadata."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Mapping, Sequence
+
+from ingest import MicroChunk, assign_micro_to_sections, build_sections, microchunk_text
+
+
+@dataclass
+class StageBuildResult:
+    doc_id: str
+    payload: Dict[str, object]
+    microchunks: List[MicroChunk]
+    section_groups: List[Dict[str, object]]
+    sections: List[Dict[str, object]]
+
+
+def build_stage_payload(
+    doc_id: str,
+    stage_chunks: Sequence[Mapping[str, object]],
+    *,
+    token_size: int = 386,
+    overlap: int = 96,
+) -> StageBuildResult:
+    """Return a stage payload extended with microchunks and section groups."""
+
+    enriched_chunks: List[Dict[str, object]] = []
+    for chunk in stage_chunks:
+        part = dict(chunk)
+        part["doc_id"] = doc_id
+        enriched_chunks.append(part)
+
+    microchunks = microchunk_text(enriched_chunks, size=token_size, overlap=overlap)
+    sections = build_sections({"doc_id": doc_id, "chunks": stage_chunks})
+    section_map = assign_micro_to_sections(microchunks, sections)
+
+    section_lookup: Dict[str, Dict[str, object]] = {
+        section["section_id"]: section for section in sections if section.get("section_id")
+    }
+    groups = [
+        {
+            "section_id": section_id,
+            "title": section_lookup.get(section_id, {}).get("section_title", ""),
+            "micro_ids": micro_ids,
+        }
+        for section_id, micro_ids in section_map.items()
+    ]
+
+    payload = {
+        "doc_id": doc_id,
+        "chunks": list(stage_chunks),
+        "microchunking": {"token_size": token_size, "overlap": overlap, "count": len(microchunks)},
+        "section_groups": groups,
+    }
+    return StageBuildResult(
+        doc_id=doc_id,
+        payload=payload,
+        microchunks=microchunks,
+        section_groups=groups,
+        sections=list(sections),
+    )
+
+
+__all__ = ["StageBuildResult", "build_stage_payload"]

--- a/tests/test_hybrid_retrieval.py
+++ b/tests/test_hybrid_retrieval.py
@@ -1,0 +1,84 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from ingest import microchunk_text
+from index import BM25Store, EmbeddingStore
+from retrieval import HybridRetriever, rerank_by_section_density
+
+
+@pytest.fixture
+def sample_microchunks():
+    parts = [
+        {
+            "doc_id": "controls",
+            "section_id": "11.2",
+            "section_title": "FAT Performance",
+            "chunk_id": "chunk-fat",
+            "text": "The FAT performance demonstration shall confirm 95 percent availability under simulated load. "
+            * 12,
+        },
+        {
+            "doc_id": "controls",
+            "section_id": "11.2",
+            "section_title": "FAT Performance",
+            "chunk_id": "chunk-dash",
+            "text": "Availability dashboards shall highlight downtime root causes and include MTBF metrics for every station. "
+            * 6,
+        },
+        {
+            "doc_id": "controls",
+            "section_id": "17.1",
+            "section_title": "Evaluation",
+            "chunk_id": "chunk-eval",
+            "text": "Supplier evaluation will consider maintenance training, spare parts, and documentation quality." * 4,
+        },
+    ]
+    return microchunk_text(parts, size=60, overlap=16)
+
+
+def test_rrf_improves_recall(tmp_path: Path, sample_microchunks):
+    embeddings = EmbeddingStore(tmp_path / "embeddings.parquet")
+    embeddings.build(sample_microchunks)
+    bm25 = BM25Store(tmp_path / "bm25.idx")
+    bm25.build(sample_microchunks)
+
+    micro_index = {chunk["micro_id"]: chunk for chunk in sample_microchunks}
+    section_map = {"11.2": [chunk["micro_id"] for chunk in sample_microchunks if chunk["section_id"] == "11.2"]}
+    hybrid = HybridRetriever(
+        embeddings=embeddings,
+        bm25=bm25,
+        micro_index=micro_index,
+        section_map=section_map,
+        log_path=tmp_path / "retrieval_log.jsonl",
+    )
+
+    query = "FAT performance availability"
+    bm25_top = [mid for mid, _ in bm25.search(query, k=1)]
+    emb_top = [mid for mid, _ in embeddings.search(query, k=1)]
+    fused = hybrid.search(query, k=3)
+
+    assert emb_top[0] in fused
+    if bm25_top and bm25_top[0] not in emb_top:
+        assert bm25_top[0] in fused
+
+
+def test_section_density_rerank_clusters_results(sample_microchunks):
+    micro_ids = [chunk["micro_id"] for chunk in sample_microchunks]
+    sections = {
+        "11.2": [mid for mid in micro_ids if any(
+            chunk["micro_id"] == mid and chunk["section_id"] == "11.2" for chunk in sample_microchunks
+        )],
+        "17.1": [mid for mid in micro_ids if any(
+            chunk["micro_id"] == mid and chunk["section_id"] == "17.1" for chunk in sample_microchunks
+        )],
+    }
+    ordered = rerank_by_section_density(micro_ids, sections, topk=3)
+    leading = ordered[:2]
+    count_section = sum(
+        1 for mid in leading for chunk in sample_microchunks if chunk["micro_id"] == mid and chunk["section_id"] == "11.2"
+    )
+    assert count_section >= 2

--- a/tests/test_microchunking.py
+++ b/tests/test_microchunking.py
@@ -1,0 +1,70 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from ingest import assign_micro_to_sections, build_sections, microchunk_text
+
+
+def _make_parts(text: str, section_id: str, section_title: str, chunk_id: str, doc_id: str = "doc-1"):
+    return {
+        "doc_id": doc_id,
+        "section_id": section_id,
+        "section_title": section_title,
+        "chunk_id": chunk_id,
+        "header_anchor": f"anchor-{section_id}",
+        "text": text,
+    }
+
+
+def test_boundary_alignment_respects_bullets():
+    text = (
+        "The system shall provide operator dashboards with clear alarms. "
+        "Each station shall report availability and downtime.\n"
+        "• Maintain 95% availability for 60 s.\n"
+        "• Provide diagnostics for all stations.\n"
+        "Compliance data shall be logged hourly to support audits."
+    )
+    parts = [_make_parts(text, "11.2", "HMI Functions", "chunk-001")]
+    chunks = microchunk_text(parts, size=30, overlap=8)
+    assert len(chunks) >= 2
+    for chunk in chunks[:-1]:
+        tail = chunk["text"].strip()
+        assert tail.endswith(".") or tail.endswith("stations."), tail
+
+
+def test_overlap_contains_numeric_phrase():
+    text = (
+        "The motor shall sustain 18 cpm for ≥ 60 s under full load without overheating. "
+        "This performance shall be verified monthly and recorded in the maintenance log."
+    )
+    parts = [_make_parts(text, "12.1", "Performance", "chunk-002")]
+    chunks = microchunk_text(parts, size=25, overlap=10)
+    phrase = "18 cpm for ≥ 60 s"
+    coverage = [phrase in chunk["text"] for chunk in chunks]
+    assert any(coverage)
+    assert sum(coverage) >= 1
+    if len(chunks) > 1:
+        assert sum(coverage) >= 1  # Overlap should at least keep the phrase intact once
+
+
+def test_section_assignment_selects_correct_section():
+    part_a = _make_parts("Section 1 intro. Requirements shall apply.", "1.0", "Introduction", "chunk-100")
+    part_b = _make_parts("Section 2 content with tables and figures.", "2.0", "Scope", "chunk-200")
+    parts = [part_a, part_b]
+    micros = microchunk_text(parts, size=15, overlap=5)
+    doc = {"doc_id": "doc-1", "chunks": parts}
+    sections = build_sections(doc)
+    mapping = assign_micro_to_sections(micros, sections)
+    assert "1.0" in mapping
+    assert "2.0" in mapping
+    assert any(mid for mid in mapping["1.0"] if micros[0]["micro_id"] == mid)
+
+
+def test_microchunk_determinism():
+    parts = [
+        _make_parts("Consistency check sentence one. Sentence two for hashing.", "3.1", "Consistency", "chunk-300")
+    ]
+    first = microchunk_text(parts, size=20, overlap=5)
+    second = microchunk_text(parts, size=20, overlap=5)
+    assert [chunk["micro_id"] for chunk in first] == [chunk["micro_id"] for chunk in second]

--- a/tools/microchunk_build.py
+++ b/tools/microchunk_build.py
@@ -1,0 +1,84 @@
+"""CLI to build microchunk, section, and retrieval artifacts."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, List, Sequence
+
+import pandas as pd
+
+from ingest import MicroChunk
+from index import BM25Store, EmbeddingStore
+from stages import build_stage_payload
+
+
+def _load_stage_chunks(path: Path) -> List[Dict[str, object]]:
+    with path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if isinstance(payload, dict):
+        chunks = payload.get("chunks") or payload.get("items") or []
+    else:
+        chunks = payload
+    result: List[Dict[str, object]] = []
+    for entry in chunks:
+        if isinstance(entry, dict):
+            result.append(entry)
+    return result
+
+
+def build_artifacts(docs_dir: Path, out_dir: Path, token_size: int, overlap: int) -> None:
+    microchunks: List[MicroChunk] = []
+    section_groups: Dict[str, List[Dict[str, object]]] = {}
+
+    for path in sorted(docs_dir.glob("*.json")):
+        doc_id = path.stem
+        chunks = _load_stage_chunks(path)
+        if not chunks:
+            continue
+        result = build_stage_payload(doc_id, chunks, token_size=token_size, overlap=overlap)
+        microchunks.extend(result.microchunks)
+        section_groups[doc_id] = result.section_groups
+
+    if not microchunks:
+        raise RuntimeError("No microchunks were generated; ensure the docs directory contains stage JSON files")
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    micro_df = pd.DataFrame(microchunks)
+    micro_df.to_parquet(out_dir / "microchunks.parquet", index=False)
+
+    sections_path = out_dir / "sections.jsonl"
+    with sections_path.open("w", encoding="utf-8") as handle:
+        for doc_id, groups in section_groups.items():
+            for group in groups:
+                record = {
+                    "doc_id": doc_id,
+                    "section_id": group.get("section_id"),
+                    "section_title": group.get("title"),
+                    "micro_ids": group.get("micro_ids", []),
+                }
+                handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+    embedding_store = EmbeddingStore(out_dir / "embeddings.parquet")
+    embedding_store.build(microchunks)
+
+    bm25_store = BM25Store(out_dir / "bm25.idx")
+    bm25_store.build(microchunks)
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build microchunk artifacts from stage JSON files")
+    parser.add_argument("--docs", type=Path, required=True, help="Directory containing staged JSON files")
+    parser.add_argument("--out-dir", type=Path, required=True, help="Directory to write cache artifacts")
+    parser.add_argument("--token-size", type=int, default=386, help="Target microchunk token size")
+    parser.add_argument("--overlap", type=int, default=96, help="Token overlap between adjacent microchunks")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    args = parse_args(argv)
+    build_artifacts(args.docs, args.out_dir, args.token_size, args.overlap)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/section_map_and_refine.py
+++ b/tools/section_map_and_refine.py
@@ -14,6 +14,8 @@ import pandas as pd
 from jsonschema import ValidationError, validate
 from rapidfuzz import fuzz, process
 
+from index import BM25Store, EmbeddingStore
+from retrieval import HybridRetriever, rerank_by_section_density
 from tools.llm_client import LLMClient
 from tools.refine_prompts import SYSTEM_PROMPT, get_granularity_guide
 
@@ -160,11 +162,180 @@ class StageIndex:
             if not normalized:
                 normalized = "Header"
             normalized_lower = normalized.lower()
-            return [
-                c for c in self.chunk_by_id.values() if c.pass_name.lower() == normalized_lower
-            ]
+        return [
+            c for c in self.chunk_by_id.values() if c.pass_name.lower() == normalized_lower
+        ]
         return list(self.chunk_by_id.values())
 
+
+class MicrochunkContextBuilder:
+    """Build hybrid retrieval contexts from cached microchunk artifacts."""
+
+    def __init__(self, cache_dir: Path, *, context_radius: int = 2) -> None:
+        self.cache_dir = cache_dir
+        self.context_radius = max(0, context_radius)
+        self.available = False
+        self.micro_index: Dict[str, Dict[str, Any]] = {}
+        self.micro_by_para: Dict[str, List[str]] = {}
+        self.section_groups: Dict[Tuple[Optional[str], Optional[str]], List[str]] = {}
+        self.doc_lookup: Dict[str, str] = {}
+
+        micro_path = cache_dir / "microchunks.parquet"
+        sections_path = cache_dir / "sections.jsonl"
+        embeddings_path = cache_dir / "embeddings.parquet"
+        bm25_path = cache_dir / "bm25.idx"
+
+        if not (micro_path.exists() and embeddings_path.exists() and bm25_path.exists()):
+            LOGGER.warning("Microchunk caches missing under %s; falling back to stage context", cache_dir)
+            return
+
+        try:
+            micro_df = pd.read_parquet(micro_path)
+        except Exception as exc:  # pragma: no cover - pandas errors should be rare
+            LOGGER.warning("Unable to load microchunks from %s: %s", micro_path, exc)
+            return
+
+        for record in micro_df.to_dict(orient="records"):
+            micro_id = record.get("micro_id")
+            if not micro_id:
+                continue
+            char_span = record.get("char_span")
+            if isinstance(char_span, list) and len(char_span) == 2:
+                record["char_span"] = (int(char_span[0]), int(char_span[1]))
+            doc_id = record.get("doc_id")
+            if isinstance(doc_id, str):
+                self.doc_lookup.setdefault(self._canonical_doc(doc_id), doc_id)
+            self.micro_index[str(micro_id)] = record
+            para_id = record.get("para_id")
+            if para_id:
+                self.micro_by_para.setdefault(str(para_id), []).append(str(micro_id))
+
+        if sections_path.exists():
+            with sections_path.open("r", encoding="utf-8") as handle:
+                for line in handle:
+                    if not line.strip():
+                        continue
+                    payload = json.loads(line)
+                    doc_id = payload.get("doc_id")
+                    section_id = payload.get("section_id")
+                    key = (self._resolve_doc(doc_id), str(section_id) if section_id else None)
+                    self.section_groups.setdefault(key, []).extend(
+                        [str(mid) for mid in payload.get("micro_ids", [])]
+                    )
+
+        try:
+            embeddings = EmbeddingStore(embeddings_path)
+            embeddings.load()
+            embeddings.ensure_vectorizer()
+            bm25 = BM25Store(bm25_path)
+            bm25.load()
+        except Exception as exc:  # pragma: no cover - missing caches
+            LOGGER.warning("Unable to load retrieval indices from %s: %s", cache_dir, exc)
+            return
+
+        log_path = Path("logs") / "retrieval_log.jsonl"
+        self.hybrid = HybridRetriever(
+            embeddings=embeddings,
+            bm25=bm25,
+            micro_index=self.micro_index,
+            section_map={
+                (section_id or ""): micro_ids
+                for (_, section_id), micro_ids in self.section_groups.items()
+            },
+            log_path=log_path,
+        )
+        self.available = True
+
+    def _canonical_doc(self, value: Optional[str]) -> Optional[str]:
+        if not value:
+            return None
+        return Path(str(value)).stem.lower()
+
+    def _resolve_doc(self, value: Optional[str]) -> Optional[str]:
+        if not value:
+            return None
+        canonical = self._canonical_doc(value)
+        if canonical and canonical in self.doc_lookup:
+            return self.doc_lookup[canonical]
+        return value if isinstance(value, str) else None
+
+    def _section_key(self, doc_id: Optional[str], section_id: Optional[str]) -> Tuple[Optional[str], Optional[str]]:
+        resolved_doc = self._resolve_doc(doc_id)
+        return resolved_doc, section_id
+
+    def _micro_window(self, micro_id: str, doc_id: Optional[str], section_id: Optional[str]) -> List[str]:
+        key = self._section_key(doc_id, section_id)
+        ordered = self.section_groups.get(key, [])
+        if not ordered or micro_id not in ordered:
+            return [micro_id]
+        index = ordered.index(micro_id)
+        start = max(0, index - self.context_radius)
+        end = min(len(ordered), index + self.context_radius + 1)
+        return ordered[start:end]
+
+    def context_for(
+        self,
+        *,
+        specification: str,
+        section: Optional[SectionRecord],
+        chunk_id: Optional[str],
+        source_doc: Optional[str],
+    ) -> Optional[List[Dict[str, str]]]:
+        if not self.available:
+            return None
+
+        candidate_ids: List[str] = []
+        if chunk_id and chunk_id in self.micro_by_para:
+            candidate_ids.extend(self.micro_by_para[chunk_id])
+
+        doc_id = self._resolve_doc(source_doc)
+        section_id = section.section_id if section else None
+
+        if not candidate_ids:
+            results = self.hybrid.search(specification, k=40)
+            if doc_id:
+                filtered = [mid for mid in results if self.micro_index.get(mid, {}).get("doc_id") == doc_id]
+                if filtered:
+                    results = filtered
+            if section_id:
+                key = self._section_key(doc_id, section_id)
+                allowed = set(self.section_groups.get(key, []))
+                if allowed:
+                    filtered = [mid for mid in results if mid in allowed]
+                    if filtered:
+                        results = filtered
+                reranked = rerank_by_section_density(
+                    results,
+                    {section_id: self.section_groups.get(key, [])},
+                    topk=self.context_radius * 2 + 3,
+                    mmr_lambda=0.4,
+                )
+                if reranked:
+                    results = reranked
+            candidate_ids = results
+
+        if not candidate_ids:
+            return None
+
+        primary_id = candidate_ids[0]
+        window_ids = self._micro_window(primary_id, doc_id, section_id)
+
+        snippets: List[Dict[str, str]] = []
+        header_text = f"{section.section_id} {section.section_title}".strip() if section else ""
+        if header_text:
+            snippets.append({"Type": "SectionHeader", "Text": header_text})
+        for micro_id in window_ids:
+            micro = self.micro_index.get(micro_id)
+            if not micro:
+                continue
+            snippets.append(
+                {
+                    "Type": "MicroChunk",
+                    "MicroID": micro_id,
+                    "Text": str(micro.get("text", "")),
+                }
+            )
+        return snippets
 
 def parse_stage_file(path: Path, index: StageIndex) -> None:
     """Parse a staged JSON file and populate the stage index."""
@@ -337,6 +508,9 @@ def run_pipeline(
     schema_path: Optional[Path] = None,
     threshold: int = 120,
     llm_client: Optional[LLMClient] = None,
+    use_microchunks: bool = False,
+    microchunk_cache: Optional[Path] = None,
+    context_radius: int = 2,
 ) -> None:
     """Execute the two-phase section mapping and refinement pipeline."""
 
@@ -405,6 +579,11 @@ def run_pipeline(
     ensure_artifacts_dir(artifacts_dir)
 
     llm = llm_client or LLMClient()
+    micro_context = (
+        MicrochunkContextBuilder(microchunk_cache or Path("data/cache"), context_radius=context_radius)
+        if use_microchunks
+        else None
+    )
 
     section_counters: Dict[str, int] = {}
     output_rows: List[Dict[str, Any]] = []
@@ -440,6 +619,18 @@ def run_pipeline(
             parent_req_id = f"S-{section_id}-{seq:03d}" if section_id else f"S-UNK-{seq:03d}"
             section_counters[section_id or "UNK"] = seq
 
+            if micro_context and micro_context.available:
+                context_snippets = micro_context.context_for(
+                    specification=spec_text,
+                    section=section_record,
+                    chunk_id=chunk_id,
+                    source_doc=row.get("SourceDoc"),
+                )
+            else:
+                context_snippets = None
+            if not context_snippets:
+                context_snippets = build_context_snippets(section_record, chunk_id, index)
+
             payload = {
                 "Pass": pass_name,
                 "SourceDoc": row.get("SourceDoc"),
@@ -449,7 +640,12 @@ def run_pipeline(
                 "HeaderAnchor": section_record.header_anchor,
                 "ParentSpecID": parent_req_id,
                 "ParentVerbatimText": spec_text,
-                "ContextSnippets": build_context_snippets(section_record, chunk_id, index),
+                "ContextSnippets": context_snippets,
+                "ContextMicroIDs": [
+                    snippet.get("MicroID")
+                    for snippet in context_snippets
+                    if isinstance(snippet, dict) and snippet.get("Type") == "MicroChunk"
+                ],
             }
 
             guide = get_granularity_guide(str(pass_name))
@@ -628,6 +824,24 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser.add_argument("--artifacts-dir", dest="artifacts_dir", type=Path, required=True, help="Directory to store refinement logs")
     parser.add_argument("--threshold", type=int, default=120, help="Character threshold for suspect detection")
     parser.add_argument("--schema", type=Path, default=None, help="Override path to refinement schema")
+    parser.add_argument(
+        "--use-microchunks",
+        type=lambda value: str(value).lower() in {"1", "true", "yes", "on"},
+        default=False,
+        help="Enable hybrid microchunk retrieval when building refinement context",
+    )
+    parser.add_argument(
+        "--microchunk-cache",
+        type=Path,
+        default=None,
+        help="Directory containing microchunk cache artifacts (defaults to data/cache)",
+    )
+    parser.add_argument(
+        "--context-radius",
+        type=int,
+        default=2,
+        help="Number of neighbouring microchunks to include on each side of the primary hit",
+    )
     return parser.parse_args(argv)
 
 
@@ -641,6 +855,9 @@ def main(argv: Optional[Sequence[str]] = None) -> None:
         artifacts_dir=args.artifacts_dir,
         schema_path=args.schema,
         threshold=args.threshold,
+        use_microchunks=args.use_microchunks,
+        microchunk_cache=args.microchunk_cache,
+        context_radius=args.context_radius,
     )
 
 


### PR DESCRIPTION
## Summary
- implement a boundary-aware microchunker with metadata capture plus section grouping helpers
- add embedding and BM25 indexes with a hybrid retriever that logs usage and supports section-density reranking
- integrate microchunks into the refinement pipeline, provide a cache build CLI, and cover the behaviour with new unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d49a8086708324bef5777de232c8dd