### PR TITLE
Refine UF chunking with EFHG scoring and header sequence repair

### DIFF
--- a/backend/parse/header_sequence_repair.py
+++ b/backend/parse/header_sequence_repair.py
@@ -1,0 +1,441 @@
+"""Aggressive deterministic header sequence repair utilities.
+
+This module implements the *sequence repair* algorithm described in the
+supplementary specification that accompanies the v1.7 header pipeline.  The
+helpers operate on the verified header list emitted by the primary LLM header
+pass and attempt to locate missing numbering entries (for example appendix
+sections like ``A5.`` and ``A6.``) by performing targeted rescans of the
+surrounding text.  The implementation is intentionally self contained so it
+can be invoked directly from :mod:`backend.pipeline.preprocess` without
+introducing a dependency on the legacy "sequence sanity" helpers.
+
+The repair process is conservative – it only searches within the bounded
+window between two verified headers and requires a direct text match inside the
+original page text (either raw or normalised) before emitting a fix.  When a
+header is recovered a structured record describing the provenance is returned
+along with a confidence score so downstream components can audit the
+intervention.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+import re
+from typing import Dict, Iterator, List, Mapping, Optional, Sequence, Tuple
+
+LOGGER = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Normalisation helpers
+
+_DOT_VARIANTS = "\u2024\u2027\uFF0E"
+_SPACE_VARIANTS = "\u00A0\u2002\u2003\u2009\u200A\u202F\u205F\u3000"
+_ZERO_WIDTH = "\u200B\u200C\u200D\uFEFF"
+
+
+def _normalise_spaces(text: str) -> str:
+    for ch in _SPACE_VARIANTS:
+        text = text.replace(ch, " ")
+    for ch in _ZERO_WIDTH:
+        text = text.replace(ch, "")
+    for ch in _DOT_VARIANTS:
+        text = text.replace(ch, ".")
+    return text
+
+
+def _collapse_whitespace(text: str) -> str:
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _normalise(text: str) -> str:
+    return _collapse_whitespace(_normalise_spaces(text or ""))
+
+
+# ---------------------------------------------------------------------------
+# Header label parsing
+
+NUMERIC_RX = re.compile(r"^\s*(\d{1,3})\)\s+(.+?)$")
+APPENDIX_RX = re.compile(
+    r"^\s*([A-Z])(\d{1,3})[.\u2024\u2027\uFF0E](?:\s{0,2}(.+?))?\s*$",
+    re.IGNORECASE,
+)
+ROMAN_RX = re.compile(
+    r"^\s*((?:M{0,4}(?:CM|CD|D?C{0,3})(?:XC|XL|L?X{0,3})(?:IX|IV|V?I{0,3})))\.\s*(.+?)?\s*$",
+    re.IGNORECASE,
+)
+ALPHA_RX = re.compile(r"^\s*([A-Z])\.\s*(.+?)?\s*$", re.IGNORECASE)
+
+
+def _roman_to_int(value: str) -> Optional[int]:
+    if not value:
+        return None
+    numerals = {
+        "M": 1000,
+        "D": 500,
+        "C": 100,
+        "L": 50,
+        "X": 10,
+        "V": 5,
+        "I": 1,
+    }
+    total = 0
+    prev = 0
+    for ch in value.upper():
+        if ch not in numerals:
+            return None
+        val = numerals[ch]
+        if val > prev:
+            total += val - 2 * prev
+        else:
+            total += val
+        prev = val
+    return total
+
+
+@dataclass(frozen=True)
+class _SeriesKey:
+    kind: str
+    prefix: Optional[str]
+
+
+def _classify_header(label: str) -> Optional[Tuple[_SeriesKey, int]]:
+    label = label or ""
+    if not label:
+        return None
+
+    match = APPENDIX_RX.match(label)
+    if match:
+        key = _SeriesKey("APPX", match.group(1).upper())
+        return key, int(match.group(2))
+
+    match = NUMERIC_RX.match(label)
+    if match:
+        key = _SeriesKey("NUM", None)
+        return key, int(match.group(1))
+
+    match = ROMAN_RX.match(label)
+    if match:
+        number = _roman_to_int(match.group(1))
+        if number is not None:
+            key = _SeriesKey("ROMAN", None)
+            return key, number
+
+    match = ALPHA_RX.match(label)
+    if match:
+        key = _SeriesKey("ALPHA", None)
+        return key, ord(match.group(1).upper()) - ord("A") + 1
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Input window representation
+
+
+@dataclass
+class _Window:
+    page_index: int
+    raw_text: str
+    norm_text: str
+    start_char: int
+    end_char: int
+    line_map: List[Tuple[int, int]]
+
+    def slice(self, start: int, end: int) -> str:
+        start = max(self.start_char, start)
+        end = min(self.end_char, end)
+        local_start = max(0, start - self.start_char)
+        local_end = max(0, end - self.start_char)
+        return self.raw_text[local_start:local_end]
+
+
+def _make_windows(
+    before: Mapping[str, object],
+    after: Mapping[str, object],
+    page_texts: Sequence[str],
+    tokens_by_page: Optional[Sequence[Sequence[Mapping[str, object]]]] = None,
+) -> List[_Window]:
+    if not page_texts:
+        return []
+
+    before_page = max(1, int(before.get("page") or 1))
+    after_page = max(1, int(after.get("page") or before_page))
+    start_page = min(before_page, len(page_texts))
+    end_page = min(max(after_page, start_page), len(page_texts))
+
+    windows: List[_Window] = []
+    for page in range(start_page, end_page + 1):
+        text = page_texts[page - 1] if 0 <= page - 1 < len(page_texts) else ""
+        norm = _normalise(text)
+        tokens = tokens_by_page[page - 1] if tokens_by_page and 0 <= page - 1 < len(tokens_by_page) else []
+        spans: List[Tuple[int, int]] = []
+        if tokens:
+            for tok in tokens:
+                start = int(tok.get("char_start") or tok.get("start", 0) or 0)
+                end = int(tok.get("char_end") or tok.get("end", start))
+                spans.append((start, end))
+        else:
+            spans = [(0, len(text))]
+        windows.append(
+            _Window(
+                page_index=page,
+                raw_text=text,
+                norm_text=norm,
+                start_char=0,
+                end_char=len(text),
+                line_map=spans,
+            )
+        )
+    return windows
+
+
+# ---------------------------------------------------------------------------
+# Search strategies
+
+
+def _regex_candidates(window: _Window, pattern: re.Pattern[str]) -> Iterator[Tuple[int, int]]:
+    search_text = _normalise_spaces(window.raw_text)
+    for match in pattern.finditer(search_text):
+        yield match.start(), match.end()
+
+
+def _label_variants(kind: str, prefix: Optional[str], index: int) -> List[str]:
+    if kind == "APPX" and prefix:
+        return [f"{prefix}{index}", f"{prefix}{index}.", f"{prefix} {index}.", f"{prefix}{index} ."]
+    if kind == "NUM":
+        return [f"{index})", f"{index} )"]
+    if kind == "ROMAN":
+        numerals = ["I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X", "XI", "XII", "XIII", "XIV", "XV", "XVI", "XVII", "XVIII", "XIX", "XX"]
+        numeral = numerals[index - 1] if 0 < index <= len(numerals) else None
+        if numeral:
+            return [f"{numeral}."]
+    if kind == "ALPHA":
+        letter = chr(ord("A") + index - 1)
+        return [f"{letter}.", f"{letter} ."]
+    return []
+
+
+def _build_pattern(label_variants: Sequence[str]) -> Optional[re.Pattern[str]]:
+    escaped = []
+    for variant in label_variants:
+        cleaned = re.escape(_normalise(variant))
+        if not cleaned:
+            continue
+        escaped.append(cleaned + r"\s+[^\n]{3,160}")
+    if not escaped:
+        return None
+    pattern = re.compile(r"|".join(f"({alt})" for alt in escaped), re.IGNORECASE | re.DOTALL)
+    return pattern
+
+
+def _verify_candidate(window: _Window, fragment: str) -> Optional[Tuple[int, int]]:
+    raw_norm = _normalise_spaces(window.raw_text)
+    fragment_norm = _normalise(fragment)
+    pos = raw_norm.find(fragment_norm)
+    if pos >= 0:
+        return pos, pos + len(fragment_norm)
+    pos = window.norm_text.find(fragment_norm)
+    if pos >= 0:
+        return pos, pos + len(fragment_norm)
+    return None
+
+
+def _score_repair(
+    *,
+    style_match: bool,
+    position_ok: bool,
+    strict_regex: bool,
+    used_soft_unwrap: bool,
+    used_ocr: bool,
+) -> float:
+    score = 0.2
+    if style_match:
+        score += 0.35
+    if position_ok:
+        score += 0.25
+    if strict_regex:
+        score += 0.20
+    if used_soft_unwrap:
+        score += 0.10
+    if used_ocr:
+        score -= 0.20
+    return max(0.0, min(score, 1.0))
+
+
+def _position_sane(candidate: Mapping[str, object], before: Mapping[str, object], after: Mapping[str, object]) -> bool:
+    page = int(candidate.get("page") or 0)
+    before_page = int(before.get("page") or 0)
+    after_page = int(after.get("page") or 0)
+    if before_page and page < before_page:
+        return False
+    if after_page and page > after_page:
+        return False
+    return True
+
+
+def _make_repair_record(
+    *,
+    level: Optional[int],
+    label: str,
+    text: str,
+    page: int,
+    span: Tuple[int, int],
+    verification: str,
+    confidence: float,
+    provenance: Mapping[str, object],
+) -> Dict[str, object]:
+    return {
+        "level": level,
+        "label": label,
+        "text": text,
+        "page": page,
+        "span": span,
+        "verification": verification,
+        "confidence": round(confidence, 4),
+        "provenance": dict(provenance),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public API
+
+
+def aggressive_sequence_repair(
+    verified_headers: Sequence[Mapping[str, object]],
+    page_texts: Sequence[str],
+    tokens_by_page: Optional[Sequence[Sequence[Mapping[str, object]]]] = None,
+) -> Tuple[List[Mapping[str, object]], List[Mapping[str, object]]]:
+    """Return ``verified_headers`` extended with repaired numbering gaps.
+
+    Parameters
+    ----------
+    verified_headers:
+        The list of headers that passed local verification after the LLM header
+        pass.  Each entry must include ``label`` (header numbering), ``text``,
+        ``page`` and optionally ``level`` and ``span``/``char_span`` metadata.
+    page_texts:
+        Normalised page-level text blobs.  These are used as the search space
+        when attempting to recover missing headers.
+    tokens_by_page:
+        Optional token metadata (line level) to assist with span calculation.
+
+    Returns
+    -------
+    Tuple[List[Mapping], List[Mapping]]
+        The first element is the merged header list sorted by page/span.
+        The second element contains the repair records that were added.
+    """
+
+    if not verified_headers:
+        return list(verified_headers), []
+
+    grouped: Dict[_SeriesKey, List[Mapping[str, object]]] = {}
+    for header in verified_headers:
+        label = str(header.get("label") or header.get("section_number") or "").strip()
+        classified = _classify_header(label)
+        if not classified:
+            continue
+        series, index = classified
+        grouped.setdefault(series, []).append(dict(header, _seq_index=index))
+
+    repairs: List[Mapping[str, object]] = []
+
+    for series_key, items in grouped.items():
+        ordered = sorted(items, key=lambda h: (int(h.get("page") or 0), (h.get("span") or h.get("char_span") or (0, 0))[0]))
+        observed = sorted(set(h["_seq_index"] for h in ordered))
+        if not observed:
+            continue
+
+        gaps: List[int] = []
+        for left, right in zip(observed, observed[1:]):
+            if right - left > 1:
+                gaps.extend(range(left + 1, right))
+
+        if not gaps:
+            continue
+
+        LOGGER.debug("sequence repair: series=%s gaps=%s", series_key, gaps)
+
+        for gap_index in gaps:
+            before = max((h for h in ordered if h["_seq_index"] < gap_index), key=lambda h: h["_seq_index"], default=None)
+            after = min((h for h in ordered if h["_seq_index"] > gap_index), key=lambda h: h["_seq_index"], default=None)
+            if before is None or after is None:
+                continue
+
+            windows = _make_windows(before, after, page_texts, tokens_by_page)
+            label_variants = _label_variants(series_key.kind, series_key.prefix, gap_index)
+            pattern = _build_pattern(label_variants)
+            if not windows or not pattern:
+                continue
+
+            found = False
+            for window in windows:
+                for start, end in _regex_candidates(window, pattern):
+                    fragment = _normalise_spaces(window.raw_text[start:end]).strip()
+                    newline = fragment.find("\n")
+                    if newline >= 0:
+                        fragment = fragment[:newline]
+                    fragment = fragment.strip()
+                    verified = _verify_candidate(window, fragment)
+                    if not verified:
+                        continue
+                    # Map back to raw span by counting characters (best effort)
+                    raw_fragment = fragment
+                    raw_match = window.raw_text.find(raw_fragment)
+                    if raw_match < 0:
+                        raw_match = window.raw_text.find(fragment.replace(" ", ""))
+                    if raw_match < 0:
+                        raw_match = verified[0]
+                    span = (raw_match, raw_match + len(raw_fragment))
+                    candidate_meta = {
+                        "page": window.page_index,
+                        "span": span,
+                    }
+                    if not _position_sane(candidate_meta, before, after):
+                        continue
+                    label = label_variants[0].replace(" ", "") if label_variants else str(gap_index)
+                    label = label if label.endswith(".") or label.endswith(")") else label + "."
+                    confidence = _score_repair(
+                        style_match=bool(before.get("style") or after.get("style")),
+                        position_ok=True,
+                        strict_regex=True,
+                        used_soft_unwrap=False,
+                        used_ocr=False,
+                    )
+                    record = _make_repair_record(
+                        level=before.get("level") or after.get("level"),
+                        label=label,
+                        text=_normalise(fragment).split(" ", 1)[-1] if " " in _normalise(fragment) else _normalise(fragment),
+                        page=window.page_index,
+                        span=span,
+                        verification="repair",
+                        confidence=confidence,
+                        provenance={
+                            "series": series_key.kind,
+                            "index": gap_index,
+                            "neighbors": {
+                                "before": before.get("label"),
+                                "after": after.get("label"),
+                            },
+                            "search": "regex",
+                        },
+                    )
+                    repairs.append(record)
+                    found = True
+                    break
+                if found:
+                    break
+            if not found:
+                LOGGER.debug("sequence repair: failed to locate %s%s", series_key.prefix or "", gap_index)
+
+    if not repairs:
+        return list(verified_headers), []
+
+    merged = list(verified_headers) + repairs
+    merged.sort(key=lambda h: (int(h.get("page") or 0), (h.get("span") or h.get("char_span") or (0, 0))[0]))
+    return merged, repairs
+
+
+__all__ = ["aggressive_sequence_repair"]
+

--- a/backend/pipeline/preprocess.py
+++ b/backend/pipeline/preprocess.py
@@ -17,8 +17,8 @@ from ..parse.header_page_mode import (
     write_header_candidate_audit,
     write_header_debug_manifest,
     write_page_debug,
-    _sequence_sanity_promote,
 )
+from ..parse.header_sequence_repair import aggressive_sequence_repair
 from ..parse.header_detector import is_header_line
 from ..state import get_state
 
@@ -459,13 +459,14 @@ async def detect_headers_page_mode(
             except Exception:
                 pass
 
-        promoted = _sequence_sanity_promote(
-            candidates,
+        merged_headers, repairs = aggressive_sequence_repair(
             final,
-            threshold=float(CONFIG.get("accept_score_threshold", 2.25) or 2.25),
+            page_texts=pages_text,
+            tokens_by_page=pages_tokens,
         )
-        if promoted:
-            final.extend(promoted)
+        if repairs:
+            LOG.debug("sequence repair added %d appendix headers", len(repairs))
+            final = list(merged_headers)
 
         # dedup by line_idx
         seen = set()

--- a/chunking/__init__.py
+++ b/chunking/__init__.py
@@ -1,0 +1,5 @@
+"""Chunking utilities exposed for external callers."""
+
+from .efhg import compute_chunk_scores, run_efhg
+
+__all__ = ["compute_chunk_scores", "run_efhg"]

--- a/chunking/efhg.py
+++ b/chunking/efhg.py
@@ -1,0 +1,254 @@
+"""EFHG scoring over UF chunks.
+
+The module implements a lightweight approximation of the EFHG rail described in
+the system design.  The goal is not to emulate a production-scale graph
+pipeline, but to provide deterministic heuristics that mimic the scoring
+signals.  The helpers operate directly on the UF chunk dictionaries emitted by
+``ingest.microchunker`` and return span descriptors enriched with the per-stage
+sub scores.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple
+
+
+@dataclass
+class _ChunkView:
+    idx: int
+    data: Mapping[str, object]
+    tokens: List[str]
+    entropy: float
+    modalness: float
+    header_weight: float
+    stop_punct: float
+    params: Dict[str, List[str]]
+
+
+def _tokenize(text: str) -> List[str]:
+    text = (text or "").lower()
+    return [tok for tok in text.replace("/", " ").split() if tok]
+
+
+def _entropy(tokens: Iterable[str]) -> float:
+    freq: Dict[str, int] = {}
+    total = 0
+    for tok in tokens:
+        freq[tok] = freq.get(tok, 0) + 1
+        total += 1
+    if total <= 1:
+        return 0.0
+    ent = 0.0
+    for count in freq.values():
+        p = count / total
+        ent -= p * math.log(p + 1e-9, 2)
+    return ent
+
+
+def _modalness(chunk: Mapping[str, object]) -> float:
+    lex = chunk.get("lex")
+    if isinstance(lex, Mapping):
+        flags = lex.get("modal_flags") or []
+        if flags:
+            return min(1.0, len(flags) / 2)
+    text = str(chunk.get("norm_text") or chunk.get("text") or "").lower()
+    hits = sum(1 for term in ("shall", "must", "should", "will") if term in text)
+    return min(1.0, hits / 2)
+
+
+def _header_weight(chunk: Mapping[str, object]) -> float:
+    weight = 0.0
+    if chunk.get("header_anchor"):
+        weight += 0.4
+    if chunk.get("section_id"):
+        weight += 0.4
+    if chunk.get("section_title"):
+        weight += 0.2
+    return min(weight, 1.0)
+
+
+def _terminal_punct(chunk: Mapping[str, object]) -> float:
+    text = str(chunk.get("text") or "").strip()
+    if not text:
+        return 0.0
+    return 1.0 if text.endswith(('.', ';')) else 0.0
+
+
+def _collect_params(chunk: Mapping[str, object]) -> Dict[str, List[str]]:
+    params: Dict[str, List[str]] = {"numbers": [], "units": []}
+    lex = chunk.get("lex")
+    if isinstance(lex, Mapping):
+        for key in ("numbers", "units"):
+            values = lex.get(key)
+            if isinstance(values, list):
+                params[key] = [str(v) for v in values]
+    return params
+
+
+def _prepare_chunks(chunks: Sequence[Mapping[str, object]]) -> List[_ChunkView]:
+    prepared: List[_ChunkView] = []
+    for idx, chunk in enumerate(chunks):
+        tokens = _tokenize(str(chunk.get("norm_text") or chunk.get("text") or ""))
+        ent = _entropy(tokens)
+        modal = _modalness(chunk)
+        header_weight = _header_weight(chunk)
+        stop = _terminal_punct(chunk)
+        params = _collect_params(chunk)
+        prepared.append(
+            _ChunkView(
+                idx=idx,
+                data=chunk,
+                tokens=tokens,
+                entropy=ent,
+                modalness=modal,
+                header_weight=header_weight,
+                stop_punct=stop,
+                params=params,
+            )
+        )
+    return prepared
+
+
+def _delta(values: Sequence[float]) -> List[float]:
+    result: List[float] = []
+    for idx, value in enumerate(values):
+        prev = values[idx - 1] if idx > 0 else value
+        nxt = values[idx + 1] if idx + 1 < len(values) else value
+        result.append((nxt - prev) / 2.0)
+    return result
+
+
+def _capacity(a: _ChunkView, b: _ChunkView) -> float:
+    if a.data.get("page") and b.data.get("page") and a.data.get("page") != b.data.get("page"):
+        return 0.0
+
+    token_overlap = len(set(a.tokens) & set(b.tokens)) / max(1, len(set(a.tokens) | set(b.tokens)))
+
+    style_a = a.data.get("style") if isinstance(a.data.get("style"), Mapping) else {}
+    style_b = b.data.get("style") if isinstance(b.data.get("style"), Mapping) else {}
+    indent_a = float(style_a.get("indent") or 0.0)
+    indent_b = float(style_b.get("indent") or 0.0)
+    indent_gap = abs(indent_a - indent_b)
+    style_score = 1.0 - min(indent_gap / 40.0, 1.0)
+
+    param_overlap = 0.0
+    if a.params["numbers"] and b.params["numbers"]:
+        param_overlap += len(set(a.params["numbers"]) & set(b.params["numbers"]))
+    if a.params["units"] and b.params["units"]:
+        param_overlap += len(set(a.params["units"]) & set(b.params["units"]))
+    param_overlap = min(param_overlap / 4.0, 1.0)
+
+    header_a = a.data.get("section_id") or a.data.get("header_anchor")
+    header_b = b.data.get("section_id") or b.data.get("header_anchor")
+    header_score = 1.0 if header_a and header_a == header_b else 0.2 if header_a and header_b else 0.0
+
+    return max(0.0, min(1.0, 0.8 * token_overlap + 0.4 * style_score + 0.5 * param_overlap + 0.3 * header_score))
+
+
+def compute_chunk_scores(chunks: Sequence[Mapping[str, object]]) -> List[Dict[str, float]]:
+    """Return per chunk E/F start-stop features."""
+
+    prepared = _prepare_chunks(chunks)
+    if not prepared:
+        return []
+
+    entropies = [p.entropy for p in prepared]
+    entropy_delta = _delta(entropies)
+
+    results: List[Dict[str, float]] = []
+    for idx, chunk in enumerate(prepared):
+        start_score = -entropy_delta[idx] + 1.2 * chunk.modalness + 0.8 * chunk.header_weight
+        stop_score = entropy_delta[idx] + chunk.stop_punct + 0.6 * (1.0 - chunk.modalness)
+        results.append(
+            {
+                "S_start": round(start_score, 4),
+                "S_stop": round(stop_score, 4),
+                "entropy": round(chunk.entropy, 4),
+                "modalness": round(chunk.modalness, 4),
+                "header_weight": round(chunk.header_weight, 4),
+                "stop_punct": round(chunk.stop_punct, 4),
+            }
+        )
+    return results
+
+
+def _hep_score(span: Sequence[_ChunkView]) -> float:
+    modal = sum(chunk.modalness for chunk in span)
+    numbers = sum(1 for chunk in span if chunk.params["numbers"])
+    citations = sum(1 for chunk in span if chunk.data.get("lex", {}).get("citation_hint"))
+    actors = sum(1 for chunk in span if "shall" in " ".join(chunk.tokens))
+    ambiguity_penalty = sum(0.3 for chunk in span if "etc" in chunk.tokens or "as" in chunk.tokens)
+    return modal + 0.9 * numbers + 0.6 * citations + 0.8 * bool(actors) - ambiguity_penalty
+
+
+def _graph_penalty(span: Sequence[_ChunkView]) -> float:
+    headers = {chunk.data.get("section_id") for chunk in span if chunk.data.get("section_id")}
+    if len(headers) > 1:
+        return 1.0
+    anchors = {chunk.data.get("header_anchor") for chunk in span if chunk.data.get("header_anchor")}
+    if len(anchors) > 1:
+        return 0.6
+    return 0.0
+
+
+def run_efhg(chunks: Sequence[Mapping[str, object]]) -> List[Dict[str, object]]:
+    """Compute EFHG spans for the provided UF chunks."""
+
+    prepared = _prepare_chunks(chunks)
+    if not prepared:
+        return []
+
+    scores = compute_chunk_scores(chunks)
+    start_scores = [entry["S_start"] for entry in scores]
+    threshold = sorted(start_scores)[max(0, int(len(start_scores) * 0.85) - 1)] if start_scores else 0.0
+
+    spans: List[Dict[str, object]] = []
+    used_indices: set = set()
+
+    for view, metrics in zip(prepared, scores):
+        if metrics["S_start"] < threshold or view.idx in used_indices:
+            continue
+
+        span_chunks: List[_ChunkView] = [view]
+        gain = metrics["S_start"]
+
+        for candidate in prepared[view.idx + 1 :]:
+            if candidate.idx in used_indices:
+                break
+            cap = _capacity(span_chunks[-1], candidate)
+            if cap <= 0.05:
+                break
+            span_chunks.append(candidate)
+            gain += cap
+            if compute_chunk_scores([candidate.data])[0]["S_stop"] > 1.5:
+                break
+
+        hep = _hep_score(span_chunks)
+        graph_penalty = _graph_penalty(span_chunks)
+        total_score = hep + gain - graph_penalty
+        if total_score < 1.5:
+            continue
+
+        used_indices.update(chunk.idx for chunk in span_chunks)
+        span_text = " ".join(chunk.data.get("text", "") for chunk in span_chunks)
+        spans.append(
+            {
+                "start_index": span_chunks[0].idx,
+                "end_index": span_chunks[-1].idx,
+                "score": round(total_score, 4),
+                "E": round(sum(chunk.entropy for chunk in span_chunks) / len(span_chunks), 4),
+                "F": round(gain, 4),
+                "H": round(hep, 4),
+                "G_penalty": round(graph_penalty, 4),
+                "preview": span_text[:120],
+            }
+        )
+
+    spans.sort(key=lambda item: item["score"], reverse=True)
+    return spans
+
+
+__all__ = ["compute_chunk_scores", "run_efhg"]
+

--- a/ingest/microchunker.py
+++ b/ingest/microchunker.py
@@ -19,13 +19,13 @@ from typing import (
 import regex as re
 
 # Default chunk configuration (matches the prompt instructions)
-DEFAULT_CHUNK_SIZE = 386
-DEFAULT_OVERLAP = 96
-BOUNDARY_WINDOW = 32
+DEFAULT_CHUNK_SIZE = 90
+DEFAULT_OVERLAP = 12
+BOUNDARY_WINDOW = 24
 
 
 class MicroChunk(TypedDict, total=False):
-    """Structured metadata emitted for every microchunk."""
+    """Structured metadata emitted for every UF-chunk."""
 
     doc_id: str
     micro_id: str
@@ -45,6 +45,10 @@ class MicroChunk(TypedDict, total=False):
     section_id: Optional[str]
     section_title: Optional[str]
     sequence_index: int
+    style: Dict[str, object]
+    lex: Dict[str, object]
+    emb: List[float]
+    domain_hint: Optional[str]
 
 
 @dataclass
@@ -62,6 +66,11 @@ _SENTENCE_END_RE = re.compile(r"""[.!?]+['")]{0,1}\s*$""")
 _BULLET_RE = re.compile(r"^\s*(?:[-*\u2022\u2023\u2043]|\d+\.|\d+\))\s+")
 _WHITESPACE_RE = re.compile(r"\s+")
 _DEHYPHEN_RE = re.compile(r"(?<=\w)[-\u2010\u2011\u2012\u2013\u2014\u2212]\n(?=\w)")
+_HEADER_MARK_RE = re.compile(r"^\s*(?:\d+\)|[A-Z]\d+\.)")
+_MODAL_TERMS = {"shall", "must", "should", "will"}
+_CITATION_RX = re.compile(r"\b(?:NFPA|ISO|IEC|EN|API|ASTM|\u00a7)\b")
+_UNIT_RX = re.compile(r"\b(?:mm|cm|m|km|in|ft|°c|°f|psi|kpa|bar|hz|rpm|kw|mw|s|ms)\b", re.IGNORECASE)
+_NUMBER_RX = re.compile(r"\b\d+(?:[.,]\d+)?(?:\s*[×x]\s*10\^\d+)?\b")
 
 
 def _normalize_text(text: str) -> str:
@@ -137,6 +146,12 @@ def _candidate_boundaries(doc_text: str, tokens: Sequence[_Token], offsets: Sequ
         if _SENTENCE_END_RE.search(prev_text[-8:]):
             boundaries.add(idx)
             continue
+        # Header markers at the start of the next line
+        line_start = doc_text.rfind("\n", 0, tokens[idx].start) + 1
+        line = doc_text[line_start : tokens[idx].start]
+        if _HEADER_MARK_RE.match(line.strip()):
+            boundaries.add(idx)
+            continue
         # Part boundary alignment
         for start, end, part_idx in offsets:
             if prev_token.end <= end <= tokens[idx].start:
@@ -189,6 +204,74 @@ def _select_metadata(parts: Sequence[Mapping[str, Any]], indices: Sequence[int],
     return ordered[0]
 
 
+def _extract_style(parts: Sequence[Mapping[str, Any]], indices: Sequence[int]) -> Dict[str, object]:
+    if not indices:
+        return {}
+    fonts: List[float] = []
+    bold_votes = 0
+    indents: List[float] = []
+    for idx in indices:
+        part = parts[idx]
+        font = part.get("font_size")
+        if isinstance(font, (int, float)):
+            fonts.append(float(font))
+        if part.get("bold") or part.get("font_weight") == "bold":
+            bold_votes += 1
+        indent = part.get("indent") or part.get("left")
+        try:
+            if indent is not None:
+                indents.append(float(indent))
+        except Exception:
+            continue
+    style: Dict[str, object] = {}
+    if fonts:
+        fonts.sort()
+        mid = len(fonts) // 2
+        style["font_size"] = fonts[mid]
+    if indents:
+        indents.sort()
+        style["indent"] = indents[0]
+    style["bold"] = bold_votes >= max(1, len(indices) // 2)
+    return style
+
+
+def _extract_lex(text: str) -> Dict[str, object]:
+    normalized = _normalize_text(text)
+    tokens = {token.lower() for token in normalized.split()}
+    modal_flags = sorted(term for term in _MODAL_TERMS if term in tokens)
+    numbers = sorted({match.group(0) for match in _NUMBER_RX.finditer(normalized)})
+    units = sorted({match.group(0).lower() for match in _UNIT_RX.finditer(normalized)})
+    citations = bool(_CITATION_RX.search(normalized))
+    return {
+        "modal_flags": modal_flags,
+        "numbers": numbers,
+        "units": units,
+        "citation_hint": citations,
+    }
+
+
+def _compute_embedding(text: str, dims: int = 8) -> List[float]:
+    if not text:
+        return [0.0] * dims
+    digest = hashlib.sha1(text.encode("utf-8")).digest()
+    vector: List[float] = []
+    for idx in range(dims):
+        raw = digest[idx]
+        vector.append(round((raw / 255.0) * 2.0 - 1.0, 6))
+    return vector
+
+
+def _infer_domain_hint(text: str) -> Optional[str]:
+    lowered = text.lower()
+    if any(term in lowered for term in ("safety", "lockout", "ppe")):
+        return "safety"
+    if any(term in lowered for term in ("performance", "efficiency", "load", "torque")):
+        return "performance"
+    if any(term in lowered for term in ("quality", "inspection", "audit")):
+        return "quality"
+    return None
+
+
 def _microchunk_from_window(
     *,
     doc_id: str,
@@ -206,7 +289,7 @@ def _microchunk_from_window(
     end_char = window_tokens[-1].end
     raw_text = doc_text[start_char:end_char]
     norm_text = _normalize_text(raw_text)
-    micro_id = hashlib.sha1(norm_text.encode("utf-8")).hexdigest()[:10]
+    micro_id = "uf-" + hashlib.sha1(norm_text.encode("utf-8")).hexdigest()[:12]
 
     part_indices = sorted({token.part_index for token in window_tokens})
     part_span: Optional[Tuple[int, int]] = None
@@ -256,6 +339,10 @@ def _microchunk_from_window(
         "section_id": _select_metadata(parts, part_indices, "section_id"),
         "section_title": _select_metadata(parts, part_indices, "section_title"),
     }
+    chunk["style"] = _extract_style(parts, part_indices)
+    chunk["lex"] = _extract_lex(raw_text)
+    chunk["emb"] = _compute_embedding(norm_text)
+    chunk["domain_hint"] = _infer_domain_hint(norm_text)
     return chunk
 
 

--- a/tests/test_efhg.py
+++ b/tests/test_efhg.py
@@ -1,0 +1,45 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from chunking.efhg import compute_chunk_scores, run_efhg
+
+
+def _chunk(text: str, section: str | None = None, modal: bool = True) -> dict:
+    lex = {
+        "modal_flags": ["shall"] if modal else [],
+        "numbers": ["95"] if "95" in text else [],
+        "units": ["psi"] if "psi" in text.lower() else [],
+        "citation_hint": "api" in text.lower(),
+    }
+    return {
+        "text": text,
+        "norm_text": text,
+        "page": 2,
+        "section_id": section,
+        "lex": lex,
+        "style": {"indent": 12.0},
+    }
+
+
+def test_compute_chunk_scores_returns_entropy_and_modalness():
+    chunks = [_chunk("The system shall maintain 95 psi pressure."), _chunk("Notes and clarifications.", modal=False)]
+    scores = compute_chunk_scores(chunks)
+    assert len(scores) == 2
+    assert scores[0]["S_start"] > scores[1]["S_start"]
+    assert scores[0]["modalness"] >= scores[1]["modalness"]
+
+
+def test_run_efhg_returns_scored_spans():
+    chunks = [
+        _chunk("1) Scope and purpose.", section="1"),
+        _chunk("The controller shall maintain 95 psi in the accumulator."),
+        _chunk("Sensors must report diagnostics every 10 s."),
+        _chunk("Narrative paragraph without obligations.", modal=False),
+    ]
+    spans = run_efhg(chunks)
+    assert spans, "EFHG should return at least one span"
+    top = spans[0]
+    assert top["score"] >= top["H"]
+    assert 0 <= top["start_index"] <= top["end_index"]

--- a/tests/test_microchunking.py
+++ b/tests/test_microchunking.py
@@ -31,6 +31,9 @@ def test_boundary_alignment_respects_bullets():
     for chunk in chunks[:-1]:
         tail = chunk["text"].strip()
         assert tail.endswith(".") or tail.endswith("stations."), tail
+        assert chunk["style"] is not None
+        assert isinstance(chunk["lex"], dict)
+        assert len(chunk["emb"]) == 8
 
 
 def test_overlap_contains_numeric_phrase():
@@ -59,6 +62,7 @@ def test_section_assignment_selects_correct_section():
     assert "1.0" in mapping
     assert "2.0" in mapping
     assert any(mid for mid in mapping["1.0"] if micros[0]["micro_id"] == mid)
+    assert micros[0]["domain_hint"] in {None, "performance", "quality", "safety"}
 
 
 def test_microchunk_determinism():

--- a/tests/unit/test_header_sequence_repair.py
+++ b/tests/unit/test_header_sequence_repair.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from backend.parse.header_sequence_repair import aggressive_sequence_repair
+
+
+def _header(label: str, text: str, page: int, page_texts: list[str]) -> dict:
+    blob = page_texts[page - 1]
+    target = f"{label} {text}".replace(" .", ".")
+    start = blob.find(target)
+    if start < 0:
+        start = 0
+    return {
+        "label": label,
+        "text": text,
+        "page": page,
+        "span": (start, start + len(target)),
+    }
+
+
+def test_repair_fills_appendix_gap():
+    page_texts = [
+        "",
+        "",
+        "",
+        "",
+        "",
+        "A3. Instrumentation\nA4. Control Panels\nA5. Utilities & Consumption\nA6. Performance",  # page 6
+        "A7. Warranty\nA8. Training",  # page 7
+    ]
+    verified = [
+        _header("A3.", "Instrumentation", 6, page_texts),
+        _header("A4.", "Control Panels", 6, page_texts),
+        _header("A7.", "Warranty", 7, page_texts),
+        _header("A8.", "Training", 7, page_texts),
+    ]
+
+    merged, repairs = aggressive_sequence_repair(verified, page_texts)
+
+    labels = [header["label"] for header in merged]
+    assert "A5." in labels
+    assert "A6." in labels
+    assert len(repairs) == 2
+    confidences = {rep["label"]: rep["confidence"] for rep in repairs}
+    assert confidences["A5."] >= 0.5
+    assert confidences["A6."] >= 0.5
+
+
+def test_repair_skips_when_text_missing():
+    page_texts = ["", "A1. Scope", "A4. Drawings"]
+    verified = [
+        _header("A1.", "Scope", 2, page_texts),
+        _header("A4.", "Drawings", 3, page_texts),
+    ]
+
+    merged, repairs = aggressive_sequence_repair(verified, page_texts)
+    assert merged == verified
+    assert repairs == []


### PR DESCRIPTION
## Summary
- replace the microchunker defaults with UF-scale chunks that emit style, lexical and embedding metadata
- add an EFHG scoring module and unit coverage for both the chunker features and scoring heuristics
- introduce an aggressive header sequence repair helper and wire it into the preprocess pipeline with targeted tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d689879d148324b18aa532db6c2993