### PR TITLE
Extend UF retrieval to fuse headers and tables with EFHG boosts

### DIFF
--- a/backend/pipeline/uf_pipeline.py
+++ b/backend/pipeline/uf_pipeline.py
@@ -123,6 +123,13 @@ class RetrievalSummary:
     table_count: int
     bm25_path: Optional[Path]
     embedding_path: Optional[Path]
+    header_bm25_path: Optional[Path]
+    header_embedding_path: Optional[Path]
+    table_bm25_path: Optional[Path]
+    table_embedding_path: Optional[Path]
+    span_index_path: Optional[Path]
+    header_doc_path: Optional[Path]
+    table_doc_path: Optional[Path]
 
 
 @dataclass
@@ -654,20 +661,156 @@ def _build_retrieval(
     chunks: Sequence[MicroChunk],
     shards: Sequence[Mapping[str, Any]],
     tables: Sequence[Mapping[str, Any]],
+    spans: Sequence[Mapping[str, Any]],
     *,
     sidecar_dir: Path,
 ) -> RetrievalSummary:
     idx_dir = sidecar_dir / "uf_pipeline" / "indexes"
-    bm25_store = BM25Store(idx_dir / "bm25.pkl")
-    embedding_store = EmbeddingStore(idx_dir / "embeddings.parquet")
-    bm25_store.build(chunks)
-    embedding_store.build(chunks)
+    micro_bm25 = BM25Store(idx_dir / "micro_bm25.pkl")
+    micro_embeddings = EmbeddingStore(idx_dir / "micro_embeddings.parquet")
+    micro_bm25.build(chunks)
+    micro_embeddings.build(chunks)
+
+    chunk_by_id: Dict[str, MicroChunk] = {}
+    for chunk in chunks:
+        micro_id = chunk.get("micro_id")
+        if isinstance(micro_id, str):
+            chunk_by_id[micro_id] = chunk
+
+    header_docs: List[Dict[str, Any]] = []
+    for idx, shard in enumerate(shards):
+        label = str(shard.get("label") or "").strip()
+        text = str(shard.get("text") or "").strip()
+        page = shard.get("page")
+        header_id = f"header-{idx:03d}-p{page}" if page else f"header-{idx:03d}"
+        snippet_parts: List[str] = []
+        for micro_id in shard.get("micro_ids") or []:
+            chunk = chunk_by_id.get(str(micro_id))
+            if not chunk:
+                continue
+            snippet = str(chunk.get("text") or "").strip()
+            if snippet:
+                snippet_parts.append(snippet)
+            if len(snippet_parts) >= 2:
+                break
+        content_parts = [f"{label} {text}".strip()]
+        if snippet_parts:
+            content_parts.append(" ".join(snippet_parts))
+        content = _normalise_text(" ".join(part for part in content_parts if part))
+        header_docs.append(
+            {
+                "micro_id": header_id,
+                "doc_id": chunk_by_id.get(str((shard.get("micro_ids") or [None])[0]), {}).get("doc_id")
+                or shard.get("doc_id")
+                or "header",
+                "text": content,
+                "norm_text": content,
+                "label": label,
+                "page": page,
+                "micro_ids": [str(mid) for mid in shard.get("micro_ids") or []],
+                "shard": dict(shard),
+            }
+        )
+
+    table_docs: List[Dict[str, Any]] = []
+    for table in tables:
+        page = table.get("page")
+        index = table.get("index")
+        table_id = (
+            f"table-{page}-{index}"
+            if page is not None and index is not None
+            else f"table-{len(table_docs):03d}"
+        )
+        rows = table.get("rows") or []
+        row_texts: List[str] = []
+        for row in rows:
+            if not isinstance(row, (list, tuple)):
+                continue
+            row_text = " ".join(str(cell or "").strip() for cell in row if cell)
+            if row_text:
+                row_texts.append(row_text)
+        numbers = " ".join(table.get("numbers") or [])
+        units = " ".join(table.get("units") or [])
+        description = " ".join(
+            part for part in (table.get("title"), table.get("summary")) if part
+        )
+        content = _normalise_text(" ".join(row_texts + [numbers, units, description]))
+        table_docs.append(
+            {
+                "micro_id": table_id,
+                "doc_id": table.get("doc_id") or "table",
+                "text": content,
+                "norm_text": content,
+                "page": page,
+                "index": index,
+                "parameter_supports": [str(mid) for mid in table.get("parameter_supports") or []],
+                "table": dict(table),
+            }
+        )
+
+    header_bm25: Optional[BM25Store] = None
+    header_embeddings: Optional[EmbeddingStore] = None
+    if header_docs:
+        header_bm25 = BM25Store(idx_dir / "header_bm25.pkl")
+        header_embeddings = EmbeddingStore(idx_dir / "header_embeddings.parquet")
+        header_bm25.build(header_docs)
+        header_embeddings.build(header_docs)
+
+    table_bm25: Optional[BM25Store] = None
+    table_embeddings: Optional[EmbeddingStore] = None
+    if table_docs:
+        table_bm25 = BM25Store(idx_dir / "table_bm25.pkl")
+        table_embeddings = EmbeddingStore(idx_dir / "table_embeddings.parquet")
+        table_bm25.build(table_docs)
+        table_embeddings.build(table_docs)
+
+    span_map: Dict[str, Dict[str, Any]] = {}
+    span_records: List[Dict[str, Any]] = []
+    for span_index, span in enumerate(spans):
+        chunk_indices = span.get("chunk_indices") or []
+        for idx_in_span in chunk_indices:
+            try:
+                chunk = chunks[int(idx_in_span)]
+            except (IndexError, ValueError, TypeError):
+                continue
+            micro_id = chunk.get("micro_id")
+            if not micro_id:
+                continue
+            score = float(span.get("score") or 0.0)
+            existing = span_map.get(micro_id)
+            if existing and existing.get("score", 0.0) >= score:
+                continue
+            entry = {
+                "micro_id": micro_id,
+                "span_id": span_index,
+                "score": score,
+                "start_index": span.get("start_index"),
+                "end_index": span.get("end_index"),
+                "E": span.get("E"),
+                "F": span.get("F"),
+                "H": span.get("H"),
+                "G_penalty": span.get("G_penalty"),
+            }
+            span_map[micro_id] = entry
+    span_records.extend(span_map.values())
+
+    header_doc_path = _write_json(sidecar_dir / "uf_pipeline" / "header_docs.json", header_docs)
+    table_doc_path = _write_json(sidecar_dir / "uf_pipeline" / "table_docs.json", table_docs)
+    span_index_path = _write_json(sidecar_dir / "uf_pipeline" / "efhg_span_index.json", span_records)
+
     return RetrievalSummary(
         micro_index_size=len(chunks),
         header_shard_count=sum(1 for shard in shards if shard.get("micro_ids")),
         table_count=len(tables),
-        bm25_path=bm25_store.path if bm25_store.path.exists() else None,
-        embedding_path=embedding_store.path if embedding_store.path.exists() else None,
+        bm25_path=micro_bm25.path if micro_bm25.path.exists() else None,
+        embedding_path=micro_embeddings.path if micro_embeddings.path.exists() else None,
+        header_bm25_path=header_bm25.path if header_bm25 and header_bm25.path.exists() else None,
+        header_embedding_path=header_embeddings.path if header_embeddings and header_embeddings.path.exists() else None,
+        table_bm25_path=table_bm25.path if table_bm25 and table_bm25.path.exists() else None,
+        table_embedding_path=table_embeddings.path if table_embeddings and table_embeddings.path.exists() else None,
+        span_index_path=span_index_path if span_records else None,
+        header_doc_path=header_doc_path if header_docs else None,
+        table_doc_path=table_doc_path if table_docs else None,
     )
 
 
@@ -783,7 +926,13 @@ def run_pipeline(
     header_result = _run_header_pass(ingest, chunks, llm_client=llm_client, sidecar_dir=target_dir)
     table_records = _link_tables_to_chunks(ingest.tables, chunks)
     tables_path = _write_json(target_dir / "uf_pipeline" / "tables.json", table_records)
-    retrieval_summary = _build_retrieval(chunks, header_result.header_shards, table_records, sidecar_dir=target_dir)
+    retrieval_summary = _build_retrieval(
+        chunks,
+        header_result.header_shards,
+        table_records,
+        spans,
+        sidecar_dir=target_dir,
+    )
     chunk_artifacts = _write_chunk_audit(target_dir, chunks, chunk_scores, spans)
 
     artifacts: Dict[str, Path] = {
@@ -792,6 +941,12 @@ def run_pipeline(
         "tables": tables_path,
         **chunk_artifacts,
     }
+    if retrieval_summary.header_doc_path:
+        artifacts["header_docs"] = retrieval_summary.header_doc_path
+    if retrieval_summary.table_doc_path:
+        artifacts["table_docs"] = retrieval_summary.table_doc_path
+    if retrieval_summary.span_index_path:
+        artifacts["efhg_span_index"] = retrieval_summary.span_index_path
     audits = {
         "headers": header_result.audit,
         "tables": table_records,

--- a/retrieval/hybrid.py
+++ b/retrieval/hybrid.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 
 import json
 from collections import Counter, defaultdict
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple
 
 from ingest.microchunker import MicroChunk
 from index import BM25Store, EmbeddingStore
@@ -13,8 +14,30 @@ from index import BM25Store, EmbeddingStore
 RRF_K = 60
 
 
+@dataclass
+class _IndexSet:
+    key: str
+    prefix: str
+    result_type: str
+    bm25: Optional[BM25Store] = None
+    embeddings: Optional[EmbeddingStore] = None
+    docs: Mapping[str, Mapping[str, Any]] = None
+    weight: float = 1.0
+
+    def rank(self, query: str, k: int, rrf_fn) -> List[Tuple[str, float]]:
+        rankings: List[List[str]] = []
+        if self.embeddings:
+            rankings.append([f"{self.prefix}{mid}" for mid, _ in self.embeddings.search(query, k)])
+        if self.bm25:
+            rankings.append([f"{self.prefix}{mid}" for mid, _ in self.bm25.search(query, k)])
+        if not rankings:
+            return []
+        fused = rrf_fn(rankings, k)
+        return [(doc_id, score * self.weight) for doc_id, score in fused]
+
+
 class HybridRetriever:
-    """Combine embedding and lexical rankings using reciprocal rank fusion."""
+    """Combine embedding, header, and table rankings using reciprocal rank fusion."""
 
     def __init__(
         self,
@@ -23,10 +46,15 @@ class HybridRetriever:
         bm25: BM25Store,
         micro_index: Mapping[str, MicroChunk],
         section_map: Optional[Mapping[str, Sequence[str]]] = None,
+        header_embeddings: Optional[EmbeddingStore] = None,
+        header_bm25: Optional[BM25Store] = None,
+        header_docs: Optional[Sequence[Mapping[str, Any]]] = None,
+        table_embeddings: Optional[EmbeddingStore] = None,
+        table_bm25: Optional[BM25Store] = None,
+        table_docs: Optional[Sequence[Mapping[str, Any]]] = None,
+        span_map: Optional[Mapping[str, Mapping[str, Any]]] = None,
         log_path: Optional[Path] = None,
     ) -> None:
-        self.embeddings = embeddings
-        self.bm25 = bm25
         self.micro_index = dict(micro_index)
         self.section_for_micro: Dict[str, Optional[str]] = {}
         for micro_id, micro in self.micro_index.items():
@@ -35,33 +63,155 @@ class HybridRetriever:
             for section_id, micro_ids in section_map.items():
                 for micro_id in micro_ids:
                     self.section_for_micro.setdefault(micro_id, section_id)
+
+        self.span_map: Dict[str, Mapping[str, Any]] = {
+            str(key): value for key, value in (span_map or {}).items()
+        }
+
+        header_mapping = {
+            str(doc.get("micro_id")): dict(doc)
+            for doc in (header_docs or [])
+            if isinstance(doc, Mapping) and doc.get("micro_id")
+        }
+        table_mapping = {
+            str(doc.get("micro_id")): dict(doc)
+            for doc in (table_docs or [])
+            if isinstance(doc, Mapping) and doc.get("micro_id")
+        }
+
+        self.index_sets: Dict[str, _IndexSet] = {
+            "chunk": _IndexSet(
+                key="chunk",
+                prefix="chunk:",
+                result_type="chunk",
+                bm25=bm25,
+                embeddings=embeddings,
+                docs=self.micro_index,
+                weight=1.0,
+            )
+        }
+        if header_embeddings or header_bm25:
+            self.index_sets["header"] = _IndexSet(
+                key="header",
+                prefix="header:",
+                result_type="header",
+                bm25=header_bm25,
+                embeddings=header_embeddings,
+                docs=header_mapping,
+                weight=0.9,
+            )
+        if table_embeddings or table_bm25:
+            self.index_sets["table"] = _IndexSet(
+                key="table",
+                prefix="table:",
+                result_type="table",
+                bm25=table_bm25,
+                embeddings=table_embeddings,
+                docs=table_mapping,
+                weight=0.85,
+            )
+
         self.log_path = Path(log_path) if log_path else None
 
-    def _rrf(self, rankings: Sequence[Sequence[str]], k: int) -> List[str]:
+    def _rrf(self, rankings: Sequence[Sequence[str]], k: int) -> List[Tuple[str, float]]:
         scores: MutableMapping[str, float] = defaultdict(float)
         for ranking in rankings:
-            for rank, micro_id in enumerate(ranking):
-                scores[micro_id] += 1.0 / (RRF_K + rank + 1)
+            for rank, identifier in enumerate(ranking):
+                scores[identifier] += 1.0 / (RRF_K + rank + 1)
         ordered = sorted(scores.items(), key=lambda item: item[1], reverse=True)
-        return [mid for mid, _ in ordered[:k]]
+        return [(doc_id, score) for doc_id, score in ordered[:k]]
 
-    def search(self, query: str, k: int = 40) -> List[str]:
-        embedding_hits = [mid for mid, _ in self.embeddings.search(query, k)]
-        bm25_hits = [mid for mid, _ in self.bm25.search(query, k)]
-        rankings = [hits for hits in (embedding_hits, bm25_hits) if hits]
-        if not rankings:
+    def _span_boost(self, record: Mapping[str, Any], result_type: str) -> float:
+        if not self.span_map:
+            return 0.0
+        candidate_ids: List[str] = []
+        if result_type == "chunk":
+            micro_id = record.get("micro_id") or record.get("chunk_id")
+            if micro_id:
+                candidate_ids.append(str(micro_id))
+        elif result_type == "header":
+            for micro_id in record.get("micro_ids", []):
+                candidate_ids.append(str(micro_id))
+        elif result_type == "table":
+            for micro_id in record.get("parameter_supports", []):
+                candidate_ids.append(str(micro_id))
+        best = 0.0
+        for micro_id in candidate_ids:
+            entry = self.span_map.get(str(micro_id))
+            if not entry:
+                continue
+            score = float(entry.get("score") or 0.0)
+            if score > best:
+                best = score
+        if best <= 0.0:
+            return 0.0
+        return best * 0.05
+
+    def _split_identifier(self, identifier: str) -> Tuple[str, str]:
+        if ":" in identifier:
+            return identifier.split(":", 1)
+        return "chunk", identifier
+
+    def search(self, query: str, k: int = 40) -> List[Dict[str, Any]]:
+        dataset_rankings: List[List[str]] = []
+        dataset_scores: Dict[str, float] = {}
+
+        for dataset in self.index_sets.values():
+            ranking = dataset.rank(query, k, self._rrf)
+            if not ranking:
+                continue
+            dataset_rankings.append([identifier for identifier, _ in ranking])
+            for identifier, score in ranking:
+                dataset_scores[identifier] = max(dataset_scores.get(identifier, 0.0), score)
+
+        if not dataset_rankings:
             return []
-        fused = self._rrf(rankings, k)
-        self._log(query, fused[:k])
-        return fused[:k]
 
-    def _log(self, query: str, micro_ids: Sequence[str]) -> None:
+        fused = self._rrf(dataset_rankings, k)
+        results: List[Dict[str, Any]] = []
+        for identifier, base_score in fused:
+            dataset_key, doc_id = self._split_identifier(identifier)
+            dataset = self.index_sets.get(dataset_key)
+            if not dataset:
+                continue
+            record = dataset.docs.get(doc_id)
+            if not record and dataset.result_type == "chunk":
+                record = self.micro_index.get(doc_id)
+            if not record:
+                continue
+            combined_score = base_score + dataset_scores.get(identifier, 0.0)
+            boost = self._span_boost(record, dataset.result_type)
+            total = combined_score + boost
+            results.append(
+                {
+                    "id": doc_id,
+                    "type": dataset.result_type,
+                    "score": round(total, 6),
+                    "base_score": round(combined_score, 6),
+                    "boost": round(boost, 6),
+                    "record": record,
+                }
+            )
+
+        results.sort(key=lambda item: item["score"], reverse=True)
+        limited = results[:k]
+        self._log(query, limited)
+        return limited
+
+    def _log(self, query: str, results: Sequence[Mapping[str, Any]]) -> None:
         if not self.log_path:
             return
         record = {
             "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
             "query": query,
-            "micro_ids": list(micro_ids),
+            "results": [
+                {
+                    "type": entry.get("type"),
+                    "id": entry.get("id"),
+                    "score": entry.get("score"),
+                }
+                for entry in results
+            ],
         }
         self.log_path.parent.mkdir(parents=True, exist_ok=True)
         with self.log_path.open("a", encoding="utf-8") as handle:

--- a/tests/test_hybrid_retrieval.py
+++ b/tests/test_hybrid_retrieval.py
@@ -48,22 +48,63 @@ def test_rrf_improves_recall(tmp_path: Path, sample_microchunks):
 
     micro_index = {chunk["micro_id"]: chunk for chunk in sample_microchunks}
     section_map = {"11.2": [chunk["micro_id"] for chunk in sample_microchunks if chunk["section_id"] == "11.2"]}
+
+    header_docs = [
+        {
+            "micro_id": "header-000",
+            "text": "1) FAT Performance FAT performance demonstration shall confirm 95 percent availability.",
+            "norm_text": "1) FAT Performance FAT performance demonstration shall confirm 95 percent availability.",
+            "micro_ids": [section_map["11.2"][0]],
+        }
+    ]
+    header_embeddings = EmbeddingStore(tmp_path / "header_embeddings.parquet")
+    header_embeddings.build(header_docs)
+    header_bm25 = BM25Store(tmp_path / "header_bm25.idx")
+    header_bm25.build(header_docs)
+
+    table_docs = [
+        {
+            "micro_id": "table-000",
+            "text": "Speed 120 m/s Availability 95 percent",
+            "norm_text": "Speed 120 m/s Availability 95 percent",
+            "parameter_supports": [section_map["11.2"][0]],
+        }
+    ]
+    table_embeddings = EmbeddingStore(tmp_path / "table_embeddings.parquet")
+    table_embeddings.build(table_docs)
+    table_bm25 = BM25Store(tmp_path / "table_bm25.idx")
+    table_bm25.build(table_docs)
+
+    span_map = {section_map["11.2"][0]: {"score": 3.5}}
+
     hybrid = HybridRetriever(
         embeddings=embeddings,
         bm25=bm25,
         micro_index=micro_index,
         section_map=section_map,
+        header_embeddings=header_embeddings,
+        header_bm25=header_bm25,
+        header_docs=header_docs,
+        table_embeddings=table_embeddings,
+        table_bm25=table_bm25,
+        table_docs=table_docs,
+        span_map=span_map,
         log_path=tmp_path / "retrieval_log.jsonl",
     )
 
     query = "FAT performance availability"
     bm25_top = [mid for mid, _ in bm25.search(query, k=1)]
     emb_top = [mid for mid, _ in embeddings.search(query, k=1)]
-    fused = hybrid.search(query, k=3)
+    fused = hybrid.search(query, k=5)
 
-    assert emb_top[0] in fused
+    chunk_results = [res for res in fused if res["type"] == "chunk"]
+    chunk_ids = [res["id"] for res in chunk_results]
+    assert emb_top[0] in chunk_ids
     if bm25_top and bm25_top[0] not in emb_top:
-        assert bm25_top[0] in fused
+        assert bm25_top[0] in chunk_ids
+    assert any(res["type"] == "header" for res in fused)
+    assert any(res["type"] == "table" for res in fused)
+    assert chunk_results and chunk_results[0]["boost"] > 0.0
 
 
 def test_section_density_rerank_clusters_results(sample_microchunks):

--- a/tools/section_map_and_refine.py
+++ b/tools/section_map_and_refine.py
@@ -8,7 +8,7 @@ import math
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 import pandas as pd
 from jsonschema import ValidationError, validate
@@ -292,7 +292,11 @@ class MicrochunkContextBuilder:
         section_id = section.section_id if section else None
 
         if not candidate_ids:
-            results = self.hybrid.search(specification, k=40)
+            retrieval_results = self.hybrid.search(specification, k=40)
+            if retrieval_results and isinstance(retrieval_results[0], Mapping):
+                results = [res["id"] for res in retrieval_results if res.get("type") == "chunk"]
+            else:
+                results = list(retrieval_results)
             if doc_id:
                 filtered = [mid for mid in results if self.micro_index.get(mid, {}).get("doc_id") == doc_id]
                 if filtered:


### PR DESCRIPTION
## Summary
- extend the UF pipeline to persist header/table retrieval docs, EFHG span metadata, and index paths
- enhance the hybrid retriever to RRF fuse chunk, header, and table hits with EFHG-based boosting
- update the section refinement helper and retrieval unit tests for the richer result metadata

## Testing
- pytest tests/test_hybrid_retrieval.py tests/test_uf_pipeline.py tests/unit/test_header_sequence_repair.py

------
https://chatgpt.com/codex/tasks/task_e_68d6afcb605883248a71bb4ff3136f54