### PR TITLE
Refine header pipeline with UF chunking and EFHG logging

### DIFF
--- a/backend/efhg/entropy.py
+++ b/backend/efhg/entropy.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import math
 from typing import Dict, Iterable, List
 
-from backend.uf_chunker import UFChunk, HEADER_PATTERN
+from backend.uf_chunker import HEADER_PATTERN, UFChunk
 
 DEFAULT_WEIGHTS = {
     "w1": 0.7,
@@ -13,56 +13,32 @@ DEFAULT_WEIGHTS = {
     "w5": 0.25,
     "w6": 0.15,
 }
-DEFAULT_SEED_QUANTILE = 0.85
-DEFAULT_STOP_QUANTILE = 0.80
+DEFAULT_SEED_QUANTILE = 0.85  # top 15%
+DEFAULT_STOP_QUANTILE = 0.80  # top 20%
 
 
 def _tokenize(text: str) -> List[str]:
-    return [t for t in text.replace("\n", " ").split(" ") if t]
+    return [tok for tok in text.replace("\n", " ").split(" ") if tok]
 
 
 def _entropy(values: Iterable[float]) -> float:
     total = sum(values)
-    if total == 0:
+    if total <= 0:
         return 0.0
     entropy = 0.0
-    for v in values:
-        if v <= 0:
+    for value in values:
+        if value <= 0:
             continue
-        p = v / total
-        entropy -= p * math.log(p, 2)
+        prob = value / total
+        entropy -= prob * math.log(prob, 2)
     return entropy
-
-
-def compute_entropy_features(uf_chunks: List[UFChunk]) -> None:
-    """Annotate chunks with entropy-based features."""
-
-    for idx, chunk in enumerate(uf_chunks):
-        tokens = _tokenize(chunk.text)
-        token_lengths = [len(tok) for tok in tokens] or [1]
-        position_weights = list(range(1, len(tokens) + 1)) or [1]
-        h_tkn = _entropy(token_lengths)
-        h_pos = _entropy(position_weights)
-        chunk.entropy = {
-            "H_tkn": h_tkn,
-            "H_pos": h_pos,
-            "modal": 1.0 if chunk.lex.get("has_modal") else 0.0,
-        }
-    for idx, chunk in enumerate(uf_chunks):
-        prev_h = uf_chunks[idx - 1].entropy.get("H_tkn", 0.0) if idx > 0 else chunk.entropy.get("H_tkn", 0.0)
-        next_h = uf_chunks[idx + 1].entropy.get("H_tkn", 0.0) if idx + 1 < len(uf_chunks) else chunk.entropy.get("H_tkn", 0.0)
-        chunk.entropy["dH_prev"] = chunk.entropy.get("H_tkn", 0.0) - prev_h
-        chunk.entropy["dH_next"] = next_h - chunk.entropy.get("H_tkn", 0.0)
 
 
 def _header_proximity(chunk: UFChunk) -> float:
     if chunk.header_anchor:
         return 1.0
-    text = chunk.text.strip().splitlines()
-    if text:
-        first_line = text[0]
-        return 1.0 if HEADER_PATTERN.match(first_line.strip()) else 0.1
-    return 0.0
+    first_line = chunk.text.strip().splitlines()[0] if chunk.text.strip() else ""
+    return 0.6 if HEADER_PATTERN.match(first_line) else 0.1
 
 
 def _terminal_punct(chunk: UFChunk) -> float:
@@ -73,35 +49,59 @@ def _no_new_params_ahead(chunk: UFChunk) -> float:
     return 1.0 if not chunk.lex.get("numbers") else 0.2
 
 
+def compute_entropy_features(uf_chunks: List[UFChunk]) -> None:
+    """Annotate each UF chunk with entropy-derived statistics."""
+
+    for chunk in uf_chunks:
+        tokens = _tokenize(chunk.text)
+        token_lengths = [len(tok) for tok in tokens] or [1]
+        positional = list(range(1, len(tokens) + 1)) or [1]
+        h_tkn = _entropy(token_lengths)
+        h_pos = _entropy(positional)
+        chunk.entropy = {
+            "H_tkn": h_tkn,
+            "H_pos": h_pos,
+            "modal": 1.0 if chunk.lex.get("has_modal") else 0.0,
+        }
+
+    for idx, chunk in enumerate(uf_chunks):
+        prev_h = uf_chunks[idx - 1].entropy.get("H_tkn", 0.0) if idx > 0 else chunk.entropy.get("H_tkn", 0.0)
+        next_h = uf_chunks[idx + 1].entropy.get("H_tkn", 0.0) if idx + 1 < len(uf_chunks) else chunk.entropy.get("H_tkn", 0.0)
+        chunk.entropy["dH_prev"] = chunk.entropy.get("H_tkn", 0.0) - prev_h
+        chunk.entropy["dH_next"] = next_h - chunk.entropy.get("H_tkn", 0.0)
+
+
 def score_starts(uf_chunks: List[UFChunk], weights: Dict[str, float] | None = None) -> Dict[str, float]:
+    """Compute start likelihood scores for UF chunks."""
+
     weights = weights or DEFAULT_WEIGHTS
     scores: Dict[str, float] = {}
     for chunk in uf_chunks:
-        dh_prev = chunk.entropy.get("dH_prev", 0.0)
-        modal = chunk.entropy.get("modal", 0.0)
+        dH_prev = chunk.entropy.get("dH_prev", 0.0)
+        modalness = chunk.entropy.get("modal", 0.0)
         proximity = _header_proximity(chunk)
-        score = (
-            weights["w1"] * (-dh_prev)
-            + weights["w2"] * modal
+        scores[chunk.id] = (
+            weights["w1"] * (-dH_prev)
+            + weights["w2"] * modalness
             + weights["w3"] * proximity
         )
-        scores[chunk.id] = score
     return scores
 
 
 def score_stops(uf_chunks: List[UFChunk], weights: Dict[str, float] | None = None) -> Dict[str, float]:
+    """Compute stop likelihood scores for UF chunks."""
+
     weights = weights or DEFAULT_WEIGHTS
     scores: Dict[str, float] = {}
     for chunk in uf_chunks:
-        dh_next = chunk.entropy.get("dH_next", 0.0)
+        dH_next = chunk.entropy.get("dH_next", 0.0)
         terminal = _terminal_punct(chunk)
         params = _no_new_params_ahead(chunk)
-        score = (
-            weights["w4"] * dh_next
+        scores[chunk.id] = (
+            weights["w4"] * (+dH_next)
             + weights["w5"] * terminal
             + weights["w6"] * params
         )
-        scores[chunk.id] = score
     return scores
 
 
@@ -121,4 +121,5 @@ __all__ = [
     "select_quantile_ids",
     "DEFAULT_SEED_QUANTILE",
     "DEFAULT_STOP_QUANTILE",
+    "DEFAULT_WEIGHTS",
 ]

--- a/backend/efhg/graph_gate.py
+++ b/backend/efhg/graph_gate.py
@@ -52,6 +52,14 @@ def _collect_domain_hints(span: Span, chunks: Dict[str, UFChunk]) -> List[str]:
     return hints
 
 
+def _chunk_has_citation(chunk: UFChunk) -> bool:
+    return bool(chunk.lex.get("citation_hints"))
+
+
+def _chunk_has_params(chunk: UFChunk) -> bool:
+    return bool(chunk.lex.get("numbers")) or bool(chunk.lex.get("units"))
+
+
 def score_graph(span: Span, header_ctx: GraphContext, chunks: Dict[str, UFChunk], params: Dict[str, float] | None = None) -> Tuple[float, Dict[str, float]]:
     params = params or DEFAULT_PARAMS
     penalties = {
@@ -60,29 +68,37 @@ def score_graph(span: Span, header_ctx: GraphContext, chunks: Dict[str, UFChunk]
         "reference_gap": 0.0,
         "cross_bleed": 0.0,
     }
+
     dominant_label, overlap = _dominant_header(span, chunks, header_ctx.headers)
-    header_score = params["wH"] * (1.0 if dominant_label else 0.0)
-    domain_score = params["wD"] * (1.0 if overlap > 0 else 0.5)
-    param_support = any(chunks[cid].lex.get("numbers") for cid in span.chunk_ids)
-    param_score = params["wP"] * (1.0 if param_support else 0.4)
-    ref_score = params["wR"] * (1.0 if header_ctx.references else 0.5)
-    table_score = params["wC"] * (1.0 if header_ctx.tables else 0.4)
+    header_alignment = 1.0 if dominant_label else 0.0
+    same_section = 1.0 if overlap > 0 else 0.3
+    citations = 1.0 if any(_chunk_has_citation(chunks[cid]) for cid in span.chunk_ids) else 0.0
+    parameters = 1.0 if any(_chunk_has_params(chunks[cid]) for cid in span.chunk_ids) else 0.0
+    context_tables = 1.0 if header_ctx.tables else 0.0
+
     penalties["header_mismatch"] = 0.0 if dominant_label else 0.6
 
     domain_hints = _collect_domain_hints(span, chunks)
     if header_ctx.domain and domain_hints and header_ctx.domain not in domain_hints:
         penalties["domain_conflict"] = 0.5
 
-    if dominant_label and any(
+    if any(
         HEADER_PATTERN.match(chunks[cid].text.strip().splitlines()[0]) and cid != span.chunk_ids[0]
-        for cid in span.chunk_ids
+        for cid in span.chunk_ids[1:]
     ):
         penalties["cross_bleed"] = 0.4
 
-    if dominant_label and header_ctx.references and not any(chunks[cid].lex.get("citation_hints") for cid in span.chunk_ids):
+    if header_ctx.references and citations == 0.0:
         penalties["reference_gap"] = 0.3
 
-    score = header_score + domain_score + param_score + ref_score + table_score - sum(penalties.values())
+    score = (
+        params["wH"] * header_alignment
+        + params["wD"] * same_section
+        + params["wP"] * parameters
+        + params["wR"] * citations
+        + params["wC"] * context_tables
+        - sum(penalties.values())
+    )
     return score, penalties
 
 
@@ -104,6 +120,15 @@ def snap_and_trim(span: Span, header_ctx: GraphContext, chunks: Dict[str, UFChun
             new_start = max(h_start, base_span.span[0])
             new_end = min(h_end + 400, base_span.span[1])
             trimmed = span_from_chunk_ids(chunks, chunk_ids)
+            domain_hints = _collect_domain_hints(trimmed, chunks)
+            if header_ctx.domain and domain_hints and header_ctx.domain not in domain_hints:
+                return Span(
+                    chunk_ids=[trimmed.chunk_ids[0]],
+                    text=chunks[trimmed.chunk_ids[0]].text,
+                    page=trimmed.page,
+                    span=(chunks[trimmed.chunk_ids[0]].span_char[0], chunks[trimmed.chunk_ids[0]].span_char[1]),
+                    flow_total=span.flow_total,
+                )
             return Span(
                 chunk_ids=trimmed.chunk_ids,
                 text=trimmed.text,
@@ -111,7 +136,7 @@ def snap_and_trim(span: Span, header_ctx: GraphContext, chunks: Dict[str, UFChun
                 span=(new_start, new_end),
                 flow_total=span.flow_total,
             )
-    # If no dominant header or no trimming needed, rehydrate span to ensure consistency.
+
     recomputed = span_from_chunk_ids(chunks, chunk_ids)
     return Span(
         chunk_ids=recomputed.chunk_ids,

--- a/backend/headers/header_llm.py
+++ b/backend/headers/header_llm.py
@@ -44,9 +44,13 @@ def build_header_prompt(pages_norm: List[str]) -> List[Dict[str, str]]:
     for idx, page in enumerate(pages_norm, start=1):
         sections.append(f"Page {idx}:\n{page}")
     prompt = "\n\n".join(sections)
+    instructions = (
+        "Extract every numbered or appendix header. Respond with a single fenced JSON payload containing "
+        '{"headers": [{"label": "A1.", "text": "Heading", "page": 1}, ...]}. Include all sequence members.'
+    )
     return [
         {"role": "system", "content": "You are a diligent header extraction assistant."},
-        {"role": "user", "content": prompt},
+        {"role": "user", "content": instructions + "\n\n" + prompt},
     ]
 
 
@@ -109,21 +113,20 @@ def verify_headers(headers_json: Dict[str, Any], pages_norm: List[str], pages_ra
         page = int(entry.get("page", 1))
         if not label or page < 1 or page > len(pages_norm):
             continue
-        canonical = _normalize_space(f"{label} {text}")
+        pattern = re.compile(rf"{re.escape(label)}\s+(?P<body>[^\n]+)")
         page_text = pages_norm[page - 1]
-        page_compact = _normalize_space(page_text)
-        idx = page_compact.find(canonical)
+        match = pattern.search(page_text)
         verification: Dict[str, Any]
         span: Tuple[int, int]
-        if idx != -1:
+        if match and _normalize_space(match.group("body")).startswith(_normalize_space(text)[:50]):
             verification = {"status": "matched", "method": "normalized"}
-            span = (idx, idx + len(canonical))
+            span = (match.start(), match.end())
         else:
             raw_text = pages_raw[page - 1] if pages_raw and page - 1 < len(pages_raw) else page_text
-            raw_idx = raw_text.find(label)
-            if raw_idx != -1:
+            raw_match = pattern.search(raw_text)
+            if raw_match:
                 verification = {"status": "matched", "method": "raw"}
-                span = (raw_idx, raw_idx + len(label) + len(text) + 1)
+                span = (raw_match.start(), raw_match.end())
             else:
                 verification = {"status": "not_found"}
                 span = (0, 0)
@@ -135,7 +138,7 @@ def verify_headers(headers_json: Dict[str, Any], pages_norm: List[str], pages_ra
                 span=span,
                 verification=verification,
                 source="llm",
-                confidence=0.8 if verification.get("status") == "matched" else 0.4,
+                confidence=0.85 if verification.get("status") == "matched" else 0.4,
             )
         )
     return verified
@@ -286,15 +289,9 @@ def aggressive_sequence_repair(
                 page_text = pages_norm[page_index]
                 start = before_header.span[1]
                 end = after_header.span[0] if before_header.page == after_header.page else len(page_text)
-                win_start, win_end, _ = _window_text(page_text, start, end)
-                token_window = []
-                if 0 <= page_index < len(tokens):
-                    token_window = [
-                        token
-                        for token in tokens[page_index]
-                        if win_start <= int(token.get("start", 0)) <= win_end
-                    ]
-                log_entry["windows"] += max(1, len(token_window))
+                win_start, win_end, window_text = _window_text(page_text, start, end)
+                window_line_count = max(1, len(window_text.splitlines()))
+                log_entry["windows"] += window_line_count
                 candidates = _search_candidates(label, page_text, win_start, win_end)
                 for candidate in candidates:
                     verification = _verify_local_match(label, candidate["text"], page_text, win_start, win_end)
@@ -305,6 +302,8 @@ def aggressive_sequence_repair(
                     if confidence < confidence_threshold:
                         continue
                     normalized_label = label.rstrip(".)") + ("." if label.endswith(".") else ")")
+                    if any(h.label == normalized_label for h in repaired.headers):
+                        continue
                     new_header = VerifiedHeader(
                         label=normalized_label,
                         text=candidate["text"],

--- a/backend/headers/pipeline.py
+++ b/backend/headers/pipeline.py
@@ -3,9 +3,10 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 from backend.efhg.entropy import (
+    DEFAULT_WEIGHTS,
     DEFAULT_SEED_QUANTILE,
     DEFAULT_STOP_QUANTILE,
     compute_entropy_features,
@@ -59,6 +60,7 @@ def _span_to_audit(
     graph_score: float,
     graph_penalties: Dict[str, float],
     decision: str,
+    final_score: float,
 ) -> Dict[str, Any]:
     return {
         "header_label": _extract_label(span.text),
@@ -79,7 +81,7 @@ def _span_to_audit(
                 "S_graph": graph_score,
                 "penalties": graph_penalties,
             },
-            "final": hep_scores["S_HEP"] + span.flow_total - sum(graph_penalties.values()),
+            "final": final_score,
         },
         "decision": decision,
         "text_preview": span.text[:120],
@@ -115,6 +117,24 @@ def _persist_jsonl(path: Path, records: List[Dict[str, Any]]) -> None:
             handle.write(json.dumps(record, ensure_ascii=False) + "\n")
 
 
+def _overlap(a: Tuple[int, int], b: Tuple[int, int]) -> int:
+    return max(0, min(a[1], b[1]) - max(a[0], b[0]))
+
+
+def _build_header_shards(headers: List[VerifiedHeader], uf_chunks: List[UFChunk]) -> Dict[str, List[str]]:
+    shards: Dict[str, List[str]] = {}
+    for header in headers:
+        shard_ids: List[str] = []
+        for chunk in uf_chunks:
+            if chunk.page != header.page:
+                continue
+            if _overlap(chunk.span_char, header.span) > 0:
+                shard_ids.append(chunk.id)
+        if shard_ids:
+            shards[header.label] = shard_ids
+    return shards
+
+
 def run_headers(doc_id: str, decomp: Dict[str, Any]) -> HeaderIndex:
     pages = decomp.get("pages", [])
     pages_norm = [page.get("text", "") for page in pages]
@@ -130,7 +150,6 @@ def run_headers(doc_id: str, decomp: Dict[str, Any]) -> HeaderIndex:
 
     messages = build_header_prompt(pages_norm)
     llm_raw = ""
-    verified_headers: VerifiedHeaders
     llm_error: str | None = None
     try:
         llm_raw = call_llm(messages)
@@ -141,6 +160,8 @@ def run_headers(doc_id: str, decomp: Dict[str, Any]) -> HeaderIndex:
         verified_headers = VerifiedHeaders()
 
     repaired_headers = aggressive_sequence_repair(verified_headers, pages_norm, tokens_per_page)
+    header_shards = _build_header_shards(repaired_headers.headers, uf_chunks)
+
     domain_hint = (
         decomp.get("metadata", {}).get("domain")
         or decomp.get("metadata", {}).get("domain_hint")
@@ -153,6 +174,7 @@ def run_headers(doc_id: str, decomp: Dict[str, Any]) -> HeaderIndex:
                 "text": header.text,
                 "page": header.page,
                 "span": header.span,
+                "chunks": header_shards.get(header.label, []),
             }
             for header in repaired_headers.headers
         ],
@@ -161,55 +183,76 @@ def run_headers(doc_id: str, decomp: Dict[str, Any]) -> HeaderIndex:
         domain=domain_hint,
     )
 
-    seed_candidates = select_quantile_ids(start_scores, DEFAULT_SEED_QUANTILE)
     chunk_lookup = {chunk.id: chunk for chunk in uf_chunks}
-    seed_ids = [cid for cid in seed_candidates if chunk_lookup.get(cid) and chunk_lookup[cid].header_anchor]
+    ordered_ids = [chunk.id for chunk in uf_chunks]
+    seed_candidates = select_quantile_ids(start_scores, DEFAULT_SEED_QUANTILE)
+    seed_ids = [cid for cid in ordered_ids if cid in seed_candidates and chunk_lookup[cid].header_anchor]
     if not seed_ids:
-        seed_ids = [chunk.id for chunk in uf_chunks if chunk.header_anchor]
+        seed_ids = [cid for cid in ordered_ids if chunk_lookup[cid].header_anchor]
+    seed_ids = list(dict.fromkeys(seed_ids))
+
     spans_audit: List[Dict[str, Any]] = []
     accepted_spans: List[Span] = []
 
     for seed_id in seed_ids:
-        span = grow_span_from_seed(seed_id, uf_chunks, edges, stop_scores)
+        try:
+            span = grow_span_from_seed(seed_id, uf_chunks, edges, stop_scores)
+        except ValueError:
+            continue
         span = snap_and_trim(span, header_ctx, chunk_lookup)
         hep_detail = score_span_hep(span, chunk_lookup)
         graph_score, graph_penalties = score_graph(span, header_ctx, chunk_lookup)
         final_score = hep_detail["S_HEP"] + span.flow_total - sum(graph_penalties.values())
-        decision = "rejected"
-        if hep_detail["S_HEP"] >= HEP_DEFAULTS["theta_hep"] and final_score >= GRAPH_DEFAULTS["theta_final"]:
-            decision = "accepted"
+        decision = "accepted" if (
+            hep_detail["S_HEP"] >= HEP_DEFAULTS["theta_hep"]
+            and final_score >= GRAPH_DEFAULTS["theta_final"]
+        ) else "rejected"
+        if decision == "accepted":
             accepted_spans.append(span)
-        spans_audit.append(_span_to_audit(span, start_scores, stop_scores, hep_detail, graph_score, graph_penalties, decision))
-
-    final_headers_map: Dict[str, VerifiedHeader] = {header.label: header for header in repaired_headers.headers}
-    for span in accepted_spans:
-        label = _extract_label(span.text)
-        if not label:
-            continue
-        canonical_text = span.text.split(label, 1)[-1].strip()
-        final_headers_map[label] = VerifiedHeader(
-            label=label,
-            text=canonical_text,
-            page=span.page,
-            span=span.span,
-            verification={"status": "efhg"},
-            source="efhg",
-            confidence=0.9,
+        spans_audit.append(
+            _span_to_audit(
+                span,
+                start_scores,
+                stop_scores,
+                hep_detail,
+                graph_score,
+                graph_penalties,
+                decision,
+                final_score,
+            )
         )
 
-    if llm_error and not final_headers_map:
+    if llm_error:
+        final_headers_map: Dict[str, VerifiedHeader] = {}
         for span in accepted_spans:
             label = _extract_label(span.text)
             if not label:
                 continue
+            body = span.text.split(label, 1)[-1].strip()
             final_headers_map[label] = VerifiedHeader(
                 label=label,
-                text=span.text.split(label, 1)[-1].strip(),
+                text=body,
                 page=span.page,
                 span=span.span,
-                verification={"status": "efhg_fallback"},
+                verification={"status": "efhg_fallback", "chunks": span.chunk_ids},
                 source="efhg_fallback",
-                confidence=0.75,
+                confidence=0.8,
+            )
+    else:
+        final_headers_map = {header.label: header for header in repaired_headers.headers}
+        for span in accepted_spans:
+            label = _extract_label(span.text)
+            if not label:
+                continue
+            body = span.text.split(label, 1)[-1].strip()
+            final_headers_map[label] = VerifiedHeader(
+                label=label,
+                text=body,
+                page=span.page,
+                span=span.span,
+                verification={"status": "efhg", "chunks": span.chunk_ids},
+                source="efhg",
+                confidence=0.9,
             )
 
     final_headers = sorted(final_headers_map.values(), key=lambda h: (h.page, h.span[0], h.label))
@@ -245,13 +288,11 @@ def run_headers(doc_id: str, decomp: Dict[str, Any]) -> HeaderIndex:
         for chunk in uf_chunks
     ]
 
-    efhg_records = spans_audit
-
     audit_payload = {
         "config": {
             "uf_max_tokens": 90,
             "uf_overlap": 12,
-            "entropy": {"weights": {"w1": 0.7, "w2": 0.2, "w3": 0.1, "w4": 0.6, "w5": 0.25, "w6": 0.15}, "seed_quantile": DEFAULT_SEED_QUANTILE, "stop_quantile": DEFAULT_STOP_QUANTILE},
+            "entropy": {"weights": dict(DEFAULT_WEIGHTS), "seed_quantile": DEFAULT_SEED_QUANTILE, "stop_quantile": DEFAULT_STOP_QUANTILE},
             "fluid": FLUID_DEFAULTS,
             "hep": HEP_DEFAULTS,
             "graph": GRAPH_DEFAULTS,
@@ -284,7 +325,7 @@ def run_headers(doc_id: str, decomp: Dict[str, Any]) -> HeaderIndex:
     }
 
     _persist_jsonl(output_dir / "uf_chunks.jsonl", uf_records)
-    _persist_jsonl(output_dir / "efhg_spans.jsonl", efhg_records)
+    _persist_jsonl(output_dir / "efhg_spans.jsonl", spans_audit)
     with (output_dir / "headers.json").open("w", encoding="utf-8") as handle:
         json.dump(headers_payload, handle, ensure_ascii=False, indent=2)
     with (output_dir / "candidate_audit.json").open("w", encoding="utf-8") as handle:
@@ -294,7 +335,7 @@ def run_headers(doc_id: str, decomp: Dict[str, Any]) -> HeaderIndex:
         doc_id=doc_id,
         headers=headers_payload,
         uf_chunks=uf_chunks,
-        spans=efhg_records,
+        spans=spans_audit,
         output_dir=output_dir,
     )
 

--- a/backend/tests/test_header_pipeline.py
+++ b/backend/tests/test_header_pipeline.py
@@ -79,6 +79,7 @@ def test_sequence_repair_appx_gap(tmp_path):
     assert gap_entry["series"] == "APPX"
     assert gap_entry["before"]["text"].startswith("Prior")
     assert gap_entry["after"]["text"].startswith("Closing")
+    assert gap_entry["windows"] >= 1
     assert gap_entry["result"], "Expected repair candidates logged"
     for candidate in gap_entry["result"]:
         assert candidate["confidence"] >= 0.55
@@ -154,6 +155,8 @@ def test_logging_schema(tmp_path):
     for entry in audit["final_headers"]:
         for field in ("page", "span", "span_char", "source"):
             assert field in entry
+        assert entry["source"] in {"llm", "repair", "efhg", "efhg_fallback"}
 
     candidate = next((entry for entry in audit["final_headers"] if entry["label"].startswith("A1")), None)
     assert candidate is not None
+    assert audit["config"]["entropy"]["weights"]["w1"] == 0.7

--- a/backend/uf_chunker.py
+++ b/backend/uf_chunker.py
@@ -4,7 +4,7 @@ import hashlib
 import math
 import re
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
 
 HEADER_PATTERN = re.compile(r"^(?:\d+\)|A\d+\.)")
@@ -20,7 +20,7 @@ DOMAIN_KEYWORDS = {
 
 @dataclass
 class UFChunk:
-    """Container for an Ultrafine chunk."""
+    """Representation of an Ultrafine (UF) chunk."""
 
     id: str
     page: int
@@ -56,11 +56,7 @@ def _embed_text(text: str, dims: int = 8) -> List[float]:
 
 
 def _extract_numbers(tokens: Sequence[str]) -> List[str]:
-    results: List[str] = []
-    for tok in tokens:
-        if re.search(r"\d", tok):
-            results.append(tok)
-    return results
+    return [tok for tok in tokens if re.search(r"\d", tok)]
 
 
 def _extract_units(tokens: Sequence[str]) -> List[str]:
@@ -99,79 +95,112 @@ def _bbox_union(tokens: Sequence[Dict[str, Any]]) -> Optional[Tuple[float, float
     return float(x0), float(y0), float(x1), float(y1)
 
 
+def _should_split(prev_token: Dict[str, Any], token: Dict[str, Any]) -> bool:
+    token_text = token.get("text", "").strip()
+    prev_text = prev_token.get("text", "").strip()
+    if HEADER_PATTERN.match(token_text):
+        return True
+    if prev_text.endswith(".") and token_text[:1].isupper():
+        return True
+    indent_delta = _compute_indent(token) - _compute_indent(prev_token)
+    return indent_delta >= 2.0
+
+
+def _collect_text(page: Dict[str, Any], tokens: Sequence[Dict[str, Any]]) -> str:
+    if not tokens:
+        return ""
+    start = int(tokens[0].get("start", 0))
+    end = int(tokens[-1].get("end", start))
+    page_text = page.get("text", "")
+    if start < end <= len(page_text):
+        text = page_text[start:end]
+        if text.strip():
+            return text
+    return "".join(tok.get("text", "") for tok in tokens)
+
+
+def _lexical_profile(text: str, tokens: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    raw_tokens = [tok.get("text", "") for tok in tokens]
+    return {
+        "has_modal": _has_modal(raw_tokens),
+        "numbers": _extract_numbers(raw_tokens),
+        "units": _extract_units(raw_tokens),
+        "citation_hints": bool(re.search(r"\[[^\]]+\]|\([^)]*\d{4}[^)]*\)", text)),
+    }
+
+
+def _style_profile(tokens: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    if not tokens:
+        return {"font_size": 0.0, "bold": False, "indent": 0.0}
+    primary = tokens[0]
+    return {
+        "font_size": float(primary.get("font_size", 0.0) or 0.0),
+        "bold": bool(primary.get("bold", False)),
+        "indent": float(primary.get("indent", 0.0) or 0.0),
+    }
+
+
+def _header_anchor(text: str) -> bool:
+    head = text.strip().splitlines()[0] if text.strip() else ""
+    return bool(HEADER_PATTERN.match(head))
+
+
+def _iter_segments(tokens: Sequence[Dict[str, Any]], max_tokens: int, overlap: int) -> Iterable[Tuple[int, int]]:
+    start_idx = 0
+    while start_idx < len(tokens):
+        end_idx = min(len(tokens), start_idx + max_tokens)
+        j = start_idx + 1
+        while j < end_idx:
+            if _should_split(tokens[j - 1], tokens[j]):
+                end_idx = j
+                break
+            j += 1
+        yield start_idx, end_idx
+        if end_idx >= len(tokens):
+            break
+        step = max(1, max_tokens - max(0, overlap))
+        # If we broke early due to header or indent, respect the boundary.
+        if end_idx - start_idx < max_tokens:
+            start_idx = end_idx
+        else:
+            start_idx = max(end_idx - step, start_idx + 1)
+
+
 def uf_chunk(doc_decomp: Dict[str, Any], max_tokens: int = 90, overlap: int = 12) -> List[UFChunk]:
-    """Chunk a decomposed document into Ultrafine chunks."""
+    """Chunk the normalized document decomposition using Ultrafine logic."""
 
     pages: List[Dict[str, Any]] = doc_decomp.get("pages", [])
     chunks: List[UFChunk] = []
-    chunk_index = 0
+    chunk_counter = 0
 
-    for page_idx, page in enumerate(pages):
+    for page_index, page in enumerate(pages):
         tokens: List[Dict[str, Any]] = page.get("tokens", [])
         if not tokens:
             continue
-        i = 0
-        while i < len(tokens):
-            start_idx = i
-            span_start = tokens[start_idx].get("start", 0)
-            j = start_idx
-            while j < len(tokens) and (j - start_idx) < max_tokens:
-                if j > start_idx:
-                    token_text = tokens[j]["text"].strip()
-                    prev_text = tokens[j - 1]["text"].strip()
-                    if HEADER_PATTERN.match(token_text):
-                        break
-                    if prev_text.endswith(".") and token_text[:1].isupper():
-                        break
-                    indent_delta = _compute_indent(tokens[j]) - _compute_indent(tokens[j - 1])
-                    if indent_delta >= 2.0:
-                        break
-                j += 1
-            if j == start_idx:
-                j += 1
-            chunk_tokens = tokens[start_idx:j]
-            span_end = chunk_tokens[-1].get("end", span_start)
-            text = page.get("text", "")[span_start:span_end]
-            if not text:
-                text = "".join(tok.get("text", "") for tok in chunk_tokens)
-            raw_tokens = [tok.get("text", "") for tok in chunk_tokens]
-            lex_numbers = _extract_numbers(raw_tokens)
-            lex_units = _extract_units(raw_tokens)
-            lex_has_modal = _has_modal(raw_tokens)
-            style = {
-                "font_size": float(chunk_tokens[0].get("font_size", 0.0) or 0.0),
-                "bold": bool(chunk_tokens[0].get("bold", False)),
-                "indent": float(chunk_tokens[0].get("indent", 0.0) or 0.0),
-            }
-            lex = {
-                "has_modal": lex_has_modal,
-                "numbers": lex_numbers,
-                "units": lex_units,
-                "citation_hints": bool(re.search(r"\[[^\]]+\]|\([^)]*\d{4}[^)]*\)", text)),
-            }
-            emb = _embed_text(text)
-            chunk_id = f"uf_{page_idx + 1:04d}_{chunk_index:05d}"
-            header_anchor = bool(HEADER_PATTERN.search(text.strip().splitlines()[0] if text.strip() else ""))
-            bbox = _bbox_union(chunk_tokens)
+        segments = list(_iter_segments(tokens, max_tokens, overlap))
+        for start_idx, end_idx in segments:
+            segment_tokens = tokens[start_idx:end_idx]
+            if not segment_tokens:
+                continue
+            text = _collect_text(page, segment_tokens)
+            span_start = int(segment_tokens[0].get("start", 0))
+            span_end = int(segment_tokens[-1].get("end", span_start))
             chunk = UFChunk(
-                id=chunk_id,
-                page=page_idx + 1,
-                span_char=(int(span_start), int(span_end)),
-                span_bbox=bbox,
+                id=f"uf_{page_index + 1:04d}_{chunk_counter:05d}",
+                page=page_index + 1,
+                span_char=(span_start, span_end),
+                span_bbox=_bbox_union(segment_tokens),
                 text=text,
-                style=style,
-                lex=lex,
-                emb=emb,
+                style=_style_profile(segment_tokens),
+                lex=_lexical_profile(text, segment_tokens),
+                emb=_embed_text(text),
                 domain_hint=_infer_domain_hint(text),
-                header_anchor=header_anchor,
+                header_anchor=_header_anchor(text),
             )
             chunks.append(chunk)
-            chunk_index += 1
-            if j >= len(tokens):
-                break
-            i = max(j - max(overlap, 0), start_idx + 1)
+            chunk_counter += 1
 
     return chunks
 
 
-__all__ = ["UFChunk", "uf_chunk"]
+__all__ = ["UFChunk", "uf_chunk", "HEADER_PATTERN"]


### PR DESCRIPTION
## Summary
- rebuild the UF chunker to emit ≤90 token overlapping chunks with style, lexical and embedding metadata for header anchors
- expand EFHG entropy, graph and pipeline logic to stitch split headers, perform aggressive sequence repair and emit structured audit logs
- extend header pipeline tests to cover appendix gap repair, split-chunk stitching and audit schema validation

## Testing
- pytest backend/tests/test_header_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68d6c28eef20832484ef6e3dd753af90