### PR TITLE
Improve appendix header handling and pass dedupe

### DIFF
--- a/backend/domain/__init__.py
+++ b/backend/domain/__init__.py
@@ -1,0 +1,5 @@
+"""Domain lexicon utilities for discipline-specific filtering."""
+
+from .lexicon import PASS_DOMAIN_LEXICON, PASS_DOMAIN_THRESHOLD
+
+__all__ = ["PASS_DOMAIN_LEXICON", "PASS_DOMAIN_THRESHOLD"]

--- a/backend/domain/lexicon.py
+++ b/backend/domain/lexicon.py
@@ -1,0 +1,82 @@
+"""Discipline keyword lexicons and thresholds used for domain scoring."""
+from __future__ import annotations
+
+from typing import Dict, List, Mapping
+
+PASS_DOMAIN_LEXICON: Mapping[str, List[str]] = {
+    "Mechanical": [
+        "footprint",
+        "conveyor",
+        "cdlr",
+        "mdr",
+        "chain driven live roller",
+        "end of arm",
+        "eoat",
+        "guard",
+        "clearance",
+        "frame",
+        "weldment",
+    ],
+    "Electrical": [
+        "sccr",
+        "short circuit",
+        "feeder",
+        "transformer",
+        "ul508a",
+        "nfpa 79",
+        "panel layout",
+        "fla",
+        "full load",
+        "network power",
+        "grounding",
+    ],
+    "Controls": [
+        "plc",
+        "controller",
+        "guardlogix",
+        "safety category",
+        "performance level",
+        "sil",
+        "i/o",
+        "estop",
+        "interlock",
+        "safety relay",
+        "safety device",
+    ],
+    "Software": [
+        "udt",
+        "aoi",
+        "user defined type",
+        "versioning",
+        "backup",
+        "restore",
+        "calibration",
+        "hmi",
+        "diagnostic",
+        "alarm history",
+        "source code",
+    ],
+    "Project Management": [
+        "milestone",
+        "gantt",
+        "fat",
+        "sat",
+        "training",
+        "warranty",
+        "support",
+        "deliverable",
+        "schedule",
+        "payment",
+        "commercial",
+    ],
+}
+
+PASS_DOMAIN_THRESHOLD: Dict[str, int] = {
+    "Mechanical": 1,
+    "Electrical": 1,
+    "Controls": 1,
+    "Software": 1,
+    "Project Management": 1,
+}
+
+__all__ = ["PASS_DOMAIN_LEXICON", "PASS_DOMAIN_THRESHOLD"]

--- a/backend/pipeline/passes/chunking.py
+++ b/backend/pipeline/passes/chunking.py
@@ -16,6 +16,8 @@ from backend.prompts import PASS_PROMPTS, atomic_user_template
 from backend.state import get_state
 from backend.utils.strings import s
 
+from backend.domain import PASS_DOMAIN_LEXICON, PASS_DOMAIN_THRESHOLD
+
 from ..fluid import fluid_refine_chunks  # type: ignore[import]
 from ..hep_cluster import hep_cluster_chunks  # type: ignore[import]
 from .constants import CHUNK_GROUP_TOKEN_LIMIT
