### PR TITLE
Add token-aware micro chunker and retrieval guardrails

### DIFF
--- a/backend/chunking/__init__.py
+++ b/backend/chunking/__init__.py
@@ -1,0 +1,18 @@
+"""Chunking utilities."""
+
+from .atomic_chunker import AtomicChunker, MicroChunkConfig
+from .macro_chunker import MacroChunker
+from .token_chunker import (
+    MICRO_MAX_TOKENS,
+    MICRO_OVERLAP_TOKENS,
+    micro_chunks_by_tokens,
+)
+
+__all__ = [
+    "AtomicChunker",
+    "MicroChunkConfig",
+    "MacroChunker",
+    "MICRO_MAX_TOKENS",
+    "MICRO_OVERLAP_TOKENS",
+    "micro_chunks_by_tokens",
+]

--- a/backend/chunking/token_chunker.py
+++ b/backend/chunking/token_chunker.py
@@ -1,0 +1,136 @@
+"""Token-aware chunking helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Dict, List, Tuple
+
+from tokens import encode
+
+MICRO_MAX_TOKENS = 386
+MICRO_OVERLAP_TOKENS = 64
+
+_SENT_SPLIT = re.compile(r"(?<=[\.!\?])\s+(?=[A-Z0-9])")
+
+
+def _sentences(text: str) -> List[str]:
+    """Return a list of roughly sentence-sized strings from ``text``."""
+
+    text = text.strip()
+    if not text:
+        return []
+    return _SENT_SPLIT.split(text)
+
+
+def _window_hard_wrap(tokens: List[int], max_tokens: int) -> List[Tuple[int, int]]:
+    """Yield sliding token windows honouring the configured overlap."""
+
+    spans: List[Tuple[int, int]] = []
+    n = len(tokens)
+    if n == 0:
+        return spans
+    step = max(1, max_tokens - MICRO_OVERLAP_TOKENS)
+    start = 0
+    while start < n:
+        end = min(start + max_tokens, n)
+        spans.append((start, end))
+        if end >= n:
+            break
+        # ensure the next window overlaps the previous one by MICRO_OVERLAP_TOKENS
+        next_start = max(end - MICRO_OVERLAP_TOKENS, start + 1)
+        # guard against pathological cases where max_tokens < overlap
+        if next_start <= start:
+            next_start = start + step
+        start = min(next_start, n)
+    return spans
+
+
+def micro_chunks_by_tokens(doc_text: str) -> List[Dict[str, object]]:
+    """Split ``doc_text`` into <=386 token micro chunks with overlap.
+
+    The function first groups sentences until the budget would be exceeded and
+    falls back to a hard token window when an individual sentence (or merged
+    block) is still oversized. Overlap between consecutive hard-wrapped chunks
+    is maintained to preserve local context.
+    """
+
+    sentences = _sentences(doc_text)
+    chunks: List[Dict[str, object]] = []
+    current_sentences: List[str] = []
+    current_tokens: List[int] = []
+
+    def _flush() -> None:
+        nonlocal current_sentences, current_tokens
+        if not current_sentences:
+            return
+        text = " ".join(current_sentences).strip()
+        toks = encode(text)
+        if len(toks) > MICRO_MAX_TOKENS:
+            spans = _window_hard_wrap(toks, MICRO_MAX_TOKENS)
+            for start, end in spans:
+                chunks.append(
+                    {
+                        "text": text,
+                        "token_count": end - start,
+                        "note": "hard-wrapped window (token spans recorded)",
+                        "token_span": [start, end],
+                    }
+                )
+        else:
+            chunks.append(
+                {
+                    "text": text,
+                    "token_count": len(toks),
+                    "note": "sentence-packed",
+                }
+            )
+        current_sentences = []
+        current_tokens = []
+
+    for sentence in sentences:
+        sentence = sentence.strip()
+        if not sentence:
+            continue
+        sentence_tokens = encode(sentence)
+        if len(sentence_tokens) > MICRO_MAX_TOKENS:
+            _flush()
+            spans = _window_hard_wrap(sentence_tokens, MICRO_MAX_TOKENS)
+            for start, end in spans:
+                chunks.append(
+                    {
+                        "text": sentence,
+                        "token_count": end - start,
+                        "note": "oversize-sentence hard-wrap",
+                        "token_span": [start, end],
+                    }
+                )
+            continue
+        if len(current_tokens) + len(sentence_tokens) > MICRO_MAX_TOKENS:
+            _flush()
+        current_sentences.append(sentence)
+        current_tokens.extend(sentence_tokens)
+        if len(current_tokens) >= MICRO_MAX_TOKENS:
+            _flush()
+
+    _flush()
+    for chunk in chunks:
+        if chunk.get("token_count", 0) > MICRO_MAX_TOKENS:
+            raise AssertionError(
+                f"Chunk exceeds {MICRO_MAX_TOKENS} tokens: {chunk.get('token_count')}"
+            )
+        # attach stable debug helpers
+        text = str(chunk.get("text", ""))
+        chunk.setdefault("text_preview", text[:240])
+        chunk.setdefault(
+            "text_hash",
+            hashlib.sha256(text.encode("utf-8")).hexdigest(),
+        )
+    return chunks
+
+
+__all__ = [
+    "MICRO_MAX_TOKENS",
+    "MICRO_OVERLAP_TOKENS",
+    "micro_chunks_by_tokens",
+]

--- a/backend/compat/payload_adapter.py
+++ b/backend/compat/payload_adapter.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from typing import Dict, Iterable, List
 
+from ..retrieval.utils import trim_context_snippets
+
 
 def _format_bucket(title: str, entries: Iterable[Dict[str, object]]) -> str:
     lines = [title]
@@ -19,10 +21,35 @@ def _format_bucket(title: str, entries: Iterable[Dict[str, object]]) -> str:
     return "\n".join(lines).strip()
 
 
+def _apply_context_budget(
+    context_buckets: Dict[str, List[Dict[str, object]]]
+) -> Dict[str, List[Dict[str, object]]]:
+    ordered: List[tuple[str, Dict[str, object]]] = []
+    for bucket_name in ("Standards", "ProjectSpec", "Risk"):
+        for entry in context_buckets.get(bucket_name, []):
+            ordered.append((bucket_name, dict(entry)))
+    trimmed_texts = trim_context_snippets([entry.get("text", "") for _, entry in ordered])
+    trimmed_buckets: Dict[str, List[Dict[str, object]]] = {
+        key: [] for key in context_buckets
+    }
+    trimmed_buckets.setdefault("Standards", [])
+    trimmed_buckets.setdefault("ProjectSpec", [])
+    trimmed_buckets.setdefault("Risk", [])
+    for bucket_name, entries in context_buckets.items():
+        if bucket_name not in {"Standards", "ProjectSpec", "Risk"}:
+            trimmed_buckets[bucket_name] = [dict(entry) for entry in entries]
+    for (bucket_name, entry), text in zip(ordered, trimmed_texts):
+        new_entry = dict(entry)
+        new_entry["text"] = text
+        trimmed_buckets[bucket_name].append(new_entry)
+    return trimmed_buckets
+
+
 def to_legacy_llm_message(context_buckets: Dict[str, List[Dict[str, object]]], question: str) -> Dict[str, object]:
-    standards = context_buckets.get("Standards", [])
-    project = context_buckets.get("ProjectSpec", [])
-    risk = context_buckets.get("Risk", [])
+    trimmed = _apply_context_budget(context_buckets)
+    standards = trimmed.get("Standards", [])
+    project = trimmed.get("ProjectSpec", [])
+    risk = trimmed.get("Risk", [])
     content_sections = [
         _format_bucket("[Standards]", standards),
         _format_bucket("[ProjectSpec]", project),

--- a/backend/parse/header_page_mode.py
+++ b/backend/parse/header_page_mode.py
@@ -470,6 +470,7 @@ def write_header_candidate_audit(
     results: Iterable[Dict[str, Any]],
     *,
     output_root: Optional[str] = None,
+    debug: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Persist a machine-readable snapshot of header candidate scoring.
 
@@ -599,11 +600,20 @@ def write_header_candidate_audit(
 
         pages_payload.append(page_record)
 
-    report = {
+    report: Dict[str, Any] = {
         "doc": doc_component,
         "threshold": threshold,
         "pages": pages_payload,
     }
+    chunking_debug = None
+    if isinstance(debug, dict):
+        preprocess_debug = debug.get("preprocess")
+        if isinstance(preprocess_debug, dict):
+            chunking_debug = preprocess_debug.get("chunking")
+    if isinstance(chunking_debug, dict):
+        report.setdefault("preprocess", {})["chunking"] = json.loads(
+            json.dumps(chunking_debug, ensure_ascii=False)
+        )
 
     with open(os.path.join(out_dir, "candidate_audit.json"), "w", encoding="utf-8") as fh:
         json.dump(report, fh, ensure_ascii=False, indent=2)

--- a/backend/persistence.py
+++ b/backend/persistence.py
@@ -86,18 +86,22 @@ def save_preprocess_cache(
     response: Dict[str, Any],
     macro_chunks: Optional[list],
     micro_chunks: Optional[list],
+    debug: Optional[Dict[str, Any]] = None,
 ) -> None:
     if not file_hash:
         return
     payload = _load_payload(file_hash)
     payload.setdefault("passes", {})
-    payload["preprocess"] = {
+    entry = {
         "response": response,
         "chunks": macro_chunks or [],
         "macro_chunks": macro_chunks or [],
         "micro_chunks": micro_chunks or [],
         "stored_at": time.time(),
     }
+    if debug:
+        entry["debug"] = debug
+    payload["preprocess"] = entry
     _write_payload(file_hash, payload, filename)
 
 

--- a/backend/pipeline/preprocess.py
+++ b/backend/pipeline/preprocess.py
@@ -489,5 +489,6 @@ async def detect_headers_page_mode(
         doc_tag,
         debug_snapshots,
         results,
+        debug=None,
     )
     return results

--- a/backend/retrieval/utils.py
+++ b/backend/retrieval/utils.py
@@ -6,7 +6,11 @@ import math
 import re
 from typing import Dict, List, Sequence
 
+from tokens import encode
+
 _TOKEN_RE = re.compile(r"[A-Za-z0-9]+(?:\.[A-Za-z0-9]+)?")
+
+MAX_CONTEXT_TOKENS = 3800
 
 
 def tokenize(text: str) -> List[str]:
@@ -37,4 +41,32 @@ def normalize_scores(scores: Dict[str, float]) -> Dict[str, float]:
     return {key: (value - min_v) / scale for key, value in scores.items()}
 
 
-__all__ = ["tokenize", "vectorize_tokens", "normalize_scores"]
+def trim_context_snippets(snippets: Sequence[str]) -> List[str]:
+    total = 0
+    kept: List[str] = []
+    for snippet in snippets:
+        text = snippet or ""
+        token_len = len(encode(text))
+        if total + token_len > MAX_CONTEXT_TOKENS:
+            budget = MAX_CONTEXT_TOKENS - total
+            if budget <= 0:
+                break
+            approx_chars = max(40, budget * 4)
+            text = text[:approx_chars]
+            token_len = len(encode(text))
+            if total + token_len > MAX_CONTEXT_TOKENS:
+                break
+        kept.append(text)
+        total += token_len
+        if total >= MAX_CONTEXT_TOKENS:
+            break
+    return kept
+
+
+__all__ = [
+    "MAX_CONTEXT_TOKENS",
+    "tokenize",
+    "vectorize_tokens",
+    "normalize_scores",
+    "trim_context_snippets",
+]

--- a/backend/routes/headers.py
+++ b/backend/routes/headers.py
@@ -496,6 +496,7 @@ def determine_headers():
                 doc_tag,
                 page_debug_snapshots,
                 results,
+                debug=getattr(session_state, "debug", None),
             )
 
             response_payload = {

--- a/backend/routes/preprocess.py
+++ b/backend/routes/preprocess.py
@@ -9,6 +9,11 @@ from fluidrag.config import load_config
 
 from ..chunking.atomic_chunker import AtomicChunker
 from ..chunking.macro_chunker import MacroChunker
+from ..chunking.token_chunker import (
+    MICRO_MAX_TOKENS,
+    MICRO_OVERLAP_TOKENS,
+    micro_chunks_by_tokens,
+)
 from ..pipeline import preprocess as pp
 from ..persistence import get_preprocess_cache, save_preprocess_cache
 from ..state import get_state
@@ -43,10 +48,13 @@ def preprocess_route():
         if cached:
             cached_macro = [dict(chunk) for chunk in cached.get("macro_chunks") or cached.get("chunks", [])]
             cached_micro = [dict(chunk) for chunk in cached.get("micro_chunks", [])]
+            cached_debug = cached.get("debug") if isinstance(cached, dict) else None
             if state is not None:
                 state.pre_chunks = cached_macro
                 state.macro_chunks = cached_macro
                 state.micro_chunks = cached_micro
+                if isinstance(cached_debug, dict):
+                    state.debug = dict(cached_debug)
             response_payload = dict(cached.get("response") or {})
             response_payload.update(
                 {
@@ -86,6 +94,44 @@ def preprocess_route():
             {"page": idx + 1, "text": text}
             for idx, text in enumerate(pages_linear)
         ]
+
+        joined_text_parts = [
+            str(page.get("text") or "").strip()
+            for page in page_records
+            if page.get("text")
+        ]
+        preprocess_debug: dict = {"preprocess": {}}
+        if joined_text_parts:
+            doc_text = "\n\n".join(joined_text_parts)
+            token_chunks = micro_chunks_by_tokens(doc_text)
+            chunking_payload = {
+                "config": {
+                    "micro_max_tokens": MICRO_MAX_TOKENS,
+                    "micro_overlap_tokens": MICRO_OVERLAP_TOKENS,
+                    "tokenizer": "tiktoken/cl100k_base (fallback est. if unavailable)",
+                },
+                "summary": {
+                    "micro_chunk_count": len(token_chunks),
+                    "total_micro_tokens": sum(
+                        chunk.get("token_count", 0) for chunk in token_chunks
+                    ),
+                },
+                "micro_chunks": [
+                    {
+                        "idx": idx,
+                        "token_count": chunk.get("token_count", 0),
+                        "note": chunk.get("note", ""),
+                        "token_span": chunk.get("token_span"),
+                        "text_preview": chunk.get("text_preview", ""),
+                        "text_hash": chunk.get("text_hash"),
+                    }
+                    for idx, chunk in enumerate(token_chunks)
+                ],
+            }
+            preprocess_debug["preprocess"]["chunking"] = chunking_payload
+        preprocess_debug_payload = (
+            dict(preprocess_debug) if preprocess_debug.get("preprocess") else None
+        )
 
         header_spans = []
         if state is not None and state.headers:
@@ -191,6 +237,11 @@ def preprocess_route():
             state.pre_chunks = macro_chunks
             state.macro_chunks = macro_chunks
             state.micro_chunks = micro_chunks
+            state.debug = (
+                preprocess_debug_payload.copy()
+                if isinstance(preprocess_debug_payload, dict)
+                else None
+            )
 
         resp = {
             "ok": True,
@@ -215,6 +266,7 @@ def preprocess_route():
             store_resp,
             macro_chunks,
             micro_chunks,
+            preprocess_debug_payload,
         )
 
         return response, 200

--- a/backend/state.py
+++ b/backend/state.py
@@ -18,6 +18,7 @@ class PipelineState:
     model: Optional[str] = None
     provider: Optional[str] = None
     headers: Optional[List[Dict[str, Any]]] = None
+    debug: Optional[Dict[str, Any]] = None
     file_hash: Optional[str] = None
 
 PIPELINE_STATES: Dict[str, PipelineState] = {}

--- a/backend/tests/test_header_debug_exports.py
+++ b/backend/tests/test_header_debug_exports.py
@@ -4,6 +4,11 @@ from pathlib import Path
 
 import pytest
 
+from backend.chunking.token_chunker import (
+    MICRO_MAX_TOKENS,
+    MICRO_OVERLAP_TOKENS,
+    micro_chunks_by_tokens,
+)
 from backend.parse.header_config import CONFIG
 from backend.parse.header_page_mode import (
     write_page_debug,
@@ -107,11 +112,37 @@ def test_header_candidate_audit_written_without_debug(tmp_path):
         }
     ]
 
+    text = "Sentence body." * 50
+    token_chunks = micro_chunks_by_tokens(text)
+    chunk_debug = {
+        "config": {
+            "micro_max_tokens": MICRO_MAX_TOKENS,
+            "micro_overlap_tokens": MICRO_OVERLAP_TOKENS,
+            "tokenizer": "unit-test",
+        },
+        "summary": {
+            "micro_chunk_count": len(token_chunks),
+            "total_micro_tokens": sum(chunk["token_count"] for chunk in token_chunks),
+        },
+        "micro_chunks": [
+            {
+                "idx": idx,
+                "token_count": chunk["token_count"],
+                "note": chunk.get("note", ""),
+                "token_span": chunk.get("token_span"),
+                "text_preview": chunk.get("text_preview"),
+                "text_hash": chunk.get("text_hash"),
+            }
+            for idx, chunk in enumerate(token_chunks)
+        ],
+    }
+
     write_header_candidate_audit(
         "Doc Name",
         snapshots,
         results,
         output_root=str(tmp_path),
+        debug={"preprocess": {"chunking": chunk_debug}},
     )
 
     audit_path = Path(tmp_path) / "Doc_Name" / "candidate_audit.json"
@@ -126,3 +157,7 @@ def test_header_candidate_audit_written_without_debug(tmp_path):
     assert any(item.get("selected") for item in candidates)
     ranks = [c.get("rank") for c in candidates]
     assert ranks == sorted(ranks)
+    chunking = data.get("preprocess", {}).get("chunking")
+    assert chunking is not None
+    assert chunking["config"]["micro_max_tokens"] == MICRO_MAX_TOKENS
+    assert chunking["summary"]["micro_chunk_count"] > 0

--- a/backend/tests/test_token_chunker.py
+++ b/backend/tests/test_token_chunker.py
@@ -1,0 +1,39 @@
+from backend.chunking.token_chunker import (
+    MICRO_MAX_TOKENS,
+    MICRO_OVERLAP_TOKENS,
+    micro_chunks_by_tokens,
+)
+from backend.retrieval.utils import MAX_CONTEXT_TOKENS, trim_context_snippets
+
+
+def _total_tokens(snippets):
+    from tokens import encode
+
+    return sum(len(encode(snippet)) for snippet in snippets)
+
+
+def test_micro_chunk_token_limit():
+    text = "Lorem ipsum dolor sit amet, " * 1000
+    chunks = micro_chunks_by_tokens(text)
+    assert chunks, "expected chunks to be produced"
+    assert all(chunk["token_count"] <= MICRO_MAX_TOKENS for chunk in chunks)
+
+
+def test_micro_chunk_overlap_windows():
+    text = "A" * (MICRO_MAX_TOKENS * 5)
+    chunks = micro_chunks_by_tokens(text)
+    spans = [chunk.get("token_span") for chunk in chunks if chunk.get("token_span")]
+    assert spans, "expected hard-wrapped spans"
+    for first, second in zip(spans, spans[1:]):
+        assert first is not None and second is not None
+        assert first[1] >= first[0]
+        assert second[1] >= second[0]
+        assert first[1] - second[0] == MICRO_OVERLAP_TOKENS
+
+
+def test_trim_context_snippets_respects_budget():
+    snippets = ["token budget test " * 200 for _ in range(50)]
+    trimmed = trim_context_snippets(snippets)
+    assert _total_tokens(trimmed) <= MAX_CONTEXT_TOKENS
+    assert len(trimmed) <= len(snippets)
+    assert all(trimmed)

--- a/tokens.py
+++ b/tokens.py
@@ -1,0 +1,34 @@
+"""Tokenizer utilities with optional tiktoken support."""
+from __future__ import annotations
+
+from typing import List
+
+try:
+    import tiktoken  # type: ignore
+
+    _enc = tiktoken.get_encoding("cl100k_base")
+
+    def encode(text: str) -> List[int]:
+        """Encode ``text`` into token IDs using ``tiktoken``.
+
+        Falls back to a deterministic estimate if tiktoken is unavailable.
+        """
+
+        return _enc.encode(text, disallowed_special=())
+
+except Exception:  # pragma: no cover - exercised when tiktoken missing
+
+    def encode(text: str) -> List[int]:
+        """Return a deterministic approximate tokenisation for ``text``.
+
+        ``tiktoken`` is optional in the runtime environment. When it's not
+        installed we approximate tokens assuming roughly four characters per
+        token. The concrete values are irrelevant—callers only rely on the
+        counts and ordering, which remain deterministic for a given input.
+        """
+
+        approx = max(1, len(text) // 4)
+        return list(range(approx))
+
+
+__all__ = ["encode"]


### PR DESCRIPTION
## Summary
- add a shared tokenizer utility and token-aware micro chunker with overlap metadata
- expose chunking debug data through preprocessing state, cache, and candidate audit exports while trimming retrieval context payloads
- cover the new chunking behaviour and audit payload with regression tests

## Testing
- pytest backend/tests/test_token_chunker.py backend/tests/test_header_debug_exports.py

------
https://chatgpt.com/codex/tasks/task_e_68d65b0cedc883248c7092efe15ecc4f