### PR TITLE
Refactor preprocess pipeline for micro and macro chunking

### DIFF
--- a/backend/persistence.py
+++ b/backend/persistence.py
@@ -84,7 +84,8 @@ def save_preprocess_cache(
     file_hash: Optional[str],
     filename: Optional[str],
     response: Dict[str, Any],
-    chunks: Optional[list],
+    macro_chunks: Optional[list],
+    micro_chunks: Optional[list],
 ) -> None:
     if not file_hash:
         return
@@ -92,7 +93,9 @@ def save_preprocess_cache(
     payload.setdefault("passes", {})
     payload["preprocess"] = {
         "response": response,
-        "chunks": chunks or [],
+        "chunks": macro_chunks or [],
+        "macro_chunks": macro_chunks or [],
+        "micro_chunks": micro_chunks or [],
         "stored_at": time.time(),
     }
     _write_payload(file_hash, payload, filename)
@@ -101,7 +104,11 @@ def save_preprocess_cache(
 def get_preprocess_cache(file_hash: Optional[str]) -> Optional[Dict[str, Any]]:
     payload = _load_payload(file_hash)
     entry = payload.get("preprocess") if isinstance(payload, dict) else None
-    if isinstance(entry, dict) and entry.get("chunks"):
+    if isinstance(entry, dict) and (
+        entry.get("macro_chunks")
+        or entry.get("micro_chunks")
+        or entry.get("chunks")
+    ):
         return entry
     return None
 

--- a/backend/pipeline/passes/chunking.py
+++ b/backend/pipeline/passes/chunking.py
@@ -251,8 +251,9 @@ def ensure_chunks(session_id: str) -> List[Dict[str, Any]]:
         chunks = [dict(chunk) for chunk in state.pre_chunks]
     else:
         cached_pre = get_preprocess_cache(getattr(state, "file_hash", None))
-        if cached_pre and cached_pre.get("chunks"):
-            cached_chunks = [dict(chunk) for chunk in cached_pre.get("chunks", [])]
+        if cached_pre:
+            cached_payload = cached_pre.get("macro_chunks") or cached_pre.get("chunks") or []
+            cached_chunks = [dict(chunk) for chunk in cached_payload]
             state.pre_chunks = cached_chunks
             chunks = cached_chunks
         else:

--- a/backend/routes/preprocess.py
+++ b/backend/routes/preprocess.py
@@ -1,8 +1,14 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
+from pathlib import Path
+
 from flask import Blueprint, request, jsonify, make_response
 import os
 
+from fluidrag.config import load_config
+
+from ..chunking.atomic_chunker import AtomicChunker
+from ..chunking.macro_chunker import MacroChunker
 from ..pipeline import preprocess as pp
 from ..persistence import get_preprocess_cache, save_preprocess_cache
 from ..state import get_state
@@ -35,21 +41,28 @@ def preprocess_route():
 
         cached = get_preprocess_cache(file_hash) if not force_refresh else None
         if cached:
-            cached_chunks = [dict(chunk) for chunk in cached.get("chunks", [])]
+            cached_macro = [dict(chunk) for chunk in cached.get("macro_chunks") or cached.get("chunks", [])]
+            cached_micro = [dict(chunk) for chunk in cached.get("micro_chunks", [])]
             if state is not None:
-                state.pre_chunks = cached_chunks
+                state.pre_chunks = cached_macro
+                state.macro_chunks = cached_macro
+                state.micro_chunks = cached_micro
             response_payload = dict(cached.get("response") or {})
             response_payload.update(
                 {
                     "ok": True,
                     "httpStatus": 200,
-                    "pre_chunks": len(cached_chunks),
+                    "macro_chunks": len(cached_macro),
+                    "micro_chunks": len(cached_micro),
+                    "pre_chunks": len(cached_macro),
                     "cache": {"hit": True, "section": "preprocess"},
                     "from_cache": True,
                 }
             )
             response_payload.setdefault("pages", response_payload.get("pages") or 0)
-            response_payload.setdefault("chunks", response_payload.get("chunks") or len(cached_chunks))
+            response_payload.setdefault(
+                "chunks", response_payload.get("chunks") or len(cached_macro)
+            )
             response = jsonify(response_payload)
             response.headers["Access-Control-Allow-Origin"] = "*"
             return response, 200
@@ -62,83 +75,129 @@ def preprocess_route():
             layout = pp.extract_pages_with_layout(pdf_path, sidecar_dir=sidecar_dir)
             pages_linear = layout.get("pages_linear") or []
 
-        # Prefer legacy chunker if present, else section-bounded
-        chunks = []
-        std_chunks = getattr(pp, "standard_pre_chunks", None)
-        if callable(std_chunks):
-            for ch in std_chunks(pdf_path, sidecar_dir=sidecar_dir, session_id=session_id):
-                chunks.append(ch)
-        else:
-            for ch in pp.section_bounded_chunks_from_pdf(
-                pdf_path,
-                sidecar_dir=sidecar_dir,
-                session_id=session_id,
-            ):
-                chunks.append(ch)
+        cfg = load_config(Path("config") / "fluidrag.yaml")
+        chunk_cfg = (cfg.get("chunking", {}) or {})
+        micro_cfg = chunk_cfg.get("micro", {})
+        macro_cfg = chunk_cfg.get("macro", {})
 
-        def _chunk_sort_key(item):
-            page_start = item.get("page_start")
+        doc_name = (state.filename if state and getattr(state, "filename", None) else None) or os.path.splitext(os.path.basename(pdf_path or ""))[0] or session_id or "document"
+        doc_id = Path(doc_name).stem or "document"
+        page_records = [
+            {"page": idx + 1, "text": text}
+            for idx, text in enumerate(pages_linear)
+        ]
+
+        header_spans = []
+        if state is not None and state.headers:
+            for page_entry in state.headers:
+                headers = page_entry.get("headers") if isinstance(page_entry, dict) else None
+                if not isinstance(headers, list):
+                    continue
+                for header in headers:
+                    if not isinstance(header, dict):
+                        continue
+                    clause = header.get("section_number") or header.get("clause")
+                    text = header.get("text") or header.get("heading")
+                    if clause and text:
+                        header_spans.append({"clause": clause, "text": text})
+
+        chunker = AtomicChunker(micro_cfg)
+        micro_chunks = chunker.chunk(doc_id, page_records, header_spans)
+        for micro in micro_chunks:
+            micro.setdefault("micro_id", micro.get("id"))
+            span = micro.get("page_span") or [1, 1]
             try:
-                page_start = int(page_start)
+                page_start = int(span[0])
             except Exception:
                 page_start = 1
-            section_id = str(item.get("section_id") or "")
-            chunk_idx = item.get("chunk_index_in_section")
             try:
-                chunk_idx = int(chunk_idx)
+                page_end = int(span[1])
             except Exception:
-                chunk_idx = 0
-            return (page_start, section_id, chunk_idx)
+                page_end = page_start
+            micro.setdefault("page_start", page_start)
+            micro.setdefault("page_end", page_end)
+            micro.setdefault("pages", list(range(page_start, page_end + 1)))
 
-        if chunks:
-            chunks.sort(key=_chunk_sort_key)
+        macro_chunker = MacroChunker(macro_cfg)
+        raw_macros = macro_chunker.build(micro_chunks)
 
-        # Aggregate preview rows by section to surface fuller spans
-        preview_sections = {}
-        for ch in chunks:
-            sec_id = str(ch.get("section_id") or "")
-            sec_name = ch.get("section_title") or "Document"
-            page_start = ch.get("page_start")
-            page_end = ch.get("page_end")
+        macro_chunks = []
+        for idx, macro in enumerate(raw_macros):
+            enriched = dict(macro)
+            page_span = enriched.get("page_span") or [1, 1]
             try:
-                page_start_i = int(page_start)
+                page_start = int(page_span[0])
             except Exception:
-                page_start_i = 1
+                page_start = 1
             try:
-                page_end_i = int(page_end)
+                page_end = int(page_span[1])
             except Exception:
-                page_end_i = page_start_i
-            key = (sec_id, sec_name)
-            entry = preview_sections.setdefault(
-                key,
-                {
-                    "section_number": sec_id,
-                    "section_name": sec_name,
-                    "chars": 0,
-                    "page_start": page_start_i,
-                    "page_end": page_end_i,
-                },
+                page_end = page_start
+            pages = enriched.get("pages") or list(range(page_start, page_end + 1))
+            hierarchy = enriched.get("hierarchy") or {}
+            section_title = (
+                enriched.get("section_title")
+                or hierarchy.get("headings", [None])[0]
+                or enriched.get("hier_path")
+                or "Document"
             )
-            entry["chars"] += len(ch.get("text") or "")
-            if page_start_i < entry["page_start"]:
-                entry["page_start"] = page_start_i
-            if page_end_i > entry.get("page_end", page_end_i):
-                entry["page_end"] = page_end_i
+            section_number = enriched.get("section_id") or hierarchy.get("section")
+            enriched.update(
+                {
+                    "chunk_id": enriched.get("macro_id"),
+                    "chunk_index_in_section": idx,
+                    "page_start": page_start,
+                    "page_end": page_end,
+                    "page": page_start,
+                    "pages": pages,
+                    "section_number": section_number,
+                    "section_title": section_title,
+                    "section_name": section_title,
+                    "document": doc_name,
+                    "chunk_type": "macro",
+                }
+            )
+            meta = dict(enriched.get("meta") or {})
+            meta.setdefault("hierarchy", hierarchy)
+            meta.setdefault("micro_children", list(enriched.get("micro_children") or []))
+            enriched["meta"] = meta
+            macro_chunks.append(enriched)
 
-        preview_list = sorted(
-            preview_sections.values(),
-            key=lambda item: (item.get("page_start", 1), item.get("section_number", "")),
-        )[:5]
+        def _macro_sort_key(item):
+            return (
+                int(item.get("page_start", 1) or 1),
+                str(item.get("section_number") or ""),
+                int(item.get("chunk_index_in_section", 0) or 0),
+            )
+
+        macro_chunks.sort(key=_macro_sort_key)
+
+        preview_list = []
+        for macro in macro_chunks[:5]:
+            preview_list.append(
+                {
+                    "section_number": macro.get("section_number") or "",
+                    "section_name": macro.get("section_title") or "Document",
+                    "chars": len(macro.get("text") or ""),
+                    "page_start": macro.get("page_start"),
+                    "page_end": macro.get("page_end"),
+                    "micro_chunks": len(macro.get("micro_children") or []),
+                }
+            )
 
         if state is not None:
-            state.pre_chunks = chunks
+            state.pre_chunks = macro_chunks
+            state.macro_chunks = macro_chunks
+            state.micro_chunks = micro_chunks
 
         resp = {
             "ok": True,
             "httpStatus": 200,
             "pages": len(pages_linear),
-            "chunks": len(chunks),
-            "pre_chunks": len(chunks),
+            "chunks": len(macro_chunks),
+            "pre_chunks": len(macro_chunks),
+            "macro_chunks": len(macro_chunks),
+            "micro_chunks": len(micro_chunks),
             "preview": preview_list,
             "cache": {"hit": False, "section": "preprocess"},
         }
@@ -148,7 +207,13 @@ def preprocess_route():
         store_resp = dict(resp)
         store_resp.pop("cache", None)
         store_resp.pop("from_cache", None)
-        save_preprocess_cache(file_hash, getattr(state, "filename", None), store_resp, chunks)
+        save_preprocess_cache(
+            file_hash,
+            getattr(state, "filename", None),
+            store_resp,
+            macro_chunks,
+            micro_chunks,
+        )
 
         return response, 200
 

--- a/backend/state.py
+++ b/backend/state.py
@@ -9,6 +9,8 @@ class PipelineState:
     file_path: str
     pages: Optional[List[str]] = None
     pre_chunks: Optional[List[Dict[str, Any]]] = None
+    micro_chunks: Optional[List[Dict[str, Any]]] = None
+    macro_chunks: Optional[List[Dict[str, Any]]] = None
     section_chunks: Optional[List[Dict[str, Any]]] = None
     refined_chunks: Optional[List[Dict[str, Any]]] = None
     clustered_chunks: Optional[List[Dict[str, Any]]] = None

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -42,10 +42,10 @@
     <section class="card">
       <h2>2 · Preprocess</h2>
       <div class="actions">
-        <button id="preprocessBtn">Run standard chunking</button>
-        <button id="preprocessRechunkBtn" class="ghost">Re-run chunking (ignore caches)</button>
+        <button id="preprocessBtn">Run micro → macro chunking</button>
+        <button id="preprocessRechunkBtn" class="ghost">Re-run micro → macro chunking (ignore caches)</button>
       </div>
-      <div id="preprocessStatus" class="status">Pre-chunking pending…</div>
+      <div id="preprocessStatus" class="status">Micro/macro preprocessing pending…</div>
     </section>
 
     <section class="card">
@@ -86,6 +86,6 @@
     </section>
   </main>
 
-  <script type="module" src="/js/app.mjs?v=20250301"></script>
+  <script type="module" src="/js/app.mjs?v=20250307"></script>
 </body>
 </html>

--- a/frontend/js/flows.mjs
+++ b/frontend/js/flows.mjs
@@ -98,7 +98,7 @@ export function resetAfterUpload() {
   if (headersPreview) headersPreview.innerHTML = "";
 
   const preStatus = el("preprocessStatus");
-  if (preStatus) setStatus(preStatus, "Pre-chunking pending…");
+  if (preStatus) setStatus(preStatus, "Micro/macro preprocessing pending…");
   const headerStatus = el("headersStatus");
   if (headerStatus) setStatus(headerStatus, "Header detection pending…");
   const processStatus = el("processStatus");
@@ -186,7 +186,7 @@ export async function onUpload() {
       } else {
         updateStatus(
           "preprocessStatus",
-          "Pre-chunking cached — select provider/model to load.",
+          "Micro/macro preprocessing cached — select provider/model to load.",
           "success"
         );
       }
@@ -290,7 +290,9 @@ export async function onPreprocess(options = {}) {
       const headerStatus = el("headersStatus");
       if (headerStatus) setStatus(headerStatus, "Header detection pending…");
     }
-    const statusLabel = forceRefresh ? "Re-running standard chunking…" : "Running standard chunking…";
+    const statusLabel = forceRefresh
+      ? "Re-running micro → macro chunking…"
+      : "Running micro → macro chunking…";
     updateStatus("preprocessStatus", statusLabel);
     log(forceRefresh ? "Preprocess rerun start" : "Preprocess start");
     withGroup("[Flow] Preprocess → Request payload", () => {
@@ -314,11 +316,14 @@ export async function onPreprocess(options = {}) {
     state.hasPre = true;
     state.cacheInfo.preprocess = true;
     const cacheTag = res.cache?.hit ? " [cached]" : forceRefresh ? " [refreshed]" : "";
-    updateStatus(
-      "preprocessStatus",
-      `Pages=${res.pages}, pre-chunks=${res.pre_chunks}${cacheTag}`,
-      "success"
-    );
+    const microCount = typeof res.micro_chunks === "number" ? res.micro_chunks : null;
+    const macroCount = typeof res.macro_chunks === "number" ? res.macro_chunks : res.pre_chunks;
+    const microLabel = microCount !== null ? `micro=${microCount}` : null;
+    const macroLabel = macroCount !== null ? `macro=${macroCount}` : null;
+    const parts = [`Pages=${res.pages}`];
+    if (microLabel) parts.push(microLabel);
+    if (macroLabel) parts.push(macroLabel);
+    updateStatus("preprocessStatus", `${parts.join(", ")}${cacheTag}`, "success");
     if (res.cache?.hit) {
       log("Preprocess complete via cache");
     } else if (forceRefresh) {


### PR DESCRIPTION
## Summary
- replace the preprocess route with a micro → macro chunking pipeline and persist both granularities in the cache
- expose dedicated micro and macro chunk slots in the pipeline state and chunking fallback so later stages consume the new artifacts
- refresh the frontend labels/status messaging to highlight micro → macro preprocessing and surface micro/macro counts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5b25318748324ba67c1e7c463b936