@@ -72,6 +74,65 @@ def _collect_headers(chunks: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
             existing["page_start"] = min(existing.get("page_start", page_start), page_start)
             existing["page_end"] = max(existing.get("page_end", page_end), page_end)
     return list(headers.values())
+
+
+def _normalize_for_lookup(value: str) -> str:
+    if not value:
+        return ""
+    return re.sub(r"\s+", " ", value).strip().lower()
+
+
+def _build_section_lookup(chunks: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    lookup: List[Dict[str, Any]] = []
+    for idx, chunk in enumerate(chunks):
+        text = s(chunk.get("text"))
+        section_number = s(chunk.get("section_number") or chunk.get("section_id"))
+        section_name = s(chunk.get("section_name") or chunk.get("section_title"))
+        lookup.append(
+            {
+                "chunk_index": idx,
+                "section_number": section_number,
+                "section_name": section_name,
+                "text": text,
+                "normalized_text": _normalize_for_lookup(text),
+            }
+        )
+    return lookup
+
+
+def _compute_domain_scores(chunk: Dict[str, Any]) -> Dict[str, int]:
+    meta = chunk.setdefault("meta", {})
+    existing = meta.get("domain_scores")
+    if isinstance(existing, dict):
+        return existing
+    text_parts = [
+        s(chunk.get("section_name") or chunk.get("section_title")),
+        s(chunk.get("section_number") or chunk.get("section_id")),
+        s(chunk.get("text")),
+    ]
+    normalized = _normalize_for_lookup(" ".join(part for part in text_parts if part))
+    scores: Dict[str, int] = {}
+    for pass_name, keywords in PASS_DOMAIN_LEXICON.items():
+        count = 0
+        for keyword in keywords:
+            key = keyword.lower().strip()
+            if key and key in normalized:
+                count += 1
+        scores[pass_name] = count
+    meta["domain_scores"] = scores
+    return scores
+
+
+def _filter_chunks_for_pass(chunks: List[Dict[str, Any]], pass_name: str) -> List[Dict[str, Any]]:
+    threshold = PASS_DOMAIN_THRESHOLD.get(pass_name, 0)
+    filtered: List[Dict[str, Any]] = []
+    for chunk in chunks:
+        scores = _compute_domain_scores(chunk)
+        if scores.get(pass_name, 0) >= threshold:
+            filtered.append(chunk)
+    if not filtered:
+        return list(chunks)
+    return filtered
 
 def _normalize_stage_payload(chunks: List[Dict[str, Any]]) -> Dict[str, Any]:
     """Normalize chunk snapshots for JSON export."""
@@ -240,6 +301,10 @@ def ensure_chunks(session_id: str) -> List[Dict[str, Any]]:
         "fluid_chunks": fluid_snapshot,
         "hep_chunks": hep_snapshot,
     }
+    try:
+        state.standard_section_lookup = _build_section_lookup(standard_snapshot)
+    except Exception:  # pragma: no cover - defensive
+        log.exception("[chunking] failed to build section lookup for session %s", session_id)
     return enriched
 
 
@@ -272,6 +337,19 @@ def build_groups(chunks: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
             "token_estimate": current_tokens,
         })
     return groups
+
+
+def build_pass_groups(
+    chunks: List[Dict[str, Any]]
+) -> Tuple[List[Dict[str, Any]], Dict[str, List[Dict[str, Any]]]]:
+    """Return default chunk groups and discipline-filtered groups."""
+
+    base_groups = build_groups(chunks)
+    per_pass: Dict[str, List[Dict[str, Any]]] = {}
+    for pass_name in PASS_DOMAIN_LEXICON:
+        filtered = _filter_chunks_for_pass(chunks, pass_name)
+        per_pass[pass_name] = build_groups(filtered)
+    return base_groups, per_pass
 
 
 def build_user_prompt(metadata: Dict[str, Any], group: Dict[str, Any], batch_index: int, batch_total: int) -> str:

--- a/backend/pipeline/passes/runner.py
+++ b/backend/pipeline/passes/runner.py
@@ -5,8 +5,10 @@ import asyncio
 import base64
 import json
 import logging
+import re
 import time
 import uuid
+from difflib import SequenceMatcher
 from typing import Any, Dict, List, Tuple
 
 from backend.llm.factory import provider_default_model
@@ -16,7 +18,11 @@ from backend.utils.envsafe import env
 from backend.utils.strings import s
 from ..merge import merge_pass_outputs
 
