### PR TITLE
Align entropy config logging with defaults

### DIFF
--- a/backend/efhg/entropy.py
+++ b/backend/efhg/entropy.py
@@ -119,6 +119,7 @@ __all__ = [
     "score_starts",
     "score_stops",
     "select_quantile_ids",
+    "DEFAULT_WEIGHTS",
     "DEFAULT_SEED_QUANTILE",
     "DEFAULT_STOP_QUANTILE",
 ]

--- a/backend/headers/pipeline.py
+++ b/backend/headers/pipeline.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Any, Dict, List
 
 from backend.efhg.entropy import (
+    DEFAULT_WEIGHTS,
     DEFAULT_SEED_QUANTILE,
     DEFAULT_STOP_QUANTILE,
     compute_entropy_features,
@@ -300,7 +301,11 @@ def run_headers(doc_id: str, decomp: Dict[str, Any]) -> HeaderIndex:
         "config": {
             "uf_max_tokens": 90,
             "uf_overlap": 12,
-            "entropy": {"weights": {"w1": 0.7, "w2": 0.2, "w3": 0.1, "w4": 0.6, "w5": 0.25, "w6": 0.15}, "seed_quantile": DEFAULT_SEED_QUANTILE, "stop_quantile": DEFAULT_STOP_QUANTILE},
+        "entropy": {
+            "weights": dict(DEFAULT_WEIGHTS),
+            "seed_quantile": DEFAULT_SEED_QUANTILE,
+            "stop_quantile": DEFAULT_STOP_QUANTILE,
+        },
             "fluid": FLUID_DEFAULTS,
             "hep": HEP_DEFAULTS,
             "graph": GRAPH_DEFAULTS,


### PR DESCRIPTION
## Summary
- export the entropy DEFAULT_WEIGHTS constant for reuse
- drive header candidate audit logging from the shared entropy defaults for deterministic reporting

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d6c92818d88324be7d5c413dbeac6e