### PR TITLE
Fix preprocess section title fallback

### DIFF
--- a/backend/routes/preprocess.py
+++ b/backend/routes/preprocess.py
@@ -135,9 +135,11 @@ def preprocess_route():
                 page_end = page_start
             pages = enriched.get("pages") or list(range(page_start, page_end + 1))
             hierarchy = enriched.get("hierarchy") or {}
+            heading_values = hierarchy.get("headings") or []
+            first_heading = heading_values[0] if heading_values else None
             section_title = (
                 enriched.get("section_title")
-                or hierarchy.get("headings", [None])[0]
+                or first_heading
                 or enriched.get("hier_path")
                 or "Document"
             )


### PR DESCRIPTION
## Summary
- avoid indexing into an empty headings list when building preprocess macro chunk metadata

## Testing
- pytest backend/tests

------
https://chatgpt.com/codex/tasks/task_e_68d5b50929548324826dba1354ec689c