-from .chunking import build_groups, ensure_chunks, export_pass_stage_snapshots
+from .chunking import (
+    build_pass_groups,
+    ensure_chunks,
+    export_pass_stage_snapshots,
+)
 from .config import (
     is_truthy_flag,
     resolve_pass_concurrency,
@@ -41,6 +47,110 @@ def _snapshot(value: Any, limit: int = 3000) -> str:
     return text
 
 
+def _normalize_fragment(text: str) -> str:
+    if not text:
+        return ""
+    return re.sub(r"\s+", " ", str(text)).strip().lower()
+
+
+def _extract_pass_tokens(value: str) -> List[str]:
+    if not value:
+        return []
+    tokens = []
+    for token in str(value).replace(",", ";").split(";"):
+        token = token.strip()
+        if token:
+            tokens.append(token)
+    return tokens
+
+
+def _best_section_match(spec_text: str, lookup: List[Dict[str, Any]]) -> Dict[str, Any] | None:
+    if not spec_text or not lookup:
+        return None
+    norm_spec = _normalize_fragment(spec_text)
+    if not norm_spec:
+        return None
+    best: Dict[str, Any] | None = None
+    best_score = 0.0
+    for entry in lookup:
+        chunk_norm = entry.get("normalized_text") or _normalize_fragment(entry.get("text"))
+        if not chunk_norm:
+            continue
+        score = 0.0
+        if norm_spec in chunk_norm:
+            coverage = len(norm_spec) / max(len(chunk_norm), 1)
+            score = 1.0 + coverage * 0.01
+        elif chunk_norm in norm_spec:
+            score = 0.95
+        else:
+            ratio = SequenceMatcher(None, norm_spec, chunk_norm).ratio()
+            if ratio >= 0.55:
+                score = ratio
+        section_number = str(entry.get("section_number") or "")
+        if section_number.upper().startswith("A") and section_number[1:].isdigit():
+            score += 0.05
+        if score > best_score:
+            best = entry
+            best_score = score
+    return best if best_score > 0 else None
+
+
+def _assign_sections_to_rows(
+    rows: List[Dict[str, str]],
+    lookup: List[Dict[str, Any]] | None,
+) -> float:
+    if not rows:
+        return 0.0
+    if not lookup:
+        return 0.0
+    filled = 0
+    for row in rows:
+        spec_text = row.get("Specification")
+        match = _best_section_match(spec_text, lookup) if spec_text else None
+        if not match:
+            continue
+        current_num = _normalize_fragment(row.get("(Sub)Section #"))
+        matched_num = _normalize_fragment(match.get("section_number"))
+        if matched_num and (not current_num or len(matched_num) >= len(current_num)):
+            row["(Sub)Section #"] = match.get("section_number", "")
+        current_name = _normalize_fragment(row.get("(Sub)Section Name"))
+        matched_name = _normalize_fragment(match.get("section_name"))
+        if matched_name and (not current_name or len(matched_name) >= len(current_name)):
+            row["(Sub)Section Name"] = match.get("section_name", "")
+        if row.get("(Sub)Section #") or row.get("(Sub)Section Name"):
+            filled += 1
+    return filled / max(1, len(rows))
+
+
+def _dedupe_rows(rows: List[Dict[str, str]]) -> Tuple[List[Dict[str, str]], float]:
+    if not rows:
+        return [], 0.0
+    deduped: List[Dict[str, str]] = []
+    seen: Dict[Tuple[str, str, str], Dict[str, Any]] = {}
+    duplicates = 0
+    for row in rows:
+        spec_key = _normalize_fragment(row.get("Specification"))
+        section_number = _normalize_fragment(row.get("(Sub)Section #"))
+        section_name = _normalize_fragment(row.get("(Sub)Section Name"))
+        key = (spec_key, section_number, section_name)
+        passes = set(_extract_pass_tokens(row.get("Pass", "")))
+        if key in seen:
+            duplicates += 1
+            seen_entry = seen[key]
+            seen_entry.setdefault("_passes", set()).update(passes)
+        else:
+            record = dict(row)
+            record["_passes"] = set(passes) if passes else set()
+            seen[key] = record
+            deduped.append(record)
+    for record in deduped:
+        pass_tokens = record.pop("_passes", set()) or set()
+        existing_tokens = set(_extract_pass_tokens(record.get("Pass", "")))
+        pass_tokens.update(existing_tokens)
+        if pass_tokens:
+            record["Pass"] = "; ".join(sorted(pass_tokens))
+    overlap_ratio = duplicates / len(rows) if rows else 0.0
+    return deduped, overlap_ratio
 async def run_all_passes_async(payload: Dict[str, Any]) -> Dict[str, Any]:
     payload = payload or {}
     session_id = payload.get("session_id") or payload.get("session")
@@ -90,7 +200,7 @@ async def run_all_passes_async(payload: Dict[str, Any]) -> Dict[str, Any]:
             "httpStatus": 200,
         }
 
