### PR TITLE
Improve appendix header heuristics

### DIFF
--- a/backend/parse/header_page_mode.py
+++ b/backend/parse/header_page_mode.py
@@ -21,16 +21,32 @@ from .header_detector import (
     APPENDIX_NUM_RX,
 )
 from .header_levels import map_font_sizes_to_levels, infer_heading_level
-from .patterns_rfq import APPENDIX_TOLERANT_PATTERN
+from .patterns_rfq import (
+    APPENDIX_SINGLE_LETTER_PATTERN,
+    APPENDIX_TOLERANT_PATTERN,
+    APPENDIX_WORDONLY_PATTERN,
+)
 from .header_config import CONFIG
 
 MEASURE_RX = re.compile(r'\b(?:\d{1,4}(?:\.\d+)?)(?:\s*(?:mm|cm|m|in|inch|ft|°c|°f|a|v|hz|psi|kpa|ip\d{2}))\b', re.I)
 ADDRESS_RX = re.compile(r'\b(?:Street|St\.|Road|Rd\.|Drive|Dr\.|Ave\.|Avenue|Suite|USA|Tel|Fax)\b', re.I)
 TOO_LONG_RX = re.compile(r'^\s*.{161,}\s*$')
 SAFE_COMPONENT_RX = re.compile(r"[^A-Za-z0-9._-]+")
-NUMERIC_PREFIX_RX = re.compile(r'^\s*(?:Appendix\s+[A-Z]|Annex\s+[A-Z]|[A-Z]\d+(?:\.\d+)*|\d+(?:\.\d+)*|\d+\))', re.IGNORECASE)
+NUMERIC_PREFIX_RX = re.compile(
+    r'^\s*(?:'
+    r'Appendix\s+[A-Za-z]'
+    r'|Annex\s+[A-Za-z]'
+    r'|[A-Z]\d+(?:\.\d+)*'
+    r'|\d+(?:\.\d+)*'
+    r'|\d+\)'
+    r'|[A-Z](?:\s*[-–—:]\s*|\s+[A-Z])'
+    r')',
+    re.IGNORECASE,
+)
 APPENDIX_SEQ_RX = re.compile(r'^\s*([A-Z])(\d{1,3})[.\u2024\u2027\uFF0E]\s{0,2}(.+?)\s*$')
-APPENDIX_WORD_RX = re.compile(r'^\s*(Appendix|Annex)\s+([A-Z])', re.IGNORECASE)
+APPENDIX_WORD_RX = re.compile(r'^\s*(Appendix|Annex)\s+([A-Z])(?=\s|[-–—:.]|$)', re.IGNORECASE)
+APPENDIX_SINGLE_LETTER_RX = re.compile(APPENDIX_SINGLE_LETTER_PATTERN, re.IGNORECASE)
+APPENDIX_WORDONLY_RX = re.compile(APPENDIX_WORDONLY_PATTERN, re.IGNORECASE)
 SECTION_LETTER_NUM_RX = re.compile(r'^\s*([A-Za-z]\d+(?:\.\d+)*)')
 DEBUG_DOT_CHARS = {'.', '\u2024', '\u2027', '\uFF0E'}
 _NUMERIC_REGEX_PATTERNS = {
@@ -38,7 +54,9 @@ _NUMERIC_REGEX_PATTERNS = {
     r'^\s*(\d{1,3})\)\s+(.+?)\s*$',
     r'^\s*(\d{1,3}(?:\.\d{1,3}){0,4})\s+([A-Z].{3,})\s*$',
     r'^\s*([A-Z])\.(\d{1,3})\s+(.+?)\s*$',
-    r'^\s*(Appendix|Annex)\s+([A-Z])(?:\s*[-:]\s*(.+))?\s*$',
+    r'^\s*(Appendix|Annex)\s+([A-Z])(?:\s*[-–—:]\s*(.+))?\s*$',
+    APPENDIX_SINGLE_LETTER_PATTERN,
+    APPENDIX_WORDONLY_PATTERN,
 }
 
 def _caps_ratio(s: str) -> float:
@@ -70,12 +88,22 @@ def _extract_section_number(normalized: str) -> str:
         match = rx.match(normalized)
         if match:
             return (match.group(1) or "").strip()
+    single_letter = APPENDIX_SINGLE_LETTER_RX.match(normalized)
+    if single_letter:
+        return single_letter.group(1).upper()
     match = SECTION_LETTER_NUM_RX.match(normalized)
     if match:
         return match.group(1)
     word = APPENDIX_WORD_RX.match(normalized)
     if word:
         return f"{word.group(1).title()} {word.group(2)}"
+    wordonly = APPENDIX_WORDONLY_RX.match(normalized)
+    if wordonly:
+        prefix = wordonly.group(1).title()
+        suffix = (wordonly.group(2) or "").strip().split()[0]
+        if suffix:
+            return f"{prefix} {suffix}"
+        return prefix
     return ""
 
 
@@ -444,7 +472,12 @@ def dump_appendix_audit(
         for cand in cand_list:
             txt = (cand.get("text") or "").strip()
             normalized = normalize_heading_text(txt)
-            if not (APPENDIX_NUM_RX.match(normalized) or APPENDIX_WORD_RX.match(normalized)):
+            if not (
+                APPENDIX_NUM_RX.match(normalized)
+                or APPENDIX_WORD_RX.match(normalized)
+                or APPENDIX_SINGLE_LETTER_RX.match(normalized)
+                or APPENDIX_WORDONLY_RX.match(normalized)
+            ):
                 continue
             breakdown = score_header_candidate_debug(txt, style=cand.get("style") or {})
             audit_rows.append(

--- a/backend/parse/patterns_rfq.py
+++ b/backend/parse/patterns_rfq.py
@@ -4,6 +4,8 @@ import re
 
 
 APPENDIX_TOLERANT_PATTERN = r'^\s*([A-Z])(\d{1,3})[.\u2024\u2027\uFF0E]\s{0,2}(.+?)\s*$'
+APPENDIX_SINGLE_LETTER_PATTERN = r'^\s*([A-Z])(?:\s*[-–—:]\s*|\s+)(.{3,})\s*$'
+APPENDIX_WORDONLY_PATTERN = r'^\s*(Appendix|Annex)\s+(.{3,})\s*$'
 
 
 _RFQ_SECTION_RE_SPECS = [
@@ -11,7 +13,9 @@ _RFQ_SECTION_RE_SPECS = [
     (r'^\s*(\d{1,3})\)\s+(.+?)\s*$', 0),                            # 1) Scope
     (r'^\s*(\d{1,3}(?:\.\d{1,3}){0,4})\s+([A-Z].{3,})\s*$', re.IGNORECASE),  # 1.2 Subsection Title
     (r'^\s*([A-Z])\.(\d{1,3})\s+(.+?)\s*$', 0),                     # A.1 Heading
-    (r'^\s*(Appendix|Annex)\s+([A-Z])(?:\s*[-:]\s*(.+))?\s*$', re.IGNORECASE),  # Appendix A - ...
+    (r'^\s*(Appendix|Annex)\s+([A-Z])(?:\s*[-–—:]\s*(.+))?\s*$', re.IGNORECASE),  # Appendix A - ...
+    (APPENDIX_SINGLE_LETTER_PATTERN, re.IGNORECASE),                     # B - Pricing Table
+    (APPENDIX_WORDONLY_PATTERN, re.IGNORECASE),                          # Appendix Pricing Overview
     (r'^[A-Z0-9][A-Z0-9\s\-/&,\.]{4,}$', 0),                          # ALLCAPS line (coarse)
 ]
 

--- a/tests/test_header_detector_patterns.py
+++ b/tests/test_header_detector_patterns.py
@@ -1,0 +1,35 @@
+import pytest
+
+from backend.parse.header_detector import is_header_line, normalize_heading_text
+from backend.parse.header_page_mode import _extract_section_number
+
+
+@pytest.mark.parametrize(
+    "line",
+    [
+        "Appendix B — Pricing Breakdown (Template)",
+        "Appendix Pricing Overview",
+        "B Pricing Breakdown (Template)",
+        "C - Spare Parts Listing",
+    ],
+)
+def test_appendix_headers_detected(line: str) -> None:
+    ok, _meta = is_header_line(line, style={"font_sigma_rank": 1.6, "bold": True})
+    assert ok, f"Expected appendix-style header to be detected: {line!r}"
+
+
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        ("Appendix B — Pricing Breakdown (Template)", "Appendix B"),
+        ("Appendix Pricing Overview", "Appendix Pricing"),
+        ("B Pricing Breakdown (Template)", "B"),
+        ("C - Spare Parts Listing", "C"),
+    ],
+)
+def test_extract_section_number_for_appendix_forms(line: str, expected: str) -> None:
+    normalized = normalize_heading_text(line)
+    section_number = _extract_section_number(normalized)
+    assert (
+        section_number == expected
+    ), f"Expected {expected!r} but got {section_number!r} for line {line!r}"


### PR DESCRIPTION
## Summary
- expand the appendix regex set to handle single-letter headings and free-form Appendix titles
- update header number extraction and audits to recognize the new appendix patterns
- add regression tests covering appendix heading detection scenarios

## Testing
- pytest tests/test_header_detector_patterns.py

------
https://chatgpt.com/codex/tasks/task_e_68d6d10f21d0832487de10429d824844