### PR TITLE
Add header scoring debug exports and appendix pattern

### DIFF
--- a/backend/parse/header_config.py
+++ b/backend/parse/header_config.py
@@ -26,4 +26,8 @@ CONFIG = {
     # Fallbacks
     "fallback_if_llm_low_quality": True,
     "fallback_top_k_per_page": 3,     # return top-k best heuristic headers if LLM not available
+
+    # Debugging helpers
+    "debug": False,
+    "debug_dir": "./_debug/headers",
 }

--- a/backend/parse/header_detector.py
+++ b/backend/parse/header_detector.py
@@ -1,7 +1,8 @@
 # backend/parse/header_detector.py
 # -*- coding: utf-8 -*-
 from __future__ import annotations
-from typing import Tuple, Dict
+from typing import Tuple, Dict, List, Optional
+from dataclasses import dataclass
 import re
 
 from .patterns_rfq import RFQ_SECTION_RES, UNIT_NEARBY_RX, ADDRESS_HINT_RX, PAGE_ART_RX
@@ -93,3 +94,116 @@ def score_header_candidate(line: str, style: dict | None = None) -> float:
         score -= 1.0
 
     return score
+
+
+@dataclass
+class ScoreBreakdown:
+    text: str
+    regex_hits: List[str]
+    numbering_depth: Optional[int]
+    font_size: Optional[float]
+    bold: Optional[bool]
+    caps: bool
+    disqualifiers: List[str]
+    partial_scores: Dict[str, float]
+    total: float
+
+
+def score_header_candidate_debug(line: str, style: dict | None = None) -> ScoreBreakdown:
+    """Return a structured breakdown of how a candidate line was scored."""
+    style = style or {}
+    txt = (line or "").strip()
+    if not txt:
+        return ScoreBreakdown(
+            text="",
+            regex_hits=[],
+            numbering_depth=None,
+            font_size=style.get("font_size"),
+            bold=style.get("bold"),
+            caps=False,
+            disqualifiers=["empty"],
+            partial_scores={},
+            total=-99.0,
+        )
+
+    regex_hits: List[str] = []
+    partial: Dict[str, float] = {}
+    disqualifiers: List[str] = []
+    score = 0.0
+
+    # Mirror RFQ regex checks
+    for rx in RFQ_SECTION_RES:
+        if rx.search(txt):
+            regex_hits.append(rx.pattern)
+    if ALLCAPS_HEADER_RX.match(txt):
+        regex_hits.append("ALLCAPS_HEADER_RX")
+
+    ok, meta = is_header_line(txt, style=style)
+    if ok:
+        score += 2.0
+        partial["is_header_line"] = 2.0
+    else:
+        partial["is_header_line"] = 0.0
+
+    section_number: Optional[str] = None
+    if isinstance(meta, dict):
+        section_number = meta.get("section_number")
+    if not section_number:
+        match = re.match(r"^\s*([A-Za-z]\d+(?:\.\d+)*)", txt)
+        if match:
+            section_number = match.group(1)
+
+    from .header_levels import numbering_depth
+
+    depth = numbering_depth(section_number)
+    if depth:
+        boost = 0.5
+        score += boost
+        partial["numbering_depth"] = boost
+
+    font_size = style.get("font_size")
+    if font_size:
+        boost = 0.5
+        score += boost
+        partial["font_size"] = boost
+
+    if style.get("bold"):
+        boost = 0.4
+        score += boost
+        partial["bold"] = boost
+
+    caps_hit = bool(ALLCAPS_HEADER_RX.match(txt))
+
+    if UNIT_NEARBY_RX.search(txt):
+        penalty = -2.0
+        score += penalty
+        disqualifiers.append("units")
+        partial["units_penalty"] = penalty
+    if ADDRESS_HINT_RX.search(txt):
+        penalty = -2.0
+        score += penalty
+        disqualifiers.append("address")
+        partial["address_penalty"] = penalty
+    if PAGE_ART_RX.search(txt):
+        penalty = -2.0
+        score += penalty
+        disqualifiers.append("page_art")
+        partial["page_art_penalty"] = penalty
+
+    if len(txt) > 140 and not depth:
+        penalty = -1.0
+        score += penalty
+        disqualifiers.append("long_line")
+        partial["long_line_penalty"] = penalty
+
+    return ScoreBreakdown(
+        text=txt,
+        regex_hits=regex_hits,
+        numbering_depth=depth,
+        font_size=font_size,
+        bold=style.get("bold"),
+        caps=caps_hit,
+        disqualifiers=disqualifiers,
+        partial_scores=partial,
+        total=score,
+    )

--- a/backend/parse/header_page_mode.py
+++ b/backend/parse/header_page_mode.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Tuple, Optional
 import re
+import os
+import csv
+import json
 
 try:
     from rapidfuzz.fuzz import ratio as fuzz_ratio