-    groups = build_groups(chunks)
+    default_groups, pass_groups = build_pass_groups(chunks)
     metadata = {"document": state.filename or "Document", "session_id": session_id}
     metadata["user_query"] = s(
         payload.get("question")
@@ -218,7 +328,7 @@ async def run_all_passes_async(payload: Dict[str, Any]) -> Dict[str, Any]:
         len(pass_items),
         pending_count,
         len(cache_hits),
-        len(groups),
+        len(default_groups),
         concurrency_limit,
         requested_concurrency,
         pass_timeout,
@@ -232,7 +342,7 @@ async def run_all_passes_async(payload: Dict[str, Any]) -> Dict[str, Any]:
         pass_rows, debug_records, pass_csv_segments, pass_errors = await execute_pass(
             pass_name,
             system_prompt,
-            groups,
+            pass_groups.get(pass_name, default_groups),
             provider,
             model,
             pass_metadata,
@@ -260,10 +370,11 @@ async def run_all_passes_async(payload: Dict[str, Any]) -> Dict[str, Any]:
             pass_metadata = dict(metadata)
             pass_metadata["pass_name"] = pass_name
             pass_metadata.setdefault("discipline", pass_name)
+            target_groups = pass_groups.get(pass_name, default_groups)
             pass_rows, debug_records, pass_csv_segments, pass_errors = await execute_pass(
                 pass_name,
                 system_prompt,
-                groups,
+                target_groups,
                 provider,
                 model,
                 pass_metadata,
@@ -348,6 +459,10 @@ async def run_all_passes_async(payload: Dict[str, Any]) -> Dict[str, Any]:
     rows = merged.get("rows", [])
     merge_problems = merged.get("problems", [])
 
+    section_lookup = getattr(state, "standard_section_lookup", None)
+    coverage_ratio = _assign_sections_to_rows(rows, section_lookup)
+    rows, overlap_ratio = _dedupe_rows(rows)
+
     metrics["total"] = round((time.perf_counter() - total_start) * 1000, 1)
 
     csv_text = encode_rows_to_csv(rows)
@@ -360,7 +475,7 @@ async def run_all_passes_async(payload: Dict[str, Any]) -> Dict[str, Any]:
         "csv_text": csv_text if rows else None,
         "llm_debug": llm_debug,
         "metrics_ms": metrics,
-        "chunk_groups": len(groups),
+        "chunk_groups": len(default_groups),
         "chunk_count": len(chunks),
         "httpStatus": 200,
     }
@@ -378,6 +493,10 @@ async def run_all_passes_async(payload: Dict[str, Any]) -> Dict[str, Any]:
         response["debug"]["merge"] = {
             "problems": merge_problems,
             "rows_count": len(rows),
+        }
+        response["debug"]["sections"] = {
+            "coverage_ratio": coverage_ratio,
+            "overlap_ratio": overlap_ratio,
         }
 
     if all_errors:

--- a/backend/tests/test_pass_runner.py
+++ b/backend/tests/test_pass_runner.py
@@ -18,7 +18,13 @@ def configure_runner(monkeypatch):
 
     monkeypatch.setattr(runner, "get_state", lambda session_id: state)
     monkeypatch.setattr(runner, "ensure_chunks", lambda session_id: ["chunk-1"])
-    monkeypatch.setattr(runner, "build_groups", lambda chunks: [["chunk-group"]])
+
+    def fake_build_pass_groups(chunks):
+        group = [{"chunks": [{"id": "chunk-1"}], "token_estimate": 1}]
+        per_pass = {name: group for name in runner.ALL_PASSES}
+        return group, per_pass
+
+    monkeypatch.setattr(runner, "build_pass_groups", fake_build_pass_groups)
     monkeypatch.setattr(
         runner,
         "resolve_pass_items",
@@ -53,7 +59,7 @@ def configure_runner(monkeypatch):
 
 def test_empty_cached_pass_triggers_rerun(monkeypatch):
     pass_cache = {
-        "Mechanical": {"payload": {"items": [{"pass": "Mechanical", "cached": True}]}},
+        "Mechanical": {"payload": {"items": [{"Pass": "Mechanical", "cached": True}]}},
         "Electrical": {"payload": {"items": []}},
     }
     monkeypatch.setattr(runner, "get_pass_cache", lambda file_hash: pass_cache)
@@ -63,8 +69,8 @@ def test_empty_cached_pass_triggers_rerun(monkeypatch):
     async def fake_execute_pass(pass_name, *args, **kwargs):
         executed.append(pass_name)
         return (
-            [{"pass": pass_name, "fresh": True}],
-            [{"pass": pass_name, "debug": True}],
+            [{"Pass": pass_name, "fresh": True}],
+            [{"Pass": pass_name, "debug": True}],
             [],
             [],
         )
@@ -82,18 +88,19 @@ def test_empty_cached_pass_triggers_rerun(monkeypatch):
 
     assert executed == ["Electrical"]
     assert saved_payloads == {
-        "Electrical": {"items": [{"pass": "Electrical", "fresh": True}]}
+        "Electrical": {"items": [{"Pass": "Electrical", "fresh": True}]}
     }
     assert result["cache"]["hits"] == ["Mechanical"]
     assert result["cache"]["misses"] == ["Electrical"]
     assert result["cache"]["stored_passes"] == ["Electrical", "Mechanical"]
-    assert {row["pass"] for row in result["rows"]} == {"Mechanical", "Electrical"}
+    assert len(result["rows"]) == 1
+    assert result["rows"][0]["Pass"] == "Electrical; Mechanical"
 
 
 def test_force_refresh_runs_all_passes(monkeypatch):
     pass_cache = {
-        "Mechanical": {"payload": {"items": [{"pass": "Mechanical", "cached": True}]}},
-        "Electrical": {"payload": {"items": [{"pass": "Electrical", "cached": True}]}}
+        "Mechanical": {"payload": {"items": [{"Pass": "Mechanical", "cached": True}]}},
+        "Electrical": {"payload": {"items": [{"Pass": "Electrical", "cached": True}]}}
     }
     monkeypatch.setattr(runner, "get_pass_cache", lambda file_hash: pass_cache)
 
@@ -102,8 +109,8 @@ def test_force_refresh_runs_all_passes(monkeypatch):
     async def fake_execute_pass(pass_name, *args, **kwargs):
         executed.append(pass_name)
         return (
-            [{"pass": pass_name, "fresh": True}],
-            [{"pass": pass_name, "debug": True}],
+            [{"Pass": pass_name, "fresh": True}],
+            [{"Pass": pass_name, "debug": True}],
             [],
             [],
         )
@@ -128,4 +135,5 @@ def test_force_refresh_runs_all_passes(monkeypatch):
     assert result["cache"]["hits"] == []
     assert set(result["cache"]["misses"]) == {"Mechanical", "Electrical"}
     assert set(result["cache"]["stored_passes"]) == {"Mechanical", "Electrical"}
-    assert {row["pass"] for row in result["rows"]} == {"Mechanical", "Electrical"}
+    assert len(result["rows"]) == 1
+    assert result["rows"][0]["Pass"] == "Electrical; Mechanical"

--- a/chunking/instrumentation.py
+++ b/chunking/instrumentation.py
@@ -8,9 +8,18 @@ from pathlib import Path
 from statistics import mean
 from typing import Dict, List, Sequence, Tuple
 
-MAIN_HEADING_RE = re.compile(r"(?m)^(?P<num>\d+)\)\s+[^\n]+$")
-APPENDIX_HEADING_RE = re.compile(r"(?m)^A(?P<anum>\d+)\.\s+[^\n]+$")
-APPENDIX_BLOCK_RE = re.compile(r"(?m)^Appendix\s+[A-D]\s+—\s+[^\n]+$")
+MAIN_HEADING_RE = re.compile(
+    r"(?m)^\s*(?P<num>\d{1,2})\)\s+.+$"
+)
+APPENDIX_HEADING_RE = re.compile(
+    r"(?m)^\s*A(?P<anum>\d{1,2})\.\s+.+$"
+)
+APPENDIX_BLOCK_RE = re.compile(
+    r"(?mi)^\s*Appendix\s+[A-Za-z0-9]+(?:[\s\-–—:.]+.+)?$"
+)
+INLINE_HEADING_SPLIT_RE = re.compile(
+    r"(?<=\S)\s+(?=(?:A\d{1,2}\.|\d{1,2}\))\s+)"
+)
 
 ARTIFACT_RE = re.compile(r"\s*(?:[0-9]{1,3}|[•\-]|i|ii|iii|iv|v)\s*$", re.IGNORECASE)
 
@@ -36,13 +45,53 @@ def is_artifact(line: str) -> bool:
     return bool(ARTIFACT_RE.fullmatch(line.strip()))
 
 
+def _split_inline_headings(line: str) -> List[Tuple[int, str]]:
+    segments: List[Tuple[int, str]] = []
+    cursor = 0
+    for match in INLINE_HEADING_SPLIT_RE.finditer(line):
+        end = match.start()
+        segments.append((cursor, line[cursor:end]))
+        cursor = end
+    segments.append((cursor, line[cursor:]))
+    return segments
+
+
+def _label_for_match(match: re.Match[str]) -> Tuple[str, str]:
+    groups = match.groupdict()
+    if "num" in groups and groups["num"]:
+        return groups["num"], match.group(0).strip()
+    if "anum" in groups and groups["anum"]:
+        return f"A{groups['anum']}", match.group(0).strip()
+    return match.group(0).strip(), match.group(0).strip()
+
+
 def detect_heading_spans(text: str) -> List[Tuple[str, int, int]]:
     spans: List[Tuple[str, int, int]] = []
-    for matcher in (MAIN_HEADING_RE, APPENDIX_HEADING_RE, APPENDIX_BLOCK_RE):
-        for match in matcher.finditer(text):
-            sec_id = match.groupdict().get("num") or match.groupdict().get("anum")
-            label = match.group(0).strip()
-            spans.append((sec_id or label, match.start(), match.end()))
+    if not text:
+        return spans
+
+    lines = text.splitlines(True)
+    offset = 0
+    for raw_line in lines:
+        line = raw_line.rstrip("\r\n")
+        segments = _split_inline_headings(line)
+        for seg_offset, segment in segments:
+            stripped = segment.strip()
+            if not stripped:
+                continue
+            match = MAIN_HEADING_RE.match(stripped)
+            if not match:
+                match = APPENDIX_HEADING_RE.match(stripped)
+            if not match:
+                match = APPENDIX_BLOCK_RE.match(stripped)
+            if not match:
+                continue
+            label, heading_text = _label_for_match(match)
+            leading_ws = len(segment) - len(segment.lstrip())
+            start = offset + seg_offset + leading_ws
+            end = start + len(heading_text)
+            spans.append((label, start, end))
+        offset += len(raw_line)
     spans.sort(key=lambda item: item[1])
     return spans
 

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -6,10 +6,10 @@ from chunking.evaluate import load_config, run_evaluation
 
 EXPECTED_HASHES = {
     "rfq_alpha::baseline:baseline": "df9cc53b8b9f3399f960ba49904477ed81116631",
-    "rfq_bravo::baseline:baseline": "d8cc99bb063d5aaa4de32dfb174ee3b32c552c88",
+    "rfq_bravo::baseline:baseline": "be329bc59989d6703edb83dab9e2ce7f25eac9f4",
     "rfq_charlie::baseline:baseline": "b7a901a8ebe3de8b30fef4b4d404302e98e24ff5",
     "rfq_alpha::improved:improved": "37dd559f8e31d1ba18f9a53a73bd35c1eff4b095",
-    "rfq_bravo::improved:improved": "7d5f22cc20011b7a24023681a30d5f71265f1104",
+    "rfq_bravo::improved:improved": "5cdf127f3f6918d18112eb4af282bded42fc84b8",
     "rfq_charlie::improved:improved": "b3c017cfe2ed77d1f5e407879cf249f82fb4fae8",
 }
 

--- a/tests/test_pass_postprocessing.py
+++ b/tests/test_pass_postprocessing.py
@@ -1,0 +1,104 @@
+"""Tests for appendix header detection and pass post-processing helpers."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from chunking.instrumentation import detect_heading_spans
+from backend.pipeline.passes.chunking import build_pass_groups
+from backend.pipeline.passes.runner import _assign_sections_to_rows, _dedupe_rows
+
+
+def test_appendix_subheaders_detected() -> None:
+    text = (
+        "Appendix A — Integration Overview\n"
+        "A4. Controls & Electrical Interfaces\n"
+        "A5. Utilities & Consumption\n"
+        "A6. Safety Systems\n"
+    )
+    spans = detect_heading_spans(text)
+    labels = {label for label, _, _ in spans}
+    assert {"A4", "A5", "A6"} <= labels
+
+
+def test_assign_sections_populates_fields() -> None:
+    lookup = [
+        {
+            "section_number": "A5",
+            "section_name": "Utilities & Consumption",
+            "text": "A5. Utilities & Consumption\nProvide chilled water connection.",
+            "normalized_text": "a5. utilities & consumption provide chilled water connection.",
+        }
+    ]
+    rows = [
+        {
+            "Document": "Spec.pdf",
+            "(Sub)Section #": "",
+            "(Sub)Section Name": "",
+            "Specification": "Provide chilled water connection.",
+            "Pass": "Mechanical",
+        }
+    ]
+    coverage = _assign_sections_to_rows(rows, lookup)
+    assert coverage == pytest.approx(1.0)
+    assert rows[0]["(Sub)Section #"] == "A5"
+    assert rows[0]["(Sub)Section Name"].startswith("Utilities")
+
+
+def test_build_pass_groups_filters_domain() -> None:
+    chunks = [
+        {
+            "text": "PLC programming shall use GuardLogix safety functions.",
+            "section_number": "A4",
+            "section_name": "Controls",
+            "document": "Spec",
+            "meta": {},
+        },
+        {
+            "text": "Provide warranty milestones and training schedule.",
+            "section_number": "PM1",
+            "section_name": "Project Management",
+            "document": "Spec",
+            "meta": {},
+        },
+    ]
+    base_groups, per_pass = build_pass_groups(chunks)
+    assert len(base_groups) >= 1
+    controls_groups = per_pass.get("Controls", [])
+    controls_texts = [
+        chunk["text"]
+        for group in controls_groups
+        for chunk in group.get("chunks", [])
+    ]
+    assert controls_texts == [
+        "PLC programming shall use GuardLogix safety functions."
+    ]
+
+
+def test_dedupe_rows_merges_pass_sources() -> None:
+    rows = [
+        {
+            "Document": "Spec.pdf",
+            "(Sub)Section #": "A4",
+            "(Sub)Section Name": "Controls",
+            "Specification": "Provide PLC programming per NFPA 79.",
+            "Pass": "Controls",
+        },
+        {
+            "Document": "Spec.pdf",
+            "(Sub)Section #": "A4",
+            "(Sub)Section Name": "Controls",
+            "Specification": "Provide PLC programming per NFPA 79.",
+            "Pass": "Mechanical",
+        },
+    ]
+    deduped, overlap = _dedupe_rows(rows)
+    assert len(deduped) == 1
+    assert deduped[0]["Pass"] == "Controls; Mechanical"
+    assert overlap == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- refine appendix heading detection to split inline appendix sub-sections and accept wrapped titles
- add discipline keyword lexicon, per-pass chunk filtering, section lookup hydration, and cross-pass deduplication when writing rows
- extend unit coverage for appendix headers, section mapping, domain gating, dedupe behaviour, and update evaluation hashes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d55d5b2a6c8324a678a2c940ef085a