### PR TITLE
Add testing instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ python run.py  # starts Flask and opens the frontend
 > Without `OPENROUTER_API_KEY`, network calls fall back to mocked responses so you can exercise the UI end-to-end.
 
 
+## Testing
+
+Run the full backend and integration test suite with `pytest` from the repository root:
+
+```bash
+pytest
+```
+
+All tests should pass without additional configuration when the optional API keys are not provided.
+
+
 ## FluidRAG refactor CLI
 
 The refactored Standard-centric pipeline is available under `fluidrag/src/cli.py` and can be exercised with the following commands:


### PR DESCRIPTION
## Summary
- document how to run the project's full test suite with pytest
- clarify that the tests pass without optional API keys

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5f8e16ed88324ab6a5085e2605f34