@@ -9,7 +12,7 @@ except Exception:
     import difflib
     def fuzz_ratio(a, b): return int(100 * difflib.SequenceMatcher(None, a or "", b or "").ratio())
 
-from .header_detector import is_header_line, score_header_candidate
+from .header_detector import score_header_candidate, score_header_candidate_debug
 from .header_levels import map_font_sizes_to_levels, infer_heading_level
 from .header_config import CONFIG
 
@@ -108,3 +111,115 @@ def build_adjudication_prompt(page_text: str, candidates: List[dict], context_ch
         "CANDIDATE_LINES:\n" + "\n".join(lines) + "\n\n" +
         "PAGE_TEXT_SNIPPETS:\n" + "\n".join(ctxs)
     )
+
+
+def _ensure_dir(path: str) -> None:
+    if path:
+        os.makedirs(path, exist_ok=True)
+
+
+def _dump_page_debug(
+    doc_id: str,
+    page_idx: int,
+    page_text: str,
+    candidates: List[dict],
+    llm_prompt: Optional[str] = None,
+    llm_json: Optional[List[Dict[str, Any]]] = None,
+) -> None:
+    if not CONFIG.get("debug"):
+        return
+
+    base_dir = CONFIG.get("debug_dir", "./_debug/headers") or "./_debug/headers"
+    out_dir = os.path.join(base_dir, doc_id or "document", f"page_{page_idx:04d}")
+    _ensure_dir(out_dir)
+
+    csv_path = os.path.join(out_dir, "candidates.csv")
+    with open(csv_path, "w", newline="", encoding="utf-8") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(
+            [
+                "line_idx",
+                "text",
+                "regex_hits",
+                "numbering_depth",
+                "font_size",
+                "bold",
+                "caps",
+                "disqualifiers",
+                "partial_scores",
+                "total_score",
+                "accepted",
+                "threshold",
+            ]
+        )
+        threshold = CONFIG.get("accept_score_threshold", 2.25)
+        for cand in candidates:
+            breakdown = score_header_candidate_debug(cand.get("text"), style=cand.get("style") or {})
+            accepted = breakdown.total >= threshold
+            writer.writerow(
+                [
+                    cand.get("line_idx"),
+                    breakdown.text,
+                    " | ".join(breakdown.regex_hits),
+                    breakdown.numbering_depth,
+                    breakdown.font_size,
+                    breakdown.bold,
+                    breakdown.caps,
+                    " | ".join(breakdown.disqualifiers),
+                    json.dumps(breakdown.partial_scores, ensure_ascii=False),
+                    f"{breakdown.total:.2f}",
+                    accepted,
+                    threshold,
+                ]
+            )
+
+    with open(os.path.join(out_dir, "candidates.json"), "w", encoding="utf-8") as fh:
+        json.dump(candidates, fh, ensure_ascii=False, indent=2)
+
+    with open(os.path.join(out_dir, "page.txt"), "w", encoding="utf-8") as fh:
+        fh.write(page_text)
+
+    if llm_prompt is not None:
+        with open(os.path.join(out_dir, "llm_prompt.txt"), "w", encoding="utf-8") as fh:
+            fh.write(llm_prompt)
+
+    if llm_json is not None:
+        with open(os.path.join(out_dir, "llm_selection.json"), "w", encoding="utf-8") as fh:
+            json.dump(llm_json, fh, ensure_ascii=False, indent=2)
+
+
+def dump_appendix_audit(
+    doc_id: str,
+    pages_debug: List[Tuple[int, List[dict], str]],
+) -> None:
+    if not CONFIG.get("debug"):
+        return
+
+    rx = re.compile(r"^\s*(?:Appendix\s+[A-Za-z]|[A-Za-z]\d+\.)")
+    base_dir = CONFIG.get("debug_dir", "./_debug/headers") or "./_debug/headers"
+    out_dir = os.path.join(base_dir, doc_id or "document")
+    _ensure_dir(out_dir)
+
+    audit_rows: List[Dict[str, Any]] = []
+    threshold = CONFIG.get("accept_score_threshold", 2.25)
+    for page_idx, cand_list, _page_text in pages_debug:
+        for cand in cand_list:
+            txt = (cand.get("text") or "").strip()
+            if not rx.match(txt):
+                continue
+            breakdown = score_header_candidate_debug(txt, style=cand.get("style") or {})
+            audit_rows.append(
+                {
+                    "page": page_idx + 1,
+                    "line_idx": cand.get("line_idx"),
+                    "text": txt,
+                    "regex_hits": breakdown.regex_hits,
+                    "total": breakdown.total,
+                    "accepted": breakdown.total >= threshold,
+                    "partial_scores": breakdown.partial_scores,
+                    "disqualifiers": breakdown.disqualifiers,
+                }
+            )
+
+    with open(os.path.join(out_dir, "appendix_audit.json"), "w", encoding="utf-8") as fh:
+        json.dump(audit_rows, fh, ensure_ascii=False, indent=2)

--- a/backend/parse/patterns_rfq.py
+++ b/backend/parse/patterns_rfq.py
@@ -3,6 +3,7 @@
 import re
 
 RFQ_SECTION_RES = [re.compile(p, re.IGNORECASE) for p in [
+    r'^\s*([A-Z])(\d{1,3})\.\s+(.+?)\s*$',                          # A5. Heading
     r'^\s*(\d{1,3})\)\s+(.+?)\s*$',                                 # 1) Scope
     r'^\s*(\d{1,3}(?:\.\d{1,3}){0,4})\s+([A-Z].{3,})\s*$',          # 1.2 Subsection Title
     r'^\s*([A-Z])\.(\d{1,3})\s+(.+?)\s*$',                          # A.1 Heading

--- a/backend/pipeline/preprocess.py
+++ b/backend/pipeline/preprocess.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 import json
 import importlib
+import copy
 from typing import List, Dict, Any, Iterable, Optional, Tuple
 
 # PDF extraction wrapper
@@ -9,7 +10,12 @@ from ..ingest.pdf_extract import extract as pdf_extract
 
 # v1.7 header helpers
 from ..parse.header_config import CONFIG
-from ..parse.header_page_mode import select_candidates, build_adjudication_prompt
+from ..parse.header_page_mode import (
+    select_candidates,
+    build_adjudication_prompt,
+    _dump_page_debug,
+    dump_appendix_audit,
+)
 from ..parse.header_detector import is_header_line
 from ..state import get_state
 
@@ -365,15 +371,26 @@ async def detect_headers_page_mode(
     page_line_styles: Optional[List[List[dict]]],
     page_texts: Optional[List[str]],
     llm_client,
+    doc_id: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """
     Deterministic-first header detection, page-by-page, with optional LLM adjudication.
     Returns: [{"page": N, "headers": [{"line_idx","text","section_number","level","score","style"}]}]
     """
     results: List[Dict[str, Any]] = []
+    debug_snapshots: List[Tuple[int, List[dict], str]] = []
+    doc_tag = doc_id or "document"
     for pi, lines in enumerate(pages_lines or []):
         styles = page_line_styles[pi] if page_line_styles and pi < len(page_line_styles) else [{} for _ in lines]
         candidates = select_candidates(lines, styles)
+        page_text = (
+            page_texts[pi]
+            if page_texts and pi < len(page_texts)
+            else "\n".join(lines)
+        )
+        snapshot = [copy.deepcopy(c) for c in candidates]
+        debug_snapshots.append((pi, snapshot, page_text))
+        _dump_page_debug(doc_tag, pi, page_text, snapshot)
 
         det = [c for c in candidates if c["score"] >= CONFIG.get("accept_score_threshold", 2.0)]
         ambiguous = [c for c in candidates if CONFIG.get("ambiguous_score_threshold", 1.0) <= c["score"] < CONFIG.get("accept_score_threshold", 2.0)]
@@ -381,13 +398,15 @@ async def detect_headers_page_mode(
 
         need_llm = CONFIG.get("llm_enabled", True) and (ambiguous or len(candidates) > CONFIG.get("max_candidates_per_page", 40)//2)
         if need_llm and llm_client is not None:
+            page_prompt = build_adjudication_prompt(
+                page_text,
+                candidates,
+                CONFIG.get("context_chars_per_candidate", 700),
+            )
+            _dump_page_debug(doc_tag, pi, page_text, snapshot, llm_prompt=page_prompt)
             user_msg = {
                 "role": "user",
-                "content": build_adjudication_prompt(
-                    page_texts[pi] if page_texts and pi < len(page_texts) else "\n".join(lines),
-                    candidates,
-                    CONFIG.get("context_chars_per_candidate", 700),
-                ),
+                "content": page_prompt,
             }
             sys_prompt = _get_header_system_prompt()
             try:
@@ -420,6 +439,14 @@ async def detect_headers_page_mode(
                                 })
                         except Exception:
                             continue
+                _dump_page_debug(
+                    doc_tag,
+                    pi,
+                    page_text,
+                    snapshot,
+                    llm_prompt=page_prompt,
+                    llm_json=payload if isinstance(payload, list) else [],
+                )
             except Exception:
                 pass
 
@@ -433,4 +460,6 @@ async def detect_headers_page_mode(
             ordered.append(c)
 
         results.append({"page": pi + 1, "headers": ordered})
+
+    dump_appendix_audit(doc_tag, debug_snapshots)
     return results


### PR DESCRIPTION
## Summary
- add toggleable debugging configuration for header detection and expose rich score breakdowns
- export per-page header candidate diagnostics plus appendix-specific audits to help trace promotions
- recognise appendix short-form numbering such as `A5.` during regex scoring

## Testing
- pytest tests/test_views.py -k headers *(fails: ModuleNotFoundError: No module named 'chunking')*

------
https://chatgpt.com/codex/tasks/task_e_68d5688d3f0c8324aa5443290ddb4779