### PR TITLE
Enhance chunk metadata across legacy, micro, and macro systems

### DIFF
--- a/backend/chunking/macro_chunker.py
+++ b/backend/chunking/macro_chunker.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
 from .atomic_chunker import _approx_tokens
 
@@ -21,6 +21,18 @@ class MacroChunker:
             self.config = MacroChunkConfig(**config)
         else:
             self.config = config or MacroChunkConfig()
+
+    def _ordered_unique(self, values: Iterable[Optional[str]]) -> List[str]:
+        seen: set[str] = set()
+        ordered: List[str] = []
+        for value in values:
+            if not value:
+                continue
+            if value in seen:
+                continue
+            seen.add(value)
+            ordered.append(str(value))
+        return ordered
 
     def build(self, micro_chunks: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
         ordered = sorted(
@@ -50,6 +62,31 @@ class MacroChunker:
             hier_path = " → ".join(
                 [part for part in (section, subsection) if part]
             ) or (section or subsection or "root")
+            clause_values = self._ordered_unique(
+                (m.get("hier") or {}).get("clause") for m in members
+            )
+            heading_values = self._ordered_unique(
+                (m.get("hier") or {}).get("heading") for m in members
+            )
+            part_values = self._ordered_unique(
+                (m.get("hier") or {}).get("part") for m in members
+            )
+            section_ids = self._ordered_unique(m.get("section_id") for m in members)
+            section_titles = self._ordered_unique(
+                m.get("section_title") or (m.get("hier") or {}).get("heading")
+                for m in members
+            )
+            pages = sorted({
+                p
+                for m in members
+                for p in (m.get("pages") or [])
+                if isinstance(p, int)
+            })
+            if not pages:
+                pages = list(range(page_start, page_end + 1))
+            micro_token_counts = [int(m.get("tokens") or m.get("token_count") or 0) for m in members]
+            micro_char_counts = [len(m.get("text", "")) for m in members]
+            macro_index = len(macros)
             macro_id = f"{doc_id}|macro|{section or '0'}|{subsection or '0'}|{len(macros):03d}"
             macros.append(
                 {
@@ -60,6 +97,33 @@ class MacroChunker:
                     "page_span": [page_start, page_end],
                     "tokens": token_estimate,
                     "micro_children": [m.get("id") for m in members],
+                    "micro_count": len(members),
+                    "micro_token_total": sum(micro_token_counts),
+                    "micro_token_avg": (
+                        sum(micro_token_counts) / len(members)
+                        if members
+                        else 0.0
+                    ),
+                    "micro_token_min": min(micro_token_counts) if micro_token_counts else 0,
+                    "micro_token_max": max(micro_token_counts) if micro_token_counts else 0,
+                    "char_count": len(joined_text),
+                    "micro_char_total": sum(micro_char_counts),
+                    "pages": pages,
+                    "hierarchy": {
+                        "part": part_values[0] if part_values else None,
+                        "parts": part_values,
+                        "section": section,
+                        "section_ids": section_ids,
+                        "section_titles": section_titles,
+                        "subsection": subsection,
+                        "headings": heading_values,
+                        "clauses": clause_values,
+                    },
+                    "section_id": section_ids[0] if section_ids else None,
+                    "section_title": section_titles[0] if section_titles else None,
+                    "heading": heading_values[0] if heading_values else None,
+                    "macro_index": macro_index,
+                    "resolution": "macro",
                 }
             )
         return macros

--- a/backend/pipeline/preprocess.py
+++ b/backend/pipeline/preprocess.py
@@ -171,17 +171,41 @@ def _sections_from_detected_headers(
     return sections
 
 
-def _emit_section_chunk(section: Dict[str, Any], buf: List[str], idx: int) -> Dict[str, Any]:
-    text = "".join(buf).strip()
+def _emit_section_chunk(
+    section: Dict[str, Any], buf: List[Tuple[str, Optional[int]]], idx: int
+) -> Dict[str, Any]:
+    text = "".join(part for part, _ in buf).strip()
+    line_indices = [line_idx for _, line_idx in buf if line_idx is not None]
+    line_span: Optional[Tuple[int, int]] = None
+    if line_indices:
+        line_span = (min(line_indices), max(line_indices))
+    token_estimate = approximate_tokens(text)
+    char_count = len(text)
+    line_count = len(line_indices)
+    page_start = int(section.get("page_start", 1) or 1)
+    page_end = int(section.get("page_end", section.get("page_start", 1)) or 1)
+    pages = list(range(page_start, page_end + 1)) if page_end >= page_start else [page_start]
+    chunk_id = f"{section.get('id', 'section')}|{idx:03d}"
     return {
         "text": text,
         "section_title": section.get("title", "Document"),
         "section_id": section.get("id", "1"),
-        "page_start": int(section.get("page_start", 1) or 1),
-        "page_end": int(section.get("page_end", section.get("page_start", 1)) or 1),
+        "section_number": section.get("section_number"),
+        "section_sequence_index": section.get("sequence_index"),
+        "page_start": page_start,
+        "page_end": page_end,
+        "pages": pages,
         "chunk_index_in_section": idx,
         "chunk_type": "paragraph",
         "heading_level": section.get("heading_level"),
+        "section_source_page": section.get("source_page"),
+        "section_source_line_idx": section.get("source_line_idx"),
+        "section_line_span": line_span,
+        "char_count": char_count,
+        "line_count": line_count,
+        "token_estimate": token_estimate,
+        "chunk_id": chunk_id,
+        "resolution": "legacy",
     }
 
 
@@ -194,17 +218,17 @@ def _yield_chunks_from_sections(
         lines = section.get("content") or []
         if not lines:
             continue
-        buf: List[str] = []
+        buf: List[Tuple[str, Optional[int]]] = []
         size = 0
         idx = 0
-        for line in lines:
+        for local_idx, line in enumerate(lines):
             segment = (line or "") + "\n"
             if size + len(segment) > tok_budget_chars and buf:
                 yield _emit_section_chunk(section, buf, idx)
                 idx += 1
                 buf = buf[-overlap_lines:] if overlap_lines > 0 else []
-                size = sum(len(part) for part in buf)
-            buf.append(segment)
+                size = sum(len(part) for part, _ in buf)
+            buf.append((segment, local_idx))
             size += len(segment)
         if buf:
             yield _emit_section_chunk(section, buf, idx)
@@ -261,7 +285,8 @@ def section_bounded_chunks_from_pdf(
     # Fallback: size-based chunking
     linear = data.get("pages_linear") or []
     text = "\n".join(linear)
-    buf, size, idx = [], 0, 0
+    buf: List[Tuple[str, Optional[int]]] = []
+    size, idx, line_idx = 0, 0, 0
     for line in text.splitlines():
         l = (line or "") + "\n"
         if size + len(l) > tok_budget_chars and buf:
@@ -271,15 +296,18 @@ def section_bounded_chunks_from_pdf(
                     "id": "1",
                     "page_start": 1,
                     "page_end": max(1, len(linear)),
+                    "section_number": "1",
+                    "sequence_index": 0,
                 },
                 buf,
                 idx,
             )
             idx += 1
             buf = buf[-overlap_lines:] if overlap_lines > 0 else []
-            size = sum(len(t) for t in buf)
-        buf.append(l)
+            size = sum(len(part) for part, _ in buf)
+        buf.append((l, line_idx))
         size += len(l)
+        line_idx += 1
     if buf:
         yield _emit_section_chunk(
             {
@@ -287,6 +315,8 @@ def section_bounded_chunks_from_pdf(
                 "id": "1",
                 "page_start": 1,
                 "page_end": max(1, len(linear)),
+                "section_number": "1",
+                "sequence_index": 0,
             },
             buf,
             idx,

--- a/ingest/microchunker.py
+++ b/ingest/microchunker.py
@@ -3,7 +3,18 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List, Mapping, MutableSequence, Optional, Sequence, Tuple, TypedDict
+from typing import (
+    Any,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Set,
+    Tuple,
+    TypedDict,
+)
 
 import regex as re
 
@@ -21,12 +32,19 @@ class MicroChunk(TypedDict, total=False):
     text: str
     norm_text: str
     token_count: int
+    token_span: Tuple[int, int]
     page: Optional[int]
+    pages: List[int]
     char_span: Optional[Tuple[int, int]]
+    char_count: int
+    line_count: int
+    part_span: Optional[Tuple[int, int]]
+    part_indices: List[int]
     para_id: Optional[str]
     header_anchor: Optional[str]
     section_id: Optional[str]
     section_title: Optional[str]
+    sequence_index: int
 
 
 @dataclass
@@ -191,20 +209,33 @@ def _microchunk_from_window(
     micro_id = hashlib.sha1(norm_text.encode("utf-8")).hexdigest()[:10]
 
     part_indices = sorted({token.part_index for token in window_tokens})
+    part_span: Optional[Tuple[int, int]] = None
+    if part_indices:
+        part_span = (part_indices[0], part_indices[-1])
+
+    page_candidates: Set[int] = set()
     page = None
     for idx in part_indices:
         part = parts[idx]
-        page = part.get("page") or part.get("page_start") or part.get("page_end")
-        if page:
+        for key in ("page", "page_start", "page_end"):
+            value = part.get(key)
+            if value is None:
+                continue
             try:
-                page = int(page)
+                page_num = int(value)
             except (TypeError, ValueError):
-                page = None
-            break
+                continue
+            page_candidates.add(page_num)
+    if page_candidates:
+        page = min(page_candidates)
 
     para_id = _select_metadata(parts, part_indices, "chunk_id") or _select_metadata(
         parts, part_indices, "para_id"
     )
+
+    char_count = len(raw_text)
+    line_count = raw_text.count("\n") + 1 if raw_text else 0
+    pages = sorted(page_candidates)
 
     chunk: MicroChunk = {
         "doc_id": doc_id,
@@ -212,8 +243,14 @@ def _microchunk_from_window(
         "text": raw_text.strip(),
         "norm_text": norm_text,
         "token_count": end_idx - start_idx,
+        "token_span": (start_idx, end_idx),
         "page": page,
+        "pages": pages,
         "char_span": (start_char, end_char),
+        "char_count": char_count,
+        "line_count": line_count,
+        "part_span": part_span,
+        "part_indices": part_indices,
         "para_id": para_id,
         "header_anchor": _select_metadata(parts, part_indices, "header_anchor"),
         "section_id": _select_metadata(parts, part_indices, "section_id"),
@@ -276,15 +313,15 @@ def microchunk_text(
             end_idx = min(start_idx + size, total_tokens)
             if end_idx <= start_idx:
                 end_idx = min(start_idx + 1, total_tokens)
-        microchunks.append(
-            _microchunk_from_window(
-                doc_id=doc_id,
-                doc_text=doc_text,
-                parts=parts,
-                tokens=tokens,
-                token_indices=(start_idx, end_idx),
-            )
+        chunk = _microchunk_from_window(
+            doc_id=doc_id,
+            doc_text=doc_text,
+            parts=parts,
+            tokens=tokens,
+            token_indices=(start_idx, end_idx),
         )
+        chunk["sequence_index"] = len(microchunks)
+        microchunks.append(chunk)
         if end_idx >= total_tokens:
             break
         next_start = end_idx - overlap


### PR DESCRIPTION
## Summary
- capture additional positional and structural metadata in legacy section chunks, including sequence, page spans, and token estimates
- enrich microchunk generation with token spans, part indices, page lists, and ordering information for improved traceability
- roll up aggregated hierarchy, pagination, and token statistics when building macro chunks

## Testing
- pytest tests/test_microchunking.py

------
https://chatgpt.com/codex/tasks/task_e_68d566d0d1648324a22db8e624c8a1d8