### PR TITLE
Align pass chunking with UF pipeline outputs

### DIFF
--- a/backend/pipeline/passes/chunking.py
+++ b/backend/pipeline/passes/chunking.py
@@ -7,7 +7,7 @@ import os
 import re
 
 from datetime import UTC, datetime
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 
 from backend.persistence import get_preprocess_cache
@@ -18,8 +18,9 @@ from backend.utils.strings import s
 
 from backend.domain import PASS_DOMAIN_LEXICON, PASS_DOMAIN_THRESHOLD
 
-from ..fluid import fluid_refine_chunks  # type: ignore[import]
-from ..hep_cluster import hep_cluster_chunks  # type: ignore[import]
+from chunking.efhg import compute_chunk_scores, run_efhg
+
+from ..uf_pipeline import prepare_pass_chunk, run_pipeline as run_uf_pipeline
 from .constants import CHUNK_GROUP_TOKEN_LIMIT
 
 log = logging.getLogger("FluidRAG.chunking")
@@ -211,10 +212,7 @@ def export_pass_stage_snapshots(
 
 
 try:  # pragma: no cover - compatibility shim
-    from ..preprocess import (  # type: ignore[import]
-        approximate_tokens,
-        section_bounded_chunks_from_pdf,
-    )
+    from ..preprocess import approximate_tokens  # type: ignore[import]
 except Exception:  # pragma: no cover - compatibility shim
 
     def approximate_tokens(text: str) -> int:
@@ -224,18 +222,9 @@ except Exception:  # pragma: no cover - compatibility shim
             return 0
         return max(1, len(text) // 4)
 
-    def section_bounded_chunks_from_pdf(
-        pdf_path: str,
-        sidecar_dir: Optional[str] = None,
-        tok_budget_chars: int = 6400,
-        overlap_lines: int = 3,
-        session_id: Optional[str] = None,
-    ) -> Iterable[Dict[str, Any]]:
-        raise RuntimeError("section_bounded_chunks_from_pdf unavailable")
-
 
 def ensure_chunks(session_id: str) -> List[Dict[str, Any]]:
-    """Load or derive chunks for the provided session."""
+    """Load UF chunks for ``session_id`` and enrich them with EFHG metadata."""
 
     state = get_state(session_id)
     if state is None:
@@ -247,66 +236,150 @@ def ensure_chunks(session_id: str) -> List[Dict[str, Any]]:
     except Exception:  # pragma: no cover - defensive
         log.exception("[chunking] failed to ensure sidecar directory %s", sidecar_dir)
 
-    if state.pre_chunks is not None and state.pre_chunks:
-        chunks = [dict(chunk) for chunk in state.pre_chunks]
+    document_name = getattr(state, "filename", None) or "Document"
+    file_hash = getattr(state, "file_hash", None)
+
+    def _normalise_chunks(source: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+        normalized: List[Dict[str, Any]] = []
+        for idx, entry in enumerate(source):
+            normalized.append(prepare_pass_chunk(entry, document=document_name, position=idx))
+        return normalized
+
+    chunks: List[Dict[str, Any]] = []
+
+    if getattr(state, "uf_chunks", None):
+        chunks = _normalise_chunks(state.uf_chunks)
     else:
-        cached_pre = get_preprocess_cache(getattr(state, "file_hash", None))
+        cached_pre = get_preprocess_cache(file_hash)
         if cached_pre:
-            cached_payload = cached_pre.get("macro_chunks") or cached_pre.get("chunks") or []
-            cached_chunks = [dict(chunk) for chunk in cached_payload]
-            state.pre_chunks = cached_chunks
-            chunks = cached_chunks
+            payload = (
+                cached_pre.get("micro_chunks")
+                or cached_pre.get("macro_chunks")
+                or cached_pre.get("chunks")
+                or []
+            )
+            chunks = _normalise_chunks(payload)
+            response_payload = cached_pre.get("response") or {}
+            uf_summary = response_payload.get("uf_pipeline") or cached_pre.get("uf_pipeline")
+            if isinstance(uf_summary, dict):
+                state.uf_pipeline = uf_summary
+            tables_payload = response_payload.get("tables") or cached_pre.get("tables")
+            if isinstance(tables_payload, list):
+                state.uf_tables = tables_payload
+            headers_payload = response_payload.get("headers") or cached_pre.get("headers")
+            if isinstance(headers_payload, list):
+                state.headers = headers_payload
+            debug_payload = cached_pre.get("debug")
+            if isinstance(debug_payload, dict):
+                state.debug = dict(debug_payload)
         else:
-            pdf_path = state.file_path
+            pdf_path = getattr(state, "file_path", None)
             if not pdf_path or not os.path.exists(pdf_path):
                 uploads_dir = os.getenv("UPLOAD_FOLDER", "uploads")
                 pdf_path = os.path.join(uploads_dir, f"{session_id}.pdf")
+            doc_id = os.path.splitext(os.path.basename(pdf_path or ""))[0] or session_id or "document"
+            uf_result = run_uf_pipeline(
+                pdf_path,
+                doc_id=doc_id,
+                session_id=session_id,
+                sidecar_dir=sidecar_dir,
+                llm_client=None,
+            )
             chunks = [
-                dict(chunk)
-                for chunk in section_bounded_chunks_from_pdf(
-                    pdf_path,
-                    sidecar_dir=sidecar_dir,
-                    session_id=session_id,
-                )
+                prepare_pass_chunk(chunk, document=document_name, position=idx)
+                for idx, chunk in enumerate(uf_result.uf_chunks)
             ]
+            state.uf_pipeline = uf_result.summary()
+            state.uf_tables = uf_result.tables
+            state.headers = uf_result.headers.pages
+
+    if not chunks:
+        log.warning("[chunking] UF chunk list is empty for session %s", session_id)
+        state.uf_chunks = []
+        state.standard_section_lookup = {}
+        state.chunk_stage_snapshots = {"uf_chunks": [], "uf_scored": [], "efhg_spans": []}
+        return []
+
+    scores = compute_chunk_scores(chunks)
+    spans = run_efhg(chunks)
+
+    span_membership: Dict[int, List[Dict[str, Any]]] = {}
+    for span in spans:
+        try:
+            start = int(span.get("start_index", -1))
+            end = int(span.get("end_index", -1))
+        except Exception:
+            continue
+        for idx in range(start, end + 1):
+            entry = {k: span.get(k) for k in ("score", "start_index", "end_index", "preview")}
+            entry["span_index"] = spans.index(span)
+            span_membership.setdefault(idx, []).append(entry)
+
+    for idx, (chunk, metrics) in enumerate(zip(chunks, scores)):
+        meta = dict(chunk.get("meta") or {})
+        meta["uf_scores"] = metrics
+        members = span_membership.get(idx, [])
+        if members:
+            best = max(members, key=lambda entry: entry.get("score") or 0.0)
+            meta["efhg_span"] = best
+            meta["efhg_span_memberships"] = members
+        chunk["meta"] = meta
+
+    span_snapshot: List[Dict[str, Any]] = []
+    for span in spans:
+        record = dict(span)
+        members: List[str] = []
+        try:
+            start = int(span.get("start_index", -1))
+            end = int(span.get("end_index", -1))
+        except Exception:
+            start = end = -1
+        for idx in range(start, end + 1):
+            if 0 <= idx < len(chunks):
+                micro_id = chunks[idx].get("micro_id") or chunks[idx].get("chunk_id")
+                if micro_id:
+                    members.append(str(micro_id))
+        record["micro_ids"] = members
+        span_snapshot.append(record)
 
     raw_snapshot = [dict(chunk) for chunk in chunks]
-
-    document_name = state.filename or "Document"
+    scored_snapshot = []
     for chunk in chunks:
-        chunk.setdefault("document", document_name)
-        chunk.setdefault("section_number", chunk.get("section_id") or "")
-        chunk.setdefault("section_name", chunk.get("section_title") or "")
-        chunk.setdefault("page_start", chunk.get("page_start") or chunk.get("page") or 1)
-        chunk.setdefault(
-            "page_end",
-            chunk.get("page_end") or chunk.get("page") or chunk.get("page_start") or 1,
+        score_meta = chunk.get("meta", {}).get("uf_scores", {})
+        scored_snapshot.append(
+            {
+                "chunk_id": chunk.get("chunk_id"),
+                "section_number": chunk.get("section_number"),
+                "section_name": chunk.get("section_name"),
+                "page_start": chunk.get("page_start"),
+                "page_end": chunk.get("page_end"),
+                "meta": {
+                    "uf_scores": score_meta,
+                    "efhg_span": chunk.get("meta", {}).get("efhg_span"),
+                },
+                "text": chunk.get("text"),
+            }
         )
-        chunk.setdefault("text", chunk.get("text", ""))
-        chunk.setdefault("meta", {})
 
-
-    standard_snapshot = [dict(chunk) for chunk in chunks]
-
-    refined = fluid_refine_chunks(chunks)
-    fluid_snapshot = [dict(chunk) for chunk in refined]
-
-    enriched = hep_cluster_chunks(refined)
-    hep_snapshot = [dict(chunk) for chunk in enriched]
-
-    state.refined_chunks = refined
-    state.clustered_chunks = enriched
+    state.uf_chunks = [dict(chunk) for chunk in chunks]
+    state.pre_chunks = [dict(chunk) for chunk in chunks]
+    state.refined_chunks = list(state.uf_chunks)
+    state.clustered_chunks = list(state.uf_chunks)
     state.chunk_stage_snapshots = {
+        "uf_chunks": raw_snapshot,
+        "uf_scored": scored_snapshot,
+        "efhg_spans": span_snapshot,
         "raw_chunking": raw_snapshot,
-        "standard_chunks": standard_snapshot,
-        "fluid_chunks": fluid_snapshot,
-        "hep_chunks": hep_snapshot,
+        "standard_chunks": scored_snapshot,
+        "fluid_chunks": scored_snapshot,
+        "hep_chunks": scored_snapshot,
     }
     try:
-        state.standard_section_lookup = _build_section_lookup(standard_snapshot)
+        state.standard_section_lookup = _build_section_lookup(raw_snapshot)
     except Exception:  # pragma: no cover - defensive
         log.exception("[chunking] failed to build section lookup for session %s", session_id)
-    return enriched
+        state.standard_section_lookup = {}
+    return chunks
 
 
 def chunk_token_len(chunk: Dict[str, Any]) -> int:

--- a/backend/pipeline/uf_pipeline.py
+++ b/backend/pipeline/uf_pipeline.py
@@ -781,5 +781,76 @@ def run_pipeline(
     )
 
 
-__all__ = ["PipelineResult", "run_pipeline"]
+def prepare_pass_chunk(
+    chunk: MicroChunk,
+    *,
+    document: str,
+    position: Optional[int] = None,
+    default_section: str = "Document",
+) -> Dict[str, Any]:
+    """Return a chunk dictionary formatted for downstream passes.
+
+    The helper normalises pagination, section metadata, and ensures a ``meta``
+    container is present.  It intentionally preserves any existing metadata on
+    the source chunk while layering the UF-pipeline specific flags expected by
+    the discipline passes.
+    """
+
+    enriched: Dict[str, Any] = dict(chunk)
+
+    micro_id = enriched.get("micro_id") or enriched.get("chunk_id")
+    if micro_id:
+        enriched["chunk_id"] = str(micro_id)
+
+    enriched["document"] = document or "Document"
+    pages = enriched.get("pages")
+    page_start = page_end = None
+    if isinstance(pages, list) and pages:
+        try:
+            page_start = int(pages[0])
+            page_end = int(pages[-1])
+        except Exception:
+            page_start = page_end = None
+    if page_start is None:
+        page_value = enriched.get("page")
+        try:
+            page_start = int(page_value) if page_value is not None else 1
+        except Exception:
+            page_start = 1
+        try:
+            page_end = int(enriched.get("page_end") or page_start)
+        except Exception:
+            page_end = page_start
+        enriched.setdefault("pages", [page_start])
+    enriched["page_start"] = page_start
+    enriched["page_end"] = page_end if page_end is not None else page_start
+
+    section_number = enriched.get("section_number") or enriched.get("section_id") or ""
+    section_title = (
+        enriched.get("section_title")
+        or enriched.get("section_name")
+        or default_section
+    )
+    enriched["section_number"] = str(section_number) if section_number is not None else ""
+    enriched["section_title"] = section_title
+    enriched["section_name"] = section_title
+
+    sequence_index = enriched.get("sequence_index")
+    try:
+        sequence_index_int = int(sequence_index)
+    except Exception:
+        sequence_index_int = None
+    if sequence_index_int is None and position is not None:
+        sequence_index_int = int(position)
+    enriched["chunk_index_in_section"] = sequence_index_int or 0
+
+    meta = dict(enriched.get("meta") or {})
+    meta.setdefault("uf_pipeline", True)
+    enriched["meta"] = meta
+    enriched.setdefault("chunk_type", "uf")
+
+    return enriched
+
+
+__all__ = ["PipelineResult", "prepare_pass_chunk", "run_pipeline"]
 

--- a/backend/routes/preprocess.py
+++ b/backend/routes/preprocess.py
@@ -16,7 +16,7 @@ from ..chunking.token_chunker import (
     micro_chunks_by_tokens,
 )
 from ..pipeline import preprocess as pp
-from ..pipeline.uf_pipeline import run_pipeline as run_uf_pipeline
+from ..pipeline.uf_pipeline import prepare_pass_chunk, run_pipeline as run_uf_pipeline
 from ..persistence import get_preprocess_cache, save_preprocess_cache
 from ..state import get_state
 
@@ -254,44 +254,10 @@ def preprocess_route():
             preprocess_debug_payload = dict(preprocess_debug_payload)
             preprocess_debug_payload["uf_pipeline"] = uf_debug
 
-        macro_chunks = []
-        for idx, chunk in enumerate(uf_result.uf_chunks):
-            enriched = dict(chunk)
-            micro_id = enriched.get("micro_id")
-            if micro_id:
-                enriched.setdefault("chunk_id", micro_id)
-            enriched.setdefault("document", doc_name)
-            pages = enriched.get("pages")
-            if isinstance(pages, list) and pages:
-                try:
-                    page_start = int(pages[0])
-                except Exception:
-                    page_start = 1
-                try:
-                    page_end = int(pages[-1])
-                except Exception:
-                    page_end = page_start
-            else:
-                page_val = enriched.get("page") or 1
-                page_start = int(page_val)
-                page_end = int(enriched.get("page_end") or page_start)
-                enriched["pages"] = [page_start]
-            enriched["page_start"] = page_start
-            enriched["page_end"] = page_end
-            enriched.setdefault("section_number", enriched.get("section_id") or "")
-            section_title = (
-                enriched.get("section_title")
-                or enriched.get("section_name")
-                or "Document"
-            )
-            enriched["section_title"] = section_title
-            enriched["section_name"] = section_title
-            enriched.setdefault("chunk_index_in_section", enriched.get("sequence_index", idx))
-            enriched.setdefault("chunk_type", "uf")
-            meta = dict(enriched.get("meta") or {})
-            meta.setdefault("uf_pipeline", True)
-            enriched["meta"] = meta
-            macro_chunks.append(enriched)
+        macro_chunks = [
+            prepare_pass_chunk(chunk, document=doc_name, position=idx)
+            for idx, chunk in enumerate(uf_result.uf_chunks)
+        ]
 
         micro_chunks = [dict(chunk) for chunk in macro_chunks]
 

--- a/backend/tests/test_chunk_stage_exports.py
+++ b/backend/tests/test_chunk_stage_exports.py
@@ -22,13 +22,22 @@ def reset_logging(monkeypatch):
 def test_ensure_chunks_records_stage_snapshots(monkeypatch, tmp_path):
     session_id = "sess-stage"
     base_chunk = {
-        "text": "alpha",
+        "micro_id": "uf-001",
+        "text": "The system shall maintain 120 psi pressure at all times.",
+        "norm_text": "The system shall maintain 120 psi pressure at all times.",
         "page": 1,
-        "section_number": "1",
-        "section_name": "Intro",
+        "pages": [1],
+        "section_id": "1",
+        "section_title": "Intro",
+        "sequence_index": 0,
+        "lex": {
+            "modal_flags": ["shall"],
+            "numbers": ["120"],
+            "units": ["psi"],
+        },
     }
     state = SimpleNamespace(
-        pre_chunks=[dict(base_chunk)],
+        uf_chunks=[dict(base_chunk)],
         file_path=str(tmp_path / "doc.pdf"),
         filename="Doc.pdf",
         file_hash="hash123",
@@ -36,8 +45,6 @@ def test_ensure_chunks_records_stage_snapshots(monkeypatch, tmp_path):
     )
 
     monkeypatch.setattr(chunking, "get_state", lambda sid: state if sid == session_id else None)
-    monkeypatch.setattr(chunking, "fluid_refine_chunks", lambda chunks: [dict(chunk, fluid=True) for chunk in chunks])
-    monkeypatch.setattr(chunking, "hep_cluster_chunks", lambda chunks: [dict(chunk, hep=True) for chunk in chunks])
     monkeypatch.setattr(chunking, "get_preprocess_cache", lambda file_hash: None)
     monkeypatch.setattr(chunking.os, "makedirs", lambda path, exist_ok=True: None)
 
@@ -45,36 +52,38 @@ def test_ensure_chunks_records_stage_snapshots(monkeypatch, tmp_path):
 
     assert len(result) == 1
     final_chunk = result[0]
-    assert final_chunk["text"] == "alpha"
-    assert final_chunk["page"] == 1
+    assert final_chunk["document"] == "Doc.pdf"
     assert final_chunk["section_number"] == "1"
     assert final_chunk["section_name"] == "Intro"
-    assert final_chunk["document"] == "Doc.pdf"
     assert final_chunk["page_start"] == 1
     assert final_chunk["page_end"] == 1
-    assert final_chunk["meta"] == {}
-    assert final_chunk["fluid"] is True
-    assert final_chunk["hep"] is True
+    meta = final_chunk.get("meta") or {}
+    assert meta.get("uf_pipeline") is True
+    assert "uf_scores" in meta
     snapshots = state.chunk_stage_snapshots
-    assert set(snapshots) == {
-        "raw_chunking",
-        "standard_chunks",
-        "fluid_chunks",
-        "hep_chunks",
-    }
-    assert "document" not in snapshots["raw_chunking"][0]
-    assert snapshots["standard_chunks"][0]["document"] == "Doc.pdf"
-    assert snapshots["fluid_chunks"][0]["fluid"] is True
-    assert snapshots["hep_chunks"][0]["hep"] is True
+    keys = set(snapshots)
+    assert {"uf_chunks", "uf_scored", "efhg_spans"}.issubset(keys)
+    assert snapshots["uf_chunks"][0]["document"] == "Doc.pdf"
+    assert snapshots["uf_scored"][0]["meta"]["uf_scores"]
+    assert isinstance(snapshots["efhg_spans"], list)
+    assert snapshots["raw_chunking"] == snapshots["uf_chunks"]
+    assert snapshots["standard_chunks"] == snapshots["uf_scored"]
+    assert state.standard_section_lookup
 
 
 def test_export_pass_stage_snapshots_writes_files(monkeypatch, tmp_path):
     session_id = "sess-export"
+    uf_chunks = [{"text": "a", "document": "Doc"}]
+    uf_scored = [{"text": "a", "meta": {"uf_scores": {"S_start": 1.0}}}]
+    spans = [{"score": 2.1, "start_index": 0, "end_index": 0, "micro_ids": ["uf-1"]}]
     stage_map = {
-        "raw_chunking": [{"text": "a"}],
-        "standard_chunks": [{"text": "a", "document": "Doc"}],
-        "fluid_chunks": [{"text": "a", "fluid": True}],
-        "hep_chunks": [{"text": "a", "hep": True}],
+        "uf_chunks": uf_chunks,
+        "uf_scored": uf_scored,
+        "efhg_spans": spans,
+        "raw_chunking": uf_chunks,
+        "standard_chunks": uf_scored,
+        "fluid_chunks": uf_scored,
+        "hep_chunks": uf_scored,
     }
     state = SimpleNamespace(chunk_stage_snapshots=stage_map)
 
@@ -94,11 +103,6 @@ def test_export_pass_stage_snapshots_writes_files(monkeypatch, tmp_path):
 
     data = json.loads(files[0].read_text())
     assert data["pass"] in {"Mechanical", "Header"}
-    assert set(data["stages"]) == {
-        "raw_chunking",
-        "standard_chunks",
-        "fluid_chunks",
-        "hep_chunks",
-    }
-    assert data["stages"]["raw_chunking"]["chunk_count"] == 1
-    assert data["stages"]["hep_chunks"]["chunk_count"] == 1
+    assert {"uf_chunks", "uf_scored", "efhg_spans"}.issubset(set(data["stages"]))
+    assert data["stages"]["uf_chunks"]["chunk_count"] == 1
+    assert data["stages"]["uf_scored"]["chunk_count"] == 1


### PR DESCRIPTION
## Summary
- add `prepare_pass_chunk` helper so downstream consumers share UF chunk formatting
- refactor the pass chunking bootstrap to reuse UF chunks, compute EFHG metadata, and expose updated stage snapshots
- update preprocess routing and chunk stage tests to consume the shared helper and cover the new UF-focused snapshots

## Testing
- `pytest backend/tests/test_chunk_stage_exports.py`


------
https://chatgpt.com/codex/tasks/task_e_68d6972540a88324af39557894fc1dd9