### PR TITLE
Implement UF-only EFHG header stitching with enhanced logging

### DIFF
--- a/backend/efhg/fluid.py
+++ b/backend/efhg/fluid.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, List, Tuple
+from typing import Dict, List, Mapping, Sequence, Tuple
 
 from backend.rag.embeddings import cosine
 from backend.uf_chunker import UFChunk
@@ -76,14 +76,18 @@ def build_edges(uf_chunks: List[UFChunk], params: Dict[str, float] | None = None
     return edges
 
 
-def _span_text(chunks: List[UFChunk], chunk_ids: List[str]) -> Tuple[str, Tuple[int, int], int]:
-    chunk_lookup = {chunk.id: chunk for chunk in chunks}
+def _span_text(chunk_lookup: Mapping[str, UFChunk], chunk_ids: Sequence[str]) -> Tuple[str, Tuple[int, int], int]:
     selected = [chunk_lookup[cid] for cid in chunk_ids]
     text = " ".join(chunk.text.strip() for chunk in selected).strip()
     start = selected[0].span_char[0]
     end = selected[-1].span_char[1]
     page = selected[0].page
     return text, (start, end), page
+
+
+def span_from_chunk_ids(chunk_lookup: Mapping[str, UFChunk], chunk_ids: Sequence[str]) -> Span:
+    text, span, page = _span_text(chunk_lookup, chunk_ids)
+    return Span(chunk_ids=list(chunk_ids), text=text, page=page, span=span, flow_total=0.0)
 
 
 def grow_span_from_seed(
@@ -100,23 +104,39 @@ def grow_span_from_seed(
         raise ValueError(f"Unknown seed chunk {seed_id}")
     idx = ordered_ids.index(seed_id)
     chain = [seed_id]
-    flow_total = 0.0
+    marginals: List[Tuple[str, float]] = []
     current_id = seed_id
     while idx + 1 < len(ordered_ids):
         next_id = ordered_ids[idx + 1]
-        edge_key = (current_id, next_id)
-        capacity = edges.get(edge_key, 0.0)
+        if stop_scores.get(next_id, 0.0) >= params["theta_end"]:
+            break
+        capacity = edges.get((current_id, next_id), 0.0)
         marginal = capacity - params["lambda"]
         if marginal < params["tau"]:
             break
-        if stop_scores.get(next_id, 0.0) >= params["theta_end"]:
-            break
-        flow_total += marginal
-        chain.append(next_id)
+        marginals.append((next_id, marginal))
         current_id = next_id
         idx += 1
-    text, span, page = _span_text(uf_chunks, chain)
-    return Span(chunk_ids=chain, text=text, page=page, span=span, flow_total=flow_total)
+
+    best_total = 0.0
+    best_end = -1
+    running_total = 0.0
+    running_start = 0
+    best_start = 0
+    for i, (_, marginal) in enumerate(marginals):
+        running_total += marginal
+        if running_total > best_total:
+            best_total = running_total
+            best_end = i
+            best_start = running_start
+        if running_total < 0:
+            running_total = 0.0
+            running_start = i + 1
+
+    if best_end >= 0:
+        chain.extend(cid for cid, _ in marginals[best_start : best_end + 1])
+    text, span, page = _span_text(chunk_lookup, chain)
+    return Span(chunk_ids=chain, text=text, page=page, span=span, flow_total=best_total)
 
 
-__all__ = ["Span", "build_edges", "grow_span_from_seed", "DEFAULT_PARAMS"]
+__all__ = ["Span", "build_edges", "grow_span_from_seed", "span_from_chunk_ids", "DEFAULT_PARAMS"]

--- a/backend/efhg/graph_gate.py
+++ b/backend/efhg/graph_gate.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, List, Tuple
+from typing import Dict, List, Sequence, Tuple
 
-from backend.efhg.fluid import Span
-from backend.uf_chunker import UFChunk
+from backend.efhg.fluid import Span, span_from_chunk_ids
+from backend.uf_chunker import HEADER_PATTERN, UFChunk
 
 DEFAULT_PARAMS = {
     "wH": 1.0,
@@ -21,9 +21,10 @@ class GraphContext:
     headers: List[Dict[str, object]]
     references: List[Dict[str, object]]
     tables: List[Dict[str, object]]
+    domain: str | None = None
 
 
-def _dominant_header(span: Span, chunks: Dict[str, UFChunk], headers: List[Dict[str, object]]) -> Tuple[str | None, float]:
+def _dominant_header(span: Span, chunks: Dict[str, UFChunk], headers: Sequence[Dict[str, object]]) -> Tuple[str | None, float]:
     if not headers:
         return None, 0.0
     best = None
@@ -42,12 +43,22 @@ def _dominant_header(span: Span, chunks: Dict[str, UFChunk], headers: List[Dict[
     return best.get("label"), best_overlap
 
 
+def _collect_domain_hints(span: Span, chunks: Dict[str, UFChunk]) -> List[str]:
+    hints: List[str] = []
+    for cid in span.chunk_ids:
+        hint = chunks[cid].domain_hint
+        if hint:
+            hints.append(hint)
+    return hints
+
+
 def score_graph(span: Span, header_ctx: GraphContext, chunks: Dict[str, UFChunk], params: Dict[str, float] | None = None) -> Tuple[float, Dict[str, float]]:
     params = params or DEFAULT_PARAMS
     penalties = {
         "header_mismatch": 0.0,
         "domain_conflict": 0.0,
         "reference_gap": 0.0,
+        "cross_bleed": 0.0,
     }
     dominant_label, overlap = _dominant_header(span, chunks, header_ctx.headers)
     header_score = params["wH"] * (1.0 if dominant_label else 0.0)
@@ -57,23 +68,58 @@ def score_graph(span: Span, header_ctx: GraphContext, chunks: Dict[str, UFChunk]
     ref_score = params["wR"] * (1.0 if header_ctx.references else 0.5)
     table_score = params["wC"] * (1.0 if header_ctx.tables else 0.4)
     penalties["header_mismatch"] = 0.0 if dominant_label else 0.6
+
+    domain_hints = _collect_domain_hints(span, chunks)
+    if header_ctx.domain and domain_hints and header_ctx.domain not in domain_hints:
+        penalties["domain_conflict"] = 0.5
+
+    if dominant_label and any(
+        HEADER_PATTERN.match(chunks[cid].text.strip().splitlines()[0]) and cid != span.chunk_ids[0]
+        for cid in span.chunk_ids
+    ):
+        penalties["cross_bleed"] = 0.4
+
+    if dominant_label and header_ctx.references and not any(chunks[cid].lex.get("citation_hints") for cid in span.chunk_ids):
+        penalties["reference_gap"] = 0.3
+
     score = header_score + domain_score + param_score + ref_score + table_score - sum(penalties.values())
     return score, penalties
 
 
 def snap_and_trim(span: Span, header_ctx: GraphContext, chunks: Dict[str, UFChunk]) -> Span:
     dominant_label, _ = _dominant_header(span, chunks, header_ctx.headers)
-    if not dominant_label:
-        return span
-    header_spans = [h for h in header_ctx.headers if h.get("label") == dominant_label]
-    if not header_spans:
-        return span
-    header_span = header_spans[0]
-    h_start, h_end = header_span.get("span", span.span)
-    s_start, s_end = span.span
-    new_start = max(h_start, s_start)
-    new_end = min(h_end + 400, s_end)
-    return Span(chunk_ids=span.chunk_ids, text=span.text, page=span.page, span=(new_start, new_end), flow_total=span.flow_total)
+    chunk_ids = list(span.chunk_ids)
+    if dominant_label:
+        for idx, cid in enumerate(chunk_ids[1:], start=1):
+            chunk = chunks[cid]
+            first_line = chunk.text.strip().splitlines()[0] if chunk.text.strip() else ""
+            if HEADER_PATTERN.match(first_line):
+                chunk_ids = chunk_ids[:idx]
+                break
+        header_spans = [h for h in header_ctx.headers if h.get("label") == dominant_label]
+        if header_spans:
+            header_span = header_spans[0]
+            h_start, h_end = header_span.get("span", span.span)
+            base_span = span_from_chunk_ids(chunks, chunk_ids)
+            new_start = max(h_start, base_span.span[0])
+            new_end = min(h_end + 400, base_span.span[1])
+            trimmed = span_from_chunk_ids(chunks, chunk_ids)
+            return Span(
+                chunk_ids=trimmed.chunk_ids,
+                text=trimmed.text,
+                page=trimmed.page,
+                span=(new_start, new_end),
+                flow_total=span.flow_total,
+            )
+    # If no dominant header or no trimming needed, rehydrate span to ensure consistency.
+    recomputed = span_from_chunk_ids(chunks, chunk_ids)
+    return Span(
+        chunk_ids=recomputed.chunk_ids,
+        text=recomputed.text,
+        page=recomputed.page,
+        span=recomputed.span,
+        flow_total=span.flow_total,
+    )
 
 
 __all__ = ["GraphContext", "score_graph", "snap_and_trim", "DEFAULT_PARAMS"]

--- a/backend/headers/header_llm.py
+++ b/backend/headers/header_llm.py
@@ -157,47 +157,85 @@ def _window_text(page_text: str, start: int, end: int, padding: int = 120) -> Tu
     return win_start, win_end, page_text[win_start:win_end]
 
 
-def _search_methods(label: str, page_text: str, window_start: int, window_end: int) -> List[Dict[str, Any]]:
+def _search_candidates(label: str, page_text: str, window_start: int, window_end: int) -> List[Dict[str, Any]]:
     window = page_text[window_start:window_end]
-    methods: List[Dict[str, Any]] = []
+    candidates: List[Dict[str, Any]] = []
     regex_pattern = re.compile(rf"{re.escape(label)}\s*(?P<text>[^\n]+)")
     match = regex_pattern.search(window)
     if match:
-        methods.append(
+        candidates.append(
             {
                 "label": label,
                 "text": _normalize_space(match.group("text")),
                 "method": "regex",
-                "confidence": 0.65,
+                "confidence": 0.68,
             }
         )
-    if not methods:
-        lines = window.splitlines()
-        for idx, line in enumerate(lines[:-1]):
-            if label in line:
-                candidate = _normalize_space(line + " " + lines[idx + 1])
-                methods.append(
+    lines = window.splitlines()
+    for idx, line in enumerate(lines[:-1]):
+        stripped = line.strip()
+        if stripped == label.rstrip(".)") or stripped.startswith(label):
+            next_line = lines[idx + 1].strip()
+            if next_line:
+                candidates.append(
                     {
                         "label": label,
-                        "text": candidate,
-                        "method": "soft_unwrap",
-                        "confidence": 0.58,
+                        "text": _normalize_space(next_line),
+                        "method": "header_resegment",
+                        "confidence": 0.62,
                     }
                 )
-                break
-    if not methods and window:
-        # OCR window fallback: search for uppercase sequences
-        match = re.search(rf"{re.escape(label)}\s*([A-Z][A-Za-z &/]+)", window)
-        if match:
-            methods.append(
+        if label in line and idx + 1 < len(lines):
+            joined = _normalize_space(line + " " + lines[idx + 1])
+            candidates.append(
                 {
                     "label": label,
-                    "text": _normalize_space(match.group(0).replace(label, "", 1)),
+                    "text": joined.replace(label, "", 1).strip(),
+                    "method": "soft_unwrap+regex",
+                    "confidence": 0.6,
+                }
+            )
+            break
+    if window:
+        ocr_match = re.search(rf"{re.escape(label)}\s*([A-Z][A-Za-z &/]+)", window)
+        if ocr_match:
+            candidates.append(
+                {
+                    "label": label,
+                    "text": _normalize_space(ocr_match.group(0).replace(label, "", 1)),
                     "method": "ocr_window",
                     "confidence": 0.56,
                 }
             )
-    return methods
+    seen: set[Tuple[str, str]] = set()
+    unique: List[Dict[str, Any]] = []
+    for candidate in candidates:
+        key = (candidate["text"], candidate["method"])
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(candidate)
+    return unique
+
+
+def _verify_local_match(label: str, text: str, page_text: str, window_start: int, window_end: int) -> Optional[Tuple[int, int, str]]:
+    window = page_text[window_start:window_end]
+    pattern = re.compile(rf"{re.escape(label)}\s*{re.escape(text)}", re.IGNORECASE)
+    match = pattern.search(window)
+    if not match:
+        return None
+    start = window_start + match.start()
+    end = window_start + match.end()
+    canonical = _normalize_space(page_text[start:end])
+    return start, end, canonical
+
+
+def _series_name(prefix: str) -> str:
+    if prefix == "NUM":
+        return "NUMERIC"
+    if prefix.upper().startswith("A"):
+        return "APPX"
+    return prefix.upper()
 
 
 def aggressive_sequence_repair(
@@ -225,15 +263,17 @@ def aggressive_sequence_repair(
             before_header = entries[idx][1]
             after_header = entries[idx + 1][1]
             log_entry = {
-                "series": prefix if prefix != "NUM" else "NUMERIC",
+                "series": _series_name(prefix),
                 "gap": f"{prefix}{gap_numbers[0]}..{prefix}{gap_numbers[-1]}",
                 "before": {
                     "label": before_header.label,
+                    "text": before_header.text,
                     "page": before_header.page,
                     "span": before_header.span,
                 },
                 "after": {
                     "label": after_header.label,
+                    "text": after_header.text,
                     "page": after_header.page,
                     "span": after_header.span,
                 },
@@ -246,26 +286,31 @@ def aggressive_sequence_repair(
                 page_text = pages_norm[page_index]
                 start = before_header.span[1]
                 end = after_header.span[0] if before_header.page == after_header.page else len(page_text)
-                win_start, win_end, window = _window_text(page_text, start, end)
-                token_list = tokens[page_index] if page_index < len(tokens) else []
-                window_tokens = [t for t in token_list if win_start <= t.get("start", 0) <= win_end]
-                log_entry["windows"] += max(1, len(window_tokens))
-                candidates = _search_methods(label, page_text, win_start, win_end)
+                win_start, win_end, _ = _window_text(page_text, start, end)
+                token_window = []
+                if 0 <= page_index < len(tokens):
+                    token_window = [
+                        token
+                        for token in tokens[page_index]
+                        if win_start <= int(token.get("start", 0)) <= win_end
+                    ]
+                log_entry["windows"] += max(1, len(token_window))
+                candidates = _search_candidates(label, page_text, win_start, win_end)
                 for candidate in candidates:
-                    candidate_text = candidate["text"].replace(label, "").strip()
-                    canonical = _normalize_space(f"{label} {candidate_text}")
-                    local_idx = _normalize_space(page_text).find(canonical)
-                    if local_idx == -1:
+                    verification = _verify_local_match(label, candidate["text"], page_text, win_start, win_end)
+                    if not verification:
                         continue
+                    span_start, span_end, canonical = verification
                     confidence = candidate["confidence"]
                     if confidence < confidence_threshold:
                         continue
+                    normalized_label = label.rstrip(".)") + ("." if label.endswith(".") else ")")
                     new_header = VerifiedHeader(
-                        label=label.rstrip(".)") + ("." if label.endswith(".") else ")"),
-                        text=candidate_text,
+                        label=normalized_label,
+                        text=candidate["text"],
                         page=before_header.page,
-                        span=(local_idx, local_idx + len(canonical)),
-                        verification={"status": "matched", "method": candidate["method"]},
+                        span=(span_start, span_end),
+                        verification={"status": "matched", "method": candidate["method"], "canonical": canonical},
                         source="repair",
                         confidence=confidence,
                     )

--- a/backend/headers/pipeline.py
+++ b/backend/headers/pipeline.py
@@ -13,7 +13,12 @@ from backend.efhg.entropy import (
     score_stops,
     select_quantile_ids,
 )
-from backend.efhg.fluid import DEFAULT_PARAMS as FLUID_DEFAULTS, Span, build_edges, grow_span_from_seed
+from backend.efhg.fluid import (
+    DEFAULT_PARAMS as FLUID_DEFAULTS,
+    Span,
+    build_edges,
+    grow_span_from_seed,
+)
 from backend.efhg.graph_gate import DEFAULT_PARAMS as GRAPH_DEFAULTS, GraphContext, score_graph, snap_and_trim
 from backend.efhg.hep import DEFAULT_PARAMS as HEP_DEFAULTS, score_span_hep
 from backend.headers.header_llm import (
@@ -46,7 +51,15 @@ def _ensure_output_dir(doc_id: str, output_dir: str | Path | None) -> Path:
     return base
 
 
-def _span_to_audit(span: Span, start_scores: Dict[str, float], stop_scores: Dict[str, float], hep_scores: Dict[str, Any], graph_score: float, graph_penalties: Dict[str, float], decision: str) -> Dict[str, Any]:
+def _span_to_audit(
+    span: Span,
+    start_scores: Dict[str, float],
+    stop_scores: Dict[str, float],
+    hep_scores: Dict[str, Any],
+    graph_score: float,
+    graph_penalties: Dict[str, float],
+    decision: str,
+) -> Dict[str, Any]:
     return {
         "header_label": _extract_label(span.text),
         "page": span.page,
@@ -128,6 +141,11 @@ def run_headers(doc_id: str, decomp: Dict[str, Any]) -> HeaderIndex:
         verified_headers = VerifiedHeaders()
 
     repaired_headers = aggressive_sequence_repair(verified_headers, pages_norm, tokens_per_page)
+    domain_hint = (
+        decomp.get("metadata", {}).get("domain")
+        or decomp.get("metadata", {}).get("domain_hint")
+        or decomp.get("domain")
+    )
     header_ctx = GraphContext(
         headers=[
             {
@@ -140,6 +158,7 @@ def run_headers(doc_id: str, decomp: Dict[str, Any]) -> HeaderIndex:
         ],
         references=decomp.get("references", []),
         tables=decomp.get("tables", []),
+        domain=domain_hint,
     )
 
     seed_candidates = select_quantile_ids(start_scores, DEFAULT_SEED_QUANTILE)
@@ -202,6 +221,7 @@ def run_headers(doc_id: str, decomp: Dict[str, Any]) -> HeaderIndex:
             "text": header.text,
             "page": header.page,
             "span": header.span,
+            "span_char": header.span,
             "source": header.source,
             "confidence": header.confidence,
         }
@@ -213,11 +233,14 @@ def run_headers(doc_id: str, decomp: Dict[str, Any]) -> HeaderIndex:
             "id": chunk.id,
             "page": chunk.page,
             "span": chunk.span_char,
+            "span_char": chunk.span_char,
+            "span_bbox": chunk.span_bbox,
             "text": chunk.text,
             "style": chunk.style,
             "lex": chunk.lex,
             "entropy": chunk.entropy,
             "header_anchor": chunk.header_anchor,
+            "domain_hint": chunk.domain_hint,
         }
         for chunk in uf_chunks
     ]
@@ -232,17 +255,21 @@ def run_headers(doc_id: str, decomp: Dict[str, Any]) -> HeaderIndex:
             "fluid": FLUID_DEFAULTS,
             "hep": HEP_DEFAULTS,
             "graph": GRAPH_DEFAULTS,
+            "domain_hint": domain_hint,
         },
         "uf_chunks": [
             {
                 "id": chunk.id,
                 "page": chunk.page,
                 "span": chunk.span_char,
+                "span_char": chunk.span_char,
+                "span_bbox": chunk.span_bbox,
                 "text_preview": chunk.preview(),
                 "style": chunk.style,
                 "lex": chunk.lex,
                 "entropy": chunk.entropy,
                 "header_anchor": chunk.header_anchor,
+                "domain_hint": chunk.domain_hint,
             }
             for chunk in uf_chunks
         ],

--- a/backend/tests/test_header_pipeline.py
+++ b/backend/tests/test_header_pipeline.py
@@ -74,7 +74,15 @@ def test_sequence_repair_appx_gap(tmp_path):
     assert "A6." in final_headers and final_headers["A6."]["source"] == "repair"
 
     audit = json.loads((output_dir / "candidate_audit.json").read_text())
-    assert any(entry["gap"].startswith("A5") for entry in audit["sequence_repair"])
+    gap_entry = next((entry for entry in audit["sequence_repair"] if entry["gap"].startswith("A5")), None)
+    assert gap_entry is not None
+    assert gap_entry["series"] == "APPX"
+    assert gap_entry["before"]["text"].startswith("Prior")
+    assert gap_entry["after"]["text"].startswith("Closing")
+    assert gap_entry["result"], "Expected repair candidates logged"
+    for candidate in gap_entry["result"]:
+        assert candidate["confidence"] >= 0.55
+        assert candidate["method"] in {"regex", "header_resegment", "soft_unwrap+regex", "ocr_window"}
 
 
 def test_header_split_across_uf(tmp_path):
@@ -95,6 +103,7 @@ def test_header_split_across_uf(tmp_path):
     span_entry = accepted[0]
     assert span_entry["scores"]["fluid"]["Flow_total"] > 0
     assert span_entry["scores"]["hep"]["S_HEP"] >= HEP_DEFAULTS["theta_hep"]
+    assert "cross_bleed" in span_entry["scores"]["graph"]["penalties"]
 
 
 def test_logging_schema(tmp_path):
@@ -123,14 +132,27 @@ def test_logging_schema(tmp_path):
         assert section in config
 
     for chunk in audit["uf_chunks"]:
-        assert set(["id", "page", "span", "style", "lex", "entropy", "header_anchor"]).issubset(chunk.keys())
+        assert set(
+            [
+                "id",
+                "page",
+                "span",
+                "span_char",
+                "span_bbox",
+                "style",
+                "lex",
+                "entropy",
+                "header_anchor",
+                "domain_hint",
+            ]
+        ).issubset(chunk.keys())
 
     llm_headers = audit["llm_headers"]
     assert "raw_fenced_json" in llm_headers
     assert "verified" in llm_headers
 
     for entry in audit["final_headers"]:
-        for field in ("page", "span", "source"):
+        for field in ("page", "span", "span_char", "source"):
             assert field in entry
 
     candidate = next((entry for entry in audit["final_headers"] if entry["label"].startswith("A1")), None)

--- a/backend/uf_chunker.py
+++ b/backend/uf_chunker.py
@@ -9,6 +9,13 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 HEADER_PATTERN = re.compile(r"^(?:\d+\)|A\d+\.)")
 MODAL_WORDS = {"may", "shall", "should", "must", "will", "can", "could", "would"}
+DOMAIN_KEYWORDS = {
+    "safety": {"safety", "safe", "hazard"},
+    "performance": {"performance", "efficiency", "output"},
+    "utilities": {"utility", "utilities", "consumption", "power"},
+    "financial": {"cost", "budget", "finance"},
+    "compliance": {"compliance", "regulation", "standard"},
+}
 
 
 @dataclass
@@ -69,6 +76,29 @@ def _compute_indent(token: Dict[str, Any]) -> float:
     return float(token.get("indent", 0.0) or 0.0)
 
 
+def _infer_domain_hint(text: str) -> Optional[str]:
+    lowered = text.lower()
+    best_hint: Optional[str] = None
+    best_hits = 0
+    for hint, keywords in DOMAIN_KEYWORDS.items():
+        hits = sum(1 for keyword in keywords if keyword in lowered)
+        if hits > best_hits:
+            best_hits = hits
+            best_hint = hint
+    return best_hint if best_hits else None
+
+
+def _bbox_union(tokens: Sequence[Dict[str, Any]]) -> Optional[Tuple[float, float, float, float]]:
+    bboxes = [tok.get("bbox") for tok in tokens if tok.get("bbox")]
+    if not bboxes:
+        return None
+    x0 = min(box[0] for box in bboxes)
+    y0 = min(box[1] for box in bboxes)
+    x1 = max(box[2] for box in bboxes)
+    y1 = max(box[3] for box in bboxes)
+    return float(x0), float(y0), float(x1), float(y1)
+
+
 def uf_chunk(doc_decomp: Dict[str, Any], max_tokens: int = 90, overlap: int = 12) -> List[UFChunk]:
     """Chunk a decomposed document into Ultrafine chunks."""
 
@@ -84,7 +114,6 @@ def uf_chunk(doc_decomp: Dict[str, Any], max_tokens: int = 90, overlap: int = 12
         while i < len(tokens):
             start_idx = i
             span_start = tokens[start_idx].get("start", 0)
-            last_indent = _compute_indent(tokens[start_idx])
             j = start_idx
             while j < len(tokens) and (j - start_idx) < max_tokens:
                 if j > start_idx:
@@ -97,7 +126,6 @@ def uf_chunk(doc_decomp: Dict[str, Any], max_tokens: int = 90, overlap: int = 12
                     indent_delta = _compute_indent(tokens[j]) - _compute_indent(tokens[j - 1])
                     if indent_delta >= 2.0:
                         break
-                last_indent = _compute_indent(tokens[j])
                 j += 1
             if j == start_idx:
                 j += 1
@@ -122,28 +150,27 @@ def uf_chunk(doc_decomp: Dict[str, Any], max_tokens: int = 90, overlap: int = 12
                 "citation_hints": bool(re.search(r"\[[^\]]+\]|\([^)]*\d{4}[^)]*\)", text)),
             }
             emb = _embed_text(text)
-            chunk_id = f"uf_{page_idx + 1}_{chunk_index}"
+            chunk_id = f"uf_{page_idx + 1:04d}_{chunk_index:05d}"
             header_anchor = bool(HEADER_PATTERN.search(text.strip().splitlines()[0] if text.strip() else ""))
-            bbox = chunk_tokens[0].get("bbox") if chunk_tokens[0].get("bbox") else None
+            bbox = _bbox_union(chunk_tokens)
             chunk = UFChunk(
                 id=chunk_id,
                 page=page_idx + 1,
                 span_char=(int(span_start), int(span_end)),
-                span_bbox=tuple(bbox) if bbox else None,
+                span_bbox=bbox,
                 text=text,
                 style=style,
                 lex=lex,
                 emb=emb,
+                domain_hint=_infer_domain_hint(text),
                 header_anchor=header_anchor,
             )
             chunks.append(chunk)
             chunk_index += 1
             if j >= len(tokens):
                 break
-            i = max(j - overlap, j - 1)
-            if i <= start_idx:
-                i = start_idx + 1
-        
+            i = max(j - max(overlap, 0), start_idx + 1)
+
     return chunks
 
 


### PR DESCRIPTION
## Summary
- add domain-aware UF chunking with deterministic identifiers, bounding boxes, and lexical hints for EFHG stitching
- update EFHG fluid, HEP graph gate, and header pipeline to apply improved span growth, graph penalties, and comprehensive audit logging
- enhance aggressive sequence repair heuristics and extend regression coverage for appendix gaps, split headers, and logging schema

## Testing
- pytest backend/tests/test_header_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68d6c05ea77c8324b63de7e1a2076c74