### PR TITLE
Enhance header sequence repair for wrapped appendix gaps

### DIFF
--- a/backend/parse/header_sequence_repair.py
+++ b/backend/parse/header_sequence_repair.py
@@ -52,6 +52,31 @@ def _normalise(text: str) -> str:
     return _collapse_whitespace(_normalise_spaces(text or ""))
 
 
+def _normalise_with_map(text: str) -> Tuple[str, List[int]]:
+    """Return a normalised string alongside a map back to raw offsets."""
+
+    cleaned: List[str] = []
+    mapping: List[int] = []
+    last_space = False
+    for idx, char in enumerate(text or ""):
+        if char in _ZERO_WIDTH:
+            continue
+        if char in _SPACE_VARIANTS or char in "\r\n\t":
+            if last_space:
+                continue
+            cleaned.append(" ")
+            mapping.append(idx)
+            last_space = True
+            continue
+        last_space = False
+        if char in _DOT_VARIANTS:
+            cleaned.append(".")
+        else:
+            cleaned.append(char)
+        mapping.append(idx)
+    return "".join(cleaned), mapping
+
+
 # ---------------------------------------------------------------------------
 # Header label parsing
 
@@ -91,6 +116,35 @@ def _roman_to_int(value: str) -> Optional[int]:
             total += val
         prev = val
     return total
+
+
+def _int_to_roman(number: int) -> Optional[str]:
+    if number <= 0:
+        return None
+    mapping = [
+        (1000, "M"),
+        (900, "CM"),
+        (500, "D"),
+        (400, "CD"),
+        (100, "C"),
+        (90, "XC"),
+        (50, "L"),
+        (40, "XL"),
+        (10, "X"),
+        (9, "IX"),
+        (5, "V"),
+        (4, "IV"),
+        (1, "I"),
+    ]
+    result: List[str] = []
+    remainder = number
+    for value, numeral in mapping:
+        while remainder >= value:
+            remainder -= value
+            result.append(numeral)
+        if remainder == 0:
+            break
+    return "".join(result) if result else None
 
 
 @dataclass(frozen=True)
@@ -138,16 +192,58 @@ class _Window:
     page_index: int
     raw_text: str
     norm_text: str
-    start_char: int
-    end_char: int
-    line_map: List[Tuple[int, int]]
+    search_text: str
+    search_map: List[int]
+    base_offset: int
+    lines: List[str]
+    line_spans: List[Tuple[int, int]]
 
-    def slice(self, start: int, end: int) -> str:
-        start = max(self.start_char, start)
-        end = min(self.end_char, end)
-        local_start = max(0, start - self.start_char)
-        local_end = max(0, end - self.start_char)
-        return self.raw_text[local_start:local_end]
+    def absolute_span(self, local_span: Tuple[int, int]) -> Tuple[int, int]:
+        return self.base_offset + local_span[0], self.base_offset + local_span[1]
+
+
+def _page_line_data(text: str) -> Tuple[List[str], List[Tuple[int, int]]]:
+    lines: List[str] = []
+    spans: List[Tuple[int, int]] = []
+    cursor = 0
+    for raw_line in text.splitlines(True):
+        start = cursor
+        cursor += len(raw_line)
+        line = raw_line.rstrip("\r\n")
+        lines.append(line)
+        spans.append((start, cursor))
+    if not lines and text:
+        lines = [text]
+        spans = [(0, len(text))]
+    return lines, spans
+
+
+def _line_index_from_header(header: Mapping[str, object], spans: Sequence[Tuple[int, int]]) -> Optional[int]:
+    if not spans:
+        return None
+    if "line_idx" in header and header.get("line_idx") is not None:
+        try:
+            idx = int(header.get("line_idx"))
+        except Exception:
+            idx = None
+        if idx is not None:
+            return max(0, min(idx, len(spans) - 1))
+    span = header.get("span") or header.get("char_span")
+    if isinstance(span, (list, tuple)) and len(span) >= 2:
+        start_char = int(span[0])
+        for idx, (start, end) in enumerate(spans):
+            if start <= start_char < end:
+                return idx
+        return len(spans) - 1
+    return None
+
+
+def _clip_line_range(lo: int, hi: int, total: int) -> Tuple[int, int]:
+    if total <= 0:
+        return 0, 0
+    lo = max(0, min(lo, total))
+    hi = max(lo, min(hi, total))
+    return lo, hi
 
 
 def _make_windows(
@@ -161,32 +257,62 @@ def _make_windows(
 
     before_page = max(1, int(before.get("page") or 1))
     after_page = max(1, int(after.get("page") or before_page))
-    start_page = min(before_page, len(page_texts))
-    end_page = min(max(after_page, start_page), len(page_texts))
+    before_page = min(before_page, len(page_texts))
+    after_page = min(after_page, len(page_texts))
 
     windows: List[_Window] = []
-    for page in range(start_page, end_page + 1):
-        text = page_texts[page - 1] if 0 <= page - 1 < len(page_texts) else ""
-        norm = _normalise(text)
-        tokens = tokens_by_page[page - 1] if tokens_by_page and 0 <= page - 1 < len(tokens_by_page) else []
-        spans: List[Tuple[int, int]] = []
-        if tokens:
-            for tok in tokens:
-                start = int(tok.get("char_start") or tok.get("start", 0) or 0)
-                end = int(tok.get("char_end") or tok.get("end", start))
-                spans.append((start, end))
+
+    for page in range(before_page, after_page + 1):
+        page_text = page_texts[page - 1] if 0 <= page - 1 < len(page_texts) else ""
+        lines, spans = _page_line_data(page_text)
+        total_lines = len(lines)
+
+        if page == before_page:
+            before_idx = _line_index_from_header(before, spans) or 0
+            start_line = min(before_idx + 1, total_lines)
+            end_line = total_lines if page != after_page else (_line_index_from_header(after, spans) or total_lines)
+            if page == after_page:
+                end_line = max(start_line, end_line)
+            lo = max(0, start_line - 2)
+            hi = min(total_lines, (start_line + 10) if page != after_page else end_line + 2)
+        elif page == after_page:
+            after_idx = _line_index_from_header(after, spans) or total_lines
+            lo = max(0, after_idx - 10)
+            hi = min(total_lines, after_idx + 2)
         else:
-            spans = [(0, len(text))]
+            lo, hi = 0, total_lines
+
+        lo, hi = _clip_line_range(lo, hi, total_lines)
+        if hi <= lo:
+            continue
+
+        start_char = spans[lo][0] if spans else 0
+        end_char = spans[hi - 1][1] if spans else len(page_text)
+        raw_window = page_text[start_char:end_char]
+        search_text, search_map = _normalise_with_map(raw_window)
+        norm_text = _normalise(raw_window)
+
+        window_lines = lines[lo:hi] if lines else []
+        line_spans: List[Tuple[int, int]] = []
+        for idx in range(lo, hi):
+            segment = spans[idx]
+            local_start = max(0, segment[0] - start_char)
+            local_end = max(0, segment[1] - start_char)
+            line_spans.append((local_start, local_end))
+
         windows.append(
             _Window(
                 page_index=page,
-                raw_text=text,
-                norm_text=norm,
-                start_char=0,
-                end_char=len(text),
-                line_map=spans,
+                raw_text=raw_window,
+                norm_text=norm_text,
+                search_text=search_text,
+                search_map=search_map,
+                base_offset=start_char,
+                lines=window_lines,
+                line_spans=line_spans,
             )
         )
+
     return windows
 
 
@@ -194,15 +320,83 @@ def _make_windows(
 # Search strategies
 
 
+@dataclass
+class _SearchResult:
+    fragment: str
+    span: Tuple[int, int]
+    strict_regex: bool
+    used_soft_unwrap: bool
+    used_ocr: bool
+    search: str
+
+
 def _regex_candidates(window: _Window, pattern: re.Pattern[str]) -> Iterator[Tuple[int, int]]:
-    search_text = _normalise_spaces(window.raw_text)
+    search_text = window.search_text
     for match in pattern.finditer(search_text):
         yield match.start(), match.end()
 
 
+def _match_to_result(
+    window: _Window,
+    span: Tuple[int, int],
+    *,
+    search: str,
+    strict: bool,
+    used_soft: bool = False,
+    used_ocr: bool = False,
+) -> Optional[_SearchResult]:
+    start, end = span
+    if end <= start:
+        return None
+    if window.search_map:
+        start_idx = max(0, min(start, len(window.search_map) - 1))
+        end_idx = max(0, min(end - 1, len(window.search_map) - 1))
+        raw_start = window.search_map[start_idx]
+        raw_end = window.search_map[end_idx] + 1
+    else:
+        raw_start = max(0, min(start, len(window.raw_text)))
+        raw_end = max(raw_start + 1, min(end, len(window.raw_text)))
+    if raw_end <= raw_start:
+        return None
+    fragment = window.raw_text[raw_start:raw_end].strip()
+    if not fragment:
+        return None
+    return _SearchResult(
+        fragment=fragment,
+        span=window.absolute_span((raw_start, raw_end)),
+        strict_regex=strict,
+        used_soft_unwrap=used_soft,
+        used_ocr=used_ocr,
+        search=search,
+    )
+
+
+def _raw_span_to_search_span(window: _Window, raw_span: Tuple[int, int]) -> Tuple[int, int]:
+    raw_start, raw_end = raw_span
+    if not window.search_map:
+        return raw_start, raw_end
+    start_idx = 0
+    for idx, value in enumerate(window.search_map):
+        if value >= raw_start:
+            start_idx = idx
+            break
+    else:
+        start_idx = len(window.search_map) - 1
+    end_idx = start_idx
+    for idx in range(start_idx, len(window.search_map)):
+        if window.search_map[idx] >= raw_end:
+            end_idx = idx
+            break
+    else:
+        end_idx = len(window.search_map)
+    if end_idx <= start_idx:
+        end_idx = min(len(window.search_map), start_idx + 1)
+    return start_idx, end_idx
+
+
 def _label_variants(kind: str, prefix: Optional[str], index: int) -> List[str]:
     if kind == "APPX" and prefix:
-        return [f"{prefix}{index}", f"{prefix}{index}.", f"{prefix} {index}.", f"{prefix}{index} ."]
+        return [f"{prefix}{index}.", f"{prefix}{index}", f"{prefix} {index}.", f"{prefix}{index} ."]
     if kind == "NUM":
         return [f"{index})", f"{index} )"]
     if kind == "ROMAN":
@@ -214,6 +408,20 @@ def _label_variants(kind: str, prefix: Optional[str], index: int) -> List[str]:
         letter = chr(ord("A") + index - 1)
         return [f"{letter}.", f"{letter} ."]
     return []
+
+
+def _render_label(series: _SeriesKey, index: int) -> str:
+    if series.kind == "APPX" and series.prefix:
+        return f"{series.prefix}{index}."
+    if series.kind == "NUM":
+        return f"{index})"
+    if series.kind == "ROMAN":
+        numeral = _int_to_roman(index) or str(index)
+        return f"{numeral}."
+    if series.kind == "ALPHA":
+        letter = chr(ord("A") + index - 1)
+        return f"{letter}."
+    return str(index)
 
 
 def _build_pattern(label_variants: Sequence[str]) -> Optional[re.Pattern[str]]:
@@ -229,6 +437,98 @@ def _build_pattern(label_variants: Sequence[str]) -> Optional[re.Pattern[str]]:
     return pattern
 
 
+def _regex_probe(
+    window: _Window,
+    pattern: Optional[re.Pattern[str]],
+    label_variants: Sequence[str],
+) -> Optional[_SearchResult]:
+    if pattern is None:
+        return None
+    for span in _regex_candidates(window, pattern):
+        result = _match_to_result(window, span, search="regex", strict=True)
+        if not result:
+            continue
+        lines = result.fragment.splitlines() or [result.fragment]
+        first_line = lines[0]
+        if not _extract_header_text(first_line, label_variants):
+            continue
+        text = _extract_header_text(result.fragment, label_variants)
+        if not text:
+            continue
+        return result
+    return None
+
+
+def _header_first_segmentation_probe(
+    window: _Window, label_variants: Sequence[str]
+) -> Optional[_SearchResult]:
+    if not window.lines:
+        return None
+    targets = [_normalise(variant) for variant in label_variants]
+    for line, raw_span in zip(window.lines, window.line_spans):
+        normalised_line = _normalise(line)
+        if any(normalised_line.startswith(target) for target in targets):
+            search_span = _raw_span_to_search_span(window, raw_span)
+            result = _match_to_result(window, search_span, search="header_seg", strict=True)
+            if result:
+                return result
+    return None
+
+
+def _soft_unwrap_probe(window: _Window, label_variants: Sequence[str]) -> Optional[_SearchResult]:
+    if not window.lines:
+        return None
+    targets = [_normalise(variant) for variant in label_variants]
+    for idx, (line, raw_span) in enumerate(zip(window.lines, window.line_spans)):
+        normalised_line = _normalise(line)
+        matched = next((target for target in targets if normalised_line.startswith(target)), None)
+        if not matched:
+            continue
+        remainder = normalised_line[len(matched) :].strip()
+        if remainder and len(remainder.split()) > 6:
+            continue
+        if idx + 1 >= len(window.line_spans):
+            continue
+        combined_span = (raw_span[0], window.line_spans[idx + 1][1])
+        search_span = _raw_span_to_search_span(window, combined_span)
+        result = _match_to_result(
+            window,
+            search_span,
+            search="soft_unwrap",
+            strict=True,
+            used_soft=True,
+        )
+        if result:
+            return result
+    return None
+
+
+def _ocr_rescan_probe(
+    window: _Window, label_variants: Sequence[str]
+) -> Optional[_SearchResult]:
+    if not window.search_text:
+        return None
+    lowered = window.search_text.lower()
+    for variant in label_variants:
+        key = _normalise(variant).lower()
+        if not key:
+            continue
+        idx = lowered.find(key)
+        if idx < 0:
+            continue
+        end = min(len(window.search_text), idx + len(key) + 160)
+        result = _match_to_result(
+            window,
+            (idx, end),
+            search="ocr_rescan",
+            strict=False,
+            used_ocr=True,
+        )
+        if result:
+            return result
+    return None
+
+
 def _verify_candidate(window: _Window, fragment: str) -> Optional[Tuple[int, int]]:
     raw_norm = _normalise_spaces(window.raw_text)
     fragment_norm = _normalise(fragment)
@@ -239,6 +539,46 @@ def _verify_candidate(window: _Window, fragment: str) -> Optional[Tuple[int, int
     if pos >= 0:
         return pos, pos + len(fragment_norm)
     return None
+
+
+def _extract_header_text(fragment: str, label_variants: Sequence[str]) -> str:
+    cleaned = fragment.replace("\r", "").strip()
+    if not cleaned:
+        return ""
+    lines = [line.strip() for line in cleaned.split("\n") if line.strip()]
+    if not lines:
+        lines = [cleaned]
+
+    remainder = ""
+    first_line = lines[0]
+    matched_variant = False
+    for variant in label_variants:
+        pattern = re.compile(rf"^\s*{re.escape(variant.strip())}\s*(.+)$", re.IGNORECASE)
+        match = pattern.match(first_line)
+        if match:
+            candidate = match.group(1).strip()
+            if candidate and candidate not in {".", "-", ":"}:
+                matched_variant = True
+                remainder = candidate
+                break
+            # Try the next variant to avoid capturing stray punctuation
+            continue
+    if not matched_variant:
+        parts = _collapse_whitespace(first_line).split(" ", 1)
+        remainder = parts[1] if len(parts) == 2 else ""
+
+    extra_parts: List[str] = []
+    for line in lines[1:]:
+        token = line.split(" ", 1)[0]
+        if _classify_header(token):
+            break
+        extra_parts.append(line)
+
+    pieces = []
+    if remainder:
+        pieces.append(remainder)
+    pieces.extend(extra_parts)
+    return _collapse_whitespace(" ".join(pieces)).strip()
 
 
 def _score_repair(
@@ -358,76 +698,90 @@ def aggressive_sequence_repair(
         LOGGER.debug("sequence repair: series=%s gaps=%s", series_key, gaps)
 
         for gap_index in gaps:
-            before = max((h for h in ordered if h["_seq_index"] < gap_index), key=lambda h: h["_seq_index"], default=None)
-            after = min((h for h in ordered if h["_seq_index"] > gap_index), key=lambda h: h["_seq_index"], default=None)
+            before = max(
+                (h for h in ordered if h["_seq_index"] < gap_index),
+                key=lambda h: h["_seq_index"],
+                default=None,
+            )
+            after = min(
+                (h for h in ordered if h["_seq_index"] > gap_index),
+                key=lambda h: h["_seq_index"],
+                default=None,
+            )
             if before is None or after is None:
                 continue
 
             windows = _make_windows(before, after, page_texts, tokens_by_page)
             label_variants = _label_variants(series_key.kind, series_key.prefix, gap_index)
             pattern = _build_pattern(label_variants)
-            if not windows or not pattern:
+            if not windows or not label_variants:
                 continue
 
-            found = False
+            candidate_result: Optional[_SearchResult] = None
+            chosen_window: Optional[_Window] = None
+            header_text: str = ""
             for window in windows:
-                for start, end in _regex_candidates(window, pattern):
-                    fragment = _normalise_spaces(window.raw_text[start:end]).strip()
-                    newline = fragment.find("\n")
-                    if newline >= 0:
-                        fragment = fragment[:newline]
-                    fragment = fragment.strip()
-                    verified = _verify_candidate(window, fragment)
-                    if not verified:
+                for probe in (
+                    lambda: _regex_probe(window, pattern, label_variants),
+                    lambda: _header_first_segmentation_probe(window, label_variants),
+                    lambda: _soft_unwrap_probe(window, label_variants),
+                    lambda: _ocr_rescan_probe(window, label_variants),
+                ):
+                    candidate = probe()
+                    if not candidate:
                         continue
-                    # Map back to raw span by counting characters (best effort)
-                    raw_fragment = fragment
-                    raw_match = window.raw_text.find(raw_fragment)
-                    if raw_match < 0:
-                        raw_match = window.raw_text.find(fragment.replace(" ", ""))
-                    if raw_match < 0:
-                        raw_match = verified[0]
-                    span = (raw_match, raw_match + len(raw_fragment))
-                    candidate_meta = {
-                        "page": window.page_index,
-                        "span": span,
-                    }
-                    if not _position_sane(candidate_meta, before, after):
+                    if not _verify_candidate(window, candidate.fragment):
                         continue
-                    label = label_variants[0].replace(" ", "") if label_variants else str(gap_index)
-                    label = label if label.endswith(".") or label.endswith(")") else label + "."
-                    confidence = _score_repair(
-                        style_match=bool(before.get("style") or after.get("style")),
-                        position_ok=True,
-                        strict_regex=True,
-                        used_soft_unwrap=False,
-                        used_ocr=False,
-                    )
-                    record = _make_repair_record(
-                        level=before.get("level") or after.get("level"),
-                        label=label,
-                        text=_normalise(fragment).split(" ", 1)[-1] if " " in _normalise(fragment) else _normalise(fragment),
-                        page=window.page_index,
-                        span=span,
-                        verification="repair",
-                        confidence=confidence,
-                        provenance={
-                            "series": series_key.kind,
-                            "index": gap_index,
-                            "neighbors": {
-                                "before": before.get("label"),
-                                "after": after.get("label"),
-                            },
-                            "search": "regex",
-                        },
-                    )
-                    repairs.append(record)
-                    found = True
+                    meta = {"page": window.page_index, "span": candidate.span}
+                    if not _position_sane(meta, before, after):
+                        continue
+                    text = _extract_header_text(candidate.fragment, label_variants).strip()
+                    if not text:
+                        continue
+                    candidate_result = candidate
+                    chosen_window = window
+                    header_text = text
                     break
-                if found:
+                if candidate_result:
                     break
-            if not found:
+
+            if not candidate_result or not chosen_window or not header_text:
                 LOGGER.debug("sequence repair: failed to locate %s%s", series_key.prefix or "", gap_index)
+                continue
+
+            header_label = _render_label(series_key, gap_index)
+            if _normalise(header_text).lower() == _normalise(header_label).lower():
+                LOGGER.debug(
+                    "sequence repair: candidate text empty for %s%s", series_key.prefix or "", gap_index
+                )
+                continue
+
+            confidence = _score_repair(
+                style_match=bool(before.get("style") or after.get("style")),
+                position_ok=True,
+                strict_regex=candidate_result.strict_regex,
+                used_soft_unwrap=candidate_result.used_soft_unwrap,
+                used_ocr=candidate_result.used_ocr,
+            )
+
+            provenance = {
+                "series": series_key.kind,
+                "index": gap_index,
+                "neighbors": {"before": before.get("label"), "after": after.get("label")},
+                "search": candidate_result.search,
+            }
+
+            record = _make_repair_record(
+                level=before.get("level") or after.get("level"),
+                label=header_label,
+                text=header_text,
+                page=chosen_window.page_index,
+                span=candidate_result.span,
+                verification="repair",
+                confidence=confidence,
+                provenance=provenance,
+            )
+            repairs.append(record)
 
     if not repairs:
         return list(verified_headers), []

--- a/tests/unit/test_header_sequence_repair.py
+++ b/tests/unit/test_header_sequence_repair.py
@@ -59,3 +59,25 @@ def test_repair_skips_when_text_missing():
     merged, repairs = aggressive_sequence_repair(verified, page_texts)
     assert merged == verified
     assert repairs == []
+
+
+def test_soft_unwrap_repairs_wrapped_header():
+    page_texts = [
+        "", "", "", "", "",
+        "A3. Instrumentation\nA4. Control Panels\nA5.\nUtilities & Consumption\nA6. Performance",
+        "A7. Warranty\nA8. Training",
+    ]
+    verified = [
+        _header("A3.", "Instrumentation", 6, page_texts),
+        _header("A4.", "Control Panels", 6, page_texts),
+        _header("A7.", "Warranty", 7, page_texts),
+        _header("A8.", "Training", 7, page_texts),
+    ]
+
+    merged, repairs = aggressive_sequence_repair(verified, page_texts)
+
+    labels = [header["label"] for header in merged]
+    assert "A5." in labels
+    wrapped = next(rep for rep in repairs if rep["label"] == "A5.")
+    assert wrapped["text"].lower() == "utilities & consumption"
+    assert wrapped["provenance"]["search"] == "soft_unwrap"


### PR DESCRIPTION
## Summary
- rework the header sequence repair window builder to emit normalised search text, token mapping, and per-line metadata for accurate span mapping
- add dedicated search probes for regex, header segmentation, soft unwrap, and OCR-style rescans with improved text extraction heuristics
- update the gap-closing loop to iterate probe results, score candidates, and persist provenance for recovered headers
- add a unit test that exercises the soft unwrap recovery path for appendix gaps

## Testing
- pytest tests/unit/test_header_sequence_repair.py

------
https://chatgpt.com/codex/tasks/task_e_68d6920462708324a4cac2252094ed1b