### PR TITLE
Compute micro-chunk E/F/H signals during chunking

### DIFF
--- a/fluidrag/backend/core/chunking/microchunker.py
+++ b/fluidrag/backend/core/chunking/microchunker.py
@@ -1,34 +1,24 @@
 """Micro-chunk generation utilities."""
 from __future__ import annotations
 
+import math
 import re
 from dataclasses import dataclass
 from typing import Iterator, List, Tuple
 
 
 @dataclass
-class ChunkWindow:
-    """Metadata describing a chunk emitted by :func:`microchunk`.
-
-    Attributes
-    ----------
-    start:
-        Character offset of the chunk relative to the section text.
-    end:
-        Exclusive end offset of the chunk relative to the section text.
-    text:
-        The chunk text itself.
-    window_chars:
-        Target window size used when generating the chunk.
-    stride_chars:
-        Configured stride between successive chunks.
-    """
+class Chunk:
+    """Metadata describing a micro-chunk emitted by :func:`chunk`."""
 
     start: int
     end: int
     text: str
     window_chars: int
     stride_chars: int
+    E: float
+    F: float
+    H: float
 
 
 def _split_sentences(text: str) -> List[Tuple[int, str]]:
@@ -47,18 +37,38 @@ def _split_sentences(text: str) -> List[Tuple[int, str]]:
     return sentences
 
 
-def microchunk(
+def _compute_signals(text: str) -> Tuple[float, float, float]:
+    """Compute doc-invariant entropy/flow/heuristic signals for ``text``."""
+
+    tokens = re.findall(r"\w+", text)
+    total = len(tokens) or 1
+    numeric_tokens = len(re.findall(r"\d+(?:\.\d+)?", text))
+    unit_tokens = len(
+        re.findall(
+            r"(mm|cm|m|in|ft|psi|bar|kPa|MPa|A|mA|kA|V|VAC|VDC|kV|kW|kVA|°C|°F|Hz|rpm|N|kN|lbf)",
+            text,
+        )
+    )
+    inequality_count = len(re.findall(r"(≥|<=|≤|>=|=|==|>|<|±)", text))
+    directive_hits = sum(text.lower().count(token) for token in ("shall", "must", "ensure", "provide"))
+
+    entropy_signal = min(1.0, (numeric_tokens / total) + 0.3 * unit_tokens)
+    flow_signal = min(1.0, 0.3 + 0.1 * directive_hits)
+    hep_signal = 1.0 / (1.0 + math.exp(-0.6 * (directive_hits + inequality_count + unit_tokens)))
+
+    filler = text.lower().count("lorem")
+    hep_signal = max(0.0, min(1.0, hep_signal - 0.05 * filler))
+
+    return round(entropy_signal, 4), round(flow_signal, 4), round(hep_signal, 4)
+
+
+def chunk(
     section_text: str,
     *,
     window_chars: int = 450,
     stride_chars: int = 80,
-) -> Iterator[ChunkWindow]:
-    """Yield overlapping window chunks for ``section_text``.
-
-    The implementation prefers to align boundaries to sentence (and simple
-    bullet) edges. Offsets are calculated relative to the raw section text so
-    that downstream provenance can reference the same coordinate system.
-    """
+) -> Iterator[Chunk]:
+    """Yield overlapping window chunks for ``section_text`` with E/F/H signals."""
 
     if not section_text:
         return
@@ -92,12 +102,16 @@ def microchunk(
 
         last_sentence_offset = sentences[end_idx - 1][0]
         end_offset = last_sentence_offset + len(sentences[end_idx - 1][1])
-        yield ChunkWindow(
+        entropy, flow, hep = _compute_signals(chunk_text)
+        yield Chunk(
             start=start_offset,
             end=end_offset,
             text=chunk_text,
             window_chars=window_chars,
             stride_chars=stride_chars,
+            E=entropy,
+            F=flow,
+            H=hep,
         )
 
         if end_idx >= n_sentences:
@@ -109,6 +123,17 @@ def microchunk(
 
         if start_idx == end_idx:
             start_idx += 1
+
+
+def microchunk(
+    section_text: str,
+    *,
+    window_chars: int = 450,
+    stride_chars: int = 80,
+) -> Iterator[Chunk]:
+    """Backward-compatible alias for :func:`chunk`."""
+
+    yield from chunk(section_text, window_chars=window_chars, stride_chars=stride_chars)
 
 
 def iter_microchunks(
@@ -123,4 +148,4 @@ def iter_microchunks(
         yield window.start, window.end, window.text
 
 
-__all__ = ["ChunkWindow", "iter_microchunks", "microchunk"]
+__all__ = ["Chunk", "chunk", "iter_microchunks", "microchunk"]

--- a/fluidrag/backend/core/pipeline.py
+++ b/fluidrag/backend/core/pipeline.py
@@ -28,7 +28,6 @@ from .sectioning.header_score import THRESHOLD, score_candidate
 from .sectioning.section_graph import build_section_graph
 from .sectioning.header_features import compute_features
 from .validators.conflicts import find_conflicts
-from .validators.inequalities import extract_inequalities
 from .validators.units import parse_units
 
 DEFAULT_CONFIG: Dict[str, Mapping[str, object]] = {
@@ -143,21 +142,6 @@ def _lines_for_chunk(offset_map: Sequence[Tuple[int, int, Dict]], start: int, en
             break
         touched.append(line)
     return touched
-
-
-def _chunk_scores(text: str) -> Tuple[float, float, float]:
-    tokens = re.findall(r"\w+", text)
-    total = len(tokens) or 1
-    numeric_tokens = len(re.findall(r"\d+(?:\.\d+)?", text))
-    unit_matches = parse_units(text).get("units", [])
-    inequality_count = len(extract_inequalities(text))
-    directive_hits = sum(text.lower().count(token) for token in ("shall", "must", "ensure", "provide"))
-    entropy_signal = min(1.0, (numeric_tokens / total) + 0.3 * len(unit_matches))
-    flow_signal = min(1.0, 0.3 + 0.1 * directive_hits)
-    hep_signal = 1.0 / (1.0 + math.exp(-0.6 * (directive_hits + inequality_count + len(unit_matches))))
-    filler = text.lower().count("lorem")
-    hep_signal = max(0.0, min(1.0, hep_signal - 0.05 * filler))
-    return round(entropy_signal, 4), round(flow_signal, 4), round(hep_signal, 4)
 
 
 def _serialize_graph(graph: Graph) -> Dict[str, List[Dict]]:
@@ -342,7 +326,6 @@ def run_pipeline(
             bboxes = [line.get("bbox") for line in lines_for_chunk if line.get("bbox")]
             if not bboxes:
                 bboxes = [[0, 0, 0, 0]]
-            entropy, flow, hep = _chunk_scores(window.text)
             chunk_id = f"C-{sec_idx:04d}-{chunk_idx:03d}"
             chunk = {
                 "chunk_id": chunk_id,
@@ -354,9 +337,9 @@ def run_pipeline(
                 "text": window.text,
                 "window_chars": window_chars,
                 "stride_chars": stride_chars,
-                "E": entropy,
-                "F": flow,
-                "H": hep,
+                "E": window.E,
+                "F": window.F,
+                "H": window.H,
                 "provenance": {"bboxes": bboxes},
             }
             chunk_records.append(chunk)

--- a/tests/unit/test_microchunker.py
+++ b/tests/unit/test_microchunker.py
@@ -1,4 +1,4 @@
-from fluidrag.backend.core.chunking.microchunker import iter_microchunks
+from fluidrag.backend.core.chunking.microchunker import chunk, iter_microchunks
 
 
 def test_microchunk_window_and_stride():
@@ -18,3 +18,17 @@ def test_microchunk_prefers_sentence_boundaries():
     text = "The valve shall close. The pump shall stop. The alarm shall sound."
     windows = list(iter_microchunks(text, window_chars=60, stride_chars=20))
     assert all(window_text.endswith(".") for _, _, window_text in windows)
+
+
+def test_chunk_emits_signals():
+    text = (
+        "The system shall maintain 95% uptime. "
+        "Each robot must provide diagnostics. "
+        "Temperature shall stay ≤ 40 °C."
+    )
+    windows = list(chunk(text, window_chars=80, stride_chars=40))
+    assert windows
+    for window in windows:
+        assert 0.0 <= window.E <= 1.0
+        assert 0.0 <= window.F <= 1.0
+        assert 0.0 <= window.H <= 1.0


### PR DESCRIPTION
## Summary
- compute doc-invariant E/F/H metrics inside the microchunker and expose them via a Chunk dataclass
- adjust the pipeline to reuse the precomputed signals when materializing chunk records and extend unit tests to cover the new contract

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5efdd61cc832482278274df3b5c26