### PR TITLE
Enhance FluidRAG stubs for encoder, chunk metadata, and unit parsing

### DIFF
--- a/fluidrag/backend/core/chunking/microchunker.py
+++ b/fluidrag/backend/core/chunking/microchunker.py
@@ -18,11 +18,17 @@ class ChunkWindow:
         Exclusive end offset of the chunk relative to the section text.
     text:
         The chunk text itself.
+    window_chars:
+        Target window size used when generating the chunk.
+    stride_chars:
+        Configured stride between successive chunks.
     """
 
     start: int
     end: int
     text: str
+    window_chars: int
+    stride_chars: int
 
 
 def _split_sentences(text: str) -> List[Tuple[int, str]]:
@@ -86,7 +92,13 @@ def microchunk(
 
         last_sentence_offset = sentences[end_idx - 1][0]
         end_offset = last_sentence_offset + len(sentences[end_idx - 1][1])
-        yield ChunkWindow(start=start_offset, end=end_offset, text=chunk_text)
+        yield ChunkWindow(
+            start=start_offset,
+            end=end_offset,
+            text=chunk_text,
+            window_chars=window_chars,
+            stride_chars=stride_chars,
+        )
 
         if end_idx >= n_sentences:
             break

--- a/fluidrag/backend/core/embedding/encoder.py
+++ b/fluidrag/backend/core/embedding/encoder.py
@@ -41,5 +41,23 @@ class EmbeddingEncoder:
             vectors[idx] = vec
         return vectors
 
+    # ------------------------------------------------------------------
+    # Convenience wrappers
+    # ------------------------------------------------------------------
+    def embed_lines(self, lines: Iterable[str]) -> np.ndarray:
+        """Embed individual preprocessed lines."""
+
+        return self.embed_texts(lines)
+
+    def embed_sections(self, sections: Iterable[str]) -> np.ndarray:
+        """Embed section strings (title + prefix text)."""
+
+        return self.embed_texts(sections)
+
+    def embed_chunks(self, chunks: Iterable[str]) -> np.ndarray:
+        """Embed chunk bodies for retrieval."""
+
+        return self.embed_texts(chunks)
+
 
 __all__ = ["EmbeddingEncoder"]

--- a/fluidrag/backend/core/validators/units.py
+++ b/fluidrag/backend/core/validators/units.py
@@ -3,13 +3,21 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 UNIT_PATTERN = r"(mm|cm|m|in|ft|psi|bar|kPa|MPa|A|mA|kA|V|VAC|VDC|kV|kW|kVA|°C|°F|Hz|rpm|N|kN|lbf)"
 VALUE_PATTERN = r"[-+]?\d+(?:\.\d+)?"
 OP_PATTERN = r"(≥|<=|≤|>=|=|==|>|<|±)"
 
 TOKEN_RE = re.compile(rf"(?P<op>{OP_PATTERN})?\s*(?P<value>{VALUE_PATTERN})\s*(?P<unit>{UNIT_PATTERN})", re.IGNORECASE)
+TOLERANCE_RE = re.compile(
+    rf"(?P<value>{VALUE_PATTERN})\s*(?P<unit>{UNIT_PATTERN})?\s*±\s*(?P<tol>{VALUE_PATTERN})\s*(?P<tol_unit>{UNIT_PATTERN})?",
+    re.IGNORECASE,
+)
+RANGE_RE = re.compile(
+    rf"(?P<low>{VALUE_PATTERN})\s*(?:-|to)\s*(?P<high>{VALUE_PATTERN})\s*(?P<unit>{UNIT_PATTERN})?",
+    re.IGNORECASE,
+)
 
 
 @dataclass
@@ -21,12 +29,16 @@ class ParsedUnits:
     value: Optional[float] = None
     unit: Optional[str] = None
     op: Optional[str] = None
+    tol: Optional[float] = None
+    range: Optional[Tuple[float, float]] = None
 
     def to_dict(self) -> Dict[str, Any]:
         data: Dict[str, Any] = {
             "values": self.values,
             "units": self.units,
             "ops": self.ops,
+            "tol": self.tol,
+            "range": self.range,
         }
         if self.value is not None:
             data["value"] = self.value
@@ -62,6 +74,43 @@ def parse_units(text: str) -> Dict[str, Any]:
         parsed.value = values[0]
         parsed.unit = units[0]
         parsed.op = ops[0]
+
+    tol_match = TOLERANCE_RE.search(text)
+    if tol_match:
+        parsed.tol = float(tol_match.group("tol"))
+        base_value = float(tol_match.group("value"))
+        base_unit = tol_match.group("unit") or tol_match.group("tol_unit")
+        if parsed.value is None:
+            parsed.value = base_value
+        if parsed.unit is None and base_unit:
+            parsed.unit = base_unit
+        if parsed.op is None:
+            parsed.op = "="
+        if not parsed.ops:
+            parsed.ops.append(parsed.op)
+        if base_unit and base_unit not in parsed.units:
+            parsed.units.append(base_unit)
+        if base_value not in parsed.values:
+            parsed.values.insert(0, base_value)
+
+    range_match = RANGE_RE.search(text)
+    if range_match:
+        low = float(range_match.group("low"))
+        high = float(range_match.group("high"))
+        parsed.range = (low, high)
+        range_unit = range_match.group("unit")
+        if parsed.value is None:
+            parsed.value = low
+        if parsed.unit is None and range_unit:
+            parsed.unit = range_unit
+        if parsed.op is None:
+            parsed.op = "="
+        if not parsed.ops:
+            parsed.ops.append(parsed.op)
+        if range_unit and range_unit not in parsed.units:
+            parsed.units.append(range_unit)
+        if low not in parsed.values:
+            parsed.values.insert(0, low)
     return parsed.to_dict()
 
 

--- a/tests/unit/test_validators_and_extraction.py
+++ b/tests/unit/test_validators_and_extraction.py
@@ -14,6 +14,16 @@ def test_units_and_ops_parsed():
     assert dimension_sanity(parsed["unit"])
 
 
+def test_units_tolerance_and_range_detection():
+    tol = parse_units("Maintain 24 VDC ± 1 V")
+    assert tol["tol"] == 1.0
+    assert tol["unit"].lower() in {"vdc", "v"}
+
+    rng = parse_units("Operate between 50-60 psi under load")
+    assert rng["range"] == (50.0, 60.0)
+    assert rng["unit"].lower() == "psi"
+
+
 def test_extract_inequalities():
     ops = extract_inequalities("Pressure shall be >= 50 psi and <= 80 psi")
     assert ops == [">=", "<="]


### PR DESCRIPTION
## Summary
- expose convenience wrappers on the embedding encoder for lines, sections, and chunks
- carry window/stride metadata on microchunk windows to align with the refactor contract
- extend unit parsing to capture tolerance and range information and add regression tests

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d5ee7257448324a65b2982eb5e98fe