### PR TITLE
Align stage utilities with UF chunking spec

### DIFF
--- a/backend/chunking/token_chunker.py
+++ b/backend/chunking/token_chunker.py
@@ -8,8 +8,8 @@ from typing import Dict, List, Tuple
 
 from tokens import encode
 
-MICRO_MAX_TOKENS = 386
-MICRO_OVERLAP_TOKENS = 64
+MICRO_MAX_TOKENS = 90
+MICRO_OVERLAP_TOKENS = 12
 
 _SENT_SPLIT = re.compile(r"(?<=[\.!\?])\s+(?=[A-Z0-9])")
 
@@ -47,7 +47,7 @@ def _window_hard_wrap(tokens: List[int], max_tokens: int) -> List[Tuple[int, int
 
 
 def micro_chunks_by_tokens(doc_text: str) -> List[Dict[str, object]]:
-    """Split ``doc_text`` into <=386 token micro chunks with overlap.
+    """Split ``doc_text`` into <=90 token UF micro-chunks with overlap.
 
     The function first groups sentences until the budget would be exceeded and
     falls back to a hard token window when an individual sentence (or merged

--- a/stages/build_stages.py
+++ b/stages/build_stages.py
@@ -49,10 +49,14 @@ def build_stage_payload(
     doc_id: str,
     stage_chunks: Sequence[Mapping[str, object]],
     *,
-    token_size: int = 386,
-    overlap: int = 96,
+    token_size: int = 90,
+    overlap: int = 12,
 ) -> StageBuildResult:
-    """Return a stage payload extended with microchunks and section groups."""
+    """Return a stage payload extended with UF microchunks and section groups.
+
+    The defaults mirror the UF specification (≤90 token windows with ~12 token
+    overlap) so that stage builds are consistent with the end-to-end pipeline.
+    """
 
     enriched_chunks: List[Dict[str, object]] = []
     for chunk in stage_chunks:

--- a/tools/microchunk_build.py
+++ b/tools/microchunk_build.py
@@ -70,8 +70,18 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Build microchunk artifacts from stage JSON files")
     parser.add_argument("--docs", type=Path, required=True, help="Directory containing staged JSON files")
     parser.add_argument("--out-dir", type=Path, required=True, help="Directory to write cache artifacts")
-    parser.add_argument("--token-size", type=int, default=386, help="Target microchunk token size")
-    parser.add_argument("--overlap", type=int, default=96, help="Token overlap between adjacent microchunks")
+    parser.add_argument(
+        "--token-size",
+        type=int,
+        default=90,
+        help="Target UF microchunk token size (default: 90)",
+    )
+    parser.add_argument(
+        "--overlap",
+        type=int,
+        default=12,
+        help="Token overlap between adjacent UF microchunks (default: 12)",
+    )
     return parser.parse_args(argv)
 
 


### PR DESCRIPTION
## Summary
- update the shared token chunker constants to match the ≤90 token UF window spec
- default stage microchunk builds and tooling to the UF chunk size/overlap and clarify the docstring

## Testing
- `pytest backend/tests/test_token_chunker.py tests/test_stage_microchunk_debug.py`


------
https://chatgpt.com/codex/tasks/task_e_68d6b32abe208324b921b67c0a54c880