### PR TITLE
Refactor header promotion to bypass EFHG gating

### DIFF
--- a/backend/headers/config.py
+++ b/backend/headers/config.py
@@ -1,0 +1,16 @@
+"""Configuration flags for the header pipeline."""
+
+from __future__ import annotations
+
+# EFHG gate mode controls whether scoring is allowed to block promotions.
+# "bypass" => strong patterns auto-promote, scores only inform logging.
+# "score_gate" => legacy behaviour where EFHG scores gate weaker patterns.
+HEADER_GATE_MODE = "bypass"
+
+# When ``True`` only hard span collisions trigger suppression during
+# conflict resolution. Soft disagreements (style, graph hints) are logged but
+# do not demote a promoted header.
+STRICT_CONFLICT_ONLY = True
+
+
+__all__ = ["HEADER_GATE_MODE", "STRICT_CONFLICT_ONLY"]

--- a/backend/headers/header_llm.py
+++ b/backend/headers/header_llm.py
@@ -142,13 +142,28 @@ def verify_headers(headers_json: Dict[str, Any], pages_norm: List[str], pages_ra
 
 
 def _label_series(label: str) -> Tuple[str, int]:
-    match = re.match(r"^(?P<prefix>[A-Za-z]+)(?P<num>\d+)", label)
-    if not match:
-        match = re.match(r"^(?P<num>\d+)", label)
-        if not match:
-            return label, -1
-        return "NUM", int(match.group("num"))
-    return match.group("prefix"), int(match.group("num"))
+    cleaned = (label or "").strip()
+    if not cleaned:
+        return "", -1
+    numeric = re.match(r"^(?P<num>\d+)\)", cleaned)
+    if numeric:
+        return "NUM", int(numeric.group("num"))
+    appendix = re.match(r"(?i)^(appendix|annex)\s+([A-Z])", cleaned)
+    if appendix:
+        prefix = appendix.group(1).upper()
+        letter = appendix.group(2).upper()
+        return prefix, ord(letter) - ord("A") + 1
+    base = cleaned.rstrip(".)")
+    dotted = re.match(r"^(?P<prefix>[A-Z])\.(?P<num>\d+)$", base)
+    if dotted:
+        return dotted.group("prefix").upper(), int(dotted.group("num"))
+    simple = re.match(r"^(?P<prefix>[A-Z])(?P<num>\d+)$", base)
+    if simple:
+        return simple.group("prefix").upper(), int(simple.group("num"))
+    generic = re.match(r"^(?P<prefix>[A-Za-z]+)(?P<num>\d+)$", base)
+    if generic:
+        return generic.group("prefix").upper(), int(generic.group("num"))
+    return cleaned.upper(), -1
 
 
 def _window_text(page_text: str, start: int, end: int, padding: int = 120) -> Tuple[int, int, str]:
@@ -233,9 +248,36 @@ def _verify_local_match(label: str, text: str, page_text: str, window_start: int
 def _series_name(prefix: str) -> str:
     if prefix == "NUM":
         return "NUMERIC"
-    if prefix.upper().startswith("A"):
-        return "APPX"
+    if prefix in {"APPENDIX", "ANNEX"}:
+        return prefix
     return prefix.upper()
+
+
+def _infer_label_pattern(label: str) -> str:
+    if not label:
+        return "generic"
+    if re.match(r"^\d+\)$", label):
+        return "numeric"
+    if re.match(r"(?i)^(appendix|annex)\s+[A-Z]$", label):
+        return "appendix_top"
+    if re.match(r"^[A-Z]\d+\.$", label):
+        return "appendix_sub_AN"
+    if re.match(r"^[A-Z]\.\d+$", label):
+        return "appendix_sub_AlN"
+    return "generic"
+
+
+def _format_missing_label(prefix: str, number: int, pattern: str) -> str:
+    if pattern == "numeric" or prefix == "NUM":
+        return f"{number})"
+    if pattern == "appendix_top" and prefix in {"APPENDIX", "ANNEX"}:
+        letter = chr(ord("A") + number - 1)
+        return f"{prefix.title()} {letter}"
+    if pattern == "appendix_sub_AlN":
+        return f"{prefix}.{number}"
+    if pattern == "appendix_sub_AN":
+        return f"{prefix}{number}."
+    return f"{prefix}{number}."
 
 
 def aggressive_sequence_repair(
@@ -262,9 +304,12 @@ def aggressive_sequence_repair(
             gap_numbers = list(range(current_num + 1, next_num))
             before_header = entries[idx][1]
             after_header = entries[idx + 1][1]
+            pattern_type = _infer_label_pattern(before_header.label)
+            if pattern_type == "generic":
+                pattern_type = _infer_label_pattern(after_header.label)
             log_entry = {
                 "series": _series_name(prefix),
-                "gap": f"{prefix}{gap_numbers[0]}..{prefix}{gap_numbers[-1]}",
+                "gap": f"{_format_missing_label(prefix, gap_numbers[0], pattern_type)}..{_format_missing_label(prefix, gap_numbers[-1], pattern_type)}",
                 "before": {
                     "label": before_header.label,
                     "text": before_header.text,
@@ -281,7 +326,7 @@ def aggressive_sequence_repair(
                 "result": [],
             }
             for missing in gap_numbers:
-                label = f"{prefix}{missing}." if prefix != "NUM" else f"{missing})"
+                label = _format_missing_label(prefix, missing, pattern_type)
                 page_index = before_header.page - 1
                 page_text = pages_norm[page_index]
                 start = before_header.span[1]
@@ -304,7 +349,7 @@ def aggressive_sequence_repair(
                     confidence = candidate["confidence"]
                     if confidence < confidence_threshold:
                         continue
-                    normalized_label = label.rstrip(".)") + ("." if label.endswith(".") else ")")
+                    normalized_label = label
                     new_header = VerifiedHeader(
                         label=normalized_label,
                         text=candidate["text"],

--- a/backend/headers/header_scan.py
+++ b/backend/headers/header_scan.py
@@ -1,0 +1,171 @@
+"""Header candidate scanning and promotion helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Sequence
+
+import re
+
+from backend.headers.config import HEADER_GATE_MODE
+from backend.uf_chunker import HEADER_PATTERN, UFChunk
+
+# Strong patterns that should always auto-promote regardless of EFHG scores.
+STRONG_PATTERNS = {
+    "numeric_section",
+    "appendix_top",
+    "appendix_sub_AN",
+    "appendix_sub_AlN",
+}
+
+_PATTERN_CHECKS = {
+    "numeric_section": re.compile(r"^\s*\d+\)(?:\s+.*)?$"),
+    "appendix_top": re.compile(
+        r"(?i)^\s*(appendix|annex)\s+[A-Z]\b(?:\s*[—\-: ]\s*.+)?$"
+    ),
+    "appendix_sub_AN": re.compile(r"^\s*[A-Z]\d{1,3}\.(?:\s+.*)?$"),
+    "appendix_sub_AlN": re.compile(r"^\s*[A-Z]\.\d{1,3}(?:\s+.*)?$"),
+}
+
+_PATTERN_FINDER = {
+    "numeric_section": re.compile(r"\d+\)"),
+    "appendix_top": re.compile(r"(?i)\b(?:appendix|annex)\b"),
+    "appendix_sub_AN": re.compile(r"\b[A-Z]\d{1,3}\."),
+    "appendix_sub_AlN": re.compile(r"\b[A-Z]\.\d{1,3}"),
+}
+
+
+@dataclass
+class HeaderCandidate:
+    """Represents a single line (or inline segment) that resembles a header."""
+
+    chunk_id: str
+    chunk_index: int
+    page: int
+    line_index: int
+    text: str
+    pattern: str
+    label: str
+    start_char: int
+    end_char: int
+    style: Dict[str, object] = field(default_factory=dict)
+    candidate_id: int = -1
+    promoted: bool = False
+    promotion_reason: str | None = None
+    total: float = 0.0
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "candidate_id": self.candidate_id,
+            "chunk_id": self.chunk_id,
+            "chunk_index": self.chunk_index,
+            "page": self.page,
+            "line_index": self.line_index,
+            "text": self.text,
+            "pattern": self.pattern,
+            "label": self.label,
+            "start_char": self.start_char,
+            "end_char": self.end_char,
+            "style": dict(self.style),
+            "promoted": self.promoted,
+            "promotion_reason": self.promotion_reason,
+            "score_total": self.total,
+        }
+
+
+def _scan_line(
+    chunk: UFChunk,
+    chunk_index: int,
+    line_index: int,
+    base_offset: int,
+    raw_line: str,
+) -> Iterable[HeaderCandidate]:
+    """Yield header candidates discovered within a single chunk line."""
+
+    # Normalise the line for scanning but retain original characters for offsets.
+    line = raw_line.rstrip("\r\n")
+    if not line:
+        return []
+
+    results: List[HeaderCandidate] = []
+    for pattern, finder in _PATTERN_FINDER.items():
+        check = _PATTERN_CHECKS[pattern]
+        for match in finder.finditer(line):
+            seg = line[match.start() :]
+            if not seg:
+                continue
+            if not check.match(seg):
+                continue
+            trimmed = seg.lstrip()
+            if not trimmed:
+                continue
+            leading_ws = len(seg) - len(trimmed)
+            rel_offset = base_offset + match.start() + leading_ws
+            start_char = chunk.span_char[0] + rel_offset
+            end_char = start_char + len(trimmed)
+            label_match = HEADER_PATTERN.match(trimmed)
+            label = label_match.group(0).strip() if label_match else trimmed.split(" ")[0]
+            candidate = HeaderCandidate(
+                chunk_id=chunk.id,
+                chunk_index=chunk_index,
+                page=chunk.page,
+                line_index=line_index,
+                text=trimmed,
+                pattern=pattern,
+                label=label,
+                start_char=int(start_char),
+                end_char=int(end_char),
+                style=dict(chunk.style or {}),
+            )
+            results.append(candidate)
+            # Avoid emitting duplicate candidates for the same segment by
+            # breaking after the first anchored match per pattern.
+            break
+    return results
+
+
+def scan_candidates(chunks: Sequence[UFChunk]) -> List[HeaderCandidate]:
+    """Scan UF chunks and emit raw header candidates."""
+
+    candidates: List[HeaderCandidate] = []
+    for chunk_index, chunk in enumerate(chunks):
+        text = chunk.text or ""
+        if not text.strip():
+            continue
+        offset = 0
+        for line_index, line in enumerate(text.splitlines(keepends=True)):
+            found = list(_scan_line(chunk, chunk_index, line_index, offset, line))
+            candidates.extend(found)
+            offset += len(line)
+    for idx, candidate in enumerate(candidates):
+        candidate.candidate_id = idx
+    return candidates
+
+
+def promote_candidates(
+    candidates: Sequence[HeaderCandidate],
+    gate_mode: str | None = None,
+) -> List[HeaderCandidate]:
+    """Apply promotion rules to header candidates."""
+
+    gate = gate_mode or HEADER_GATE_MODE
+    promoted: List[HeaderCandidate] = []
+    for candidate in candidates:
+        if candidate.pattern in STRONG_PATTERNS:
+            candidate.promoted = True
+            candidate.promotion_reason = "pattern"
+            promoted.append(candidate)
+        else:
+            if gate == "score_gate":
+                candidate.promoted = candidate.total > 0.0
+            else:
+                candidate.promoted = False
+    return promoted
+
+
+__all__ = [
+    "HeaderCandidate",
+    "STRONG_PATTERNS",
+    "scan_candidates",
+    "promote_candidates",
+]

--- a/backend/headers/pipeline.py
+++ b/backend/headers/pipeline.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Set, Tuple
 
 from backend.efhg.entropy import (
     DEFAULT_WEIGHTS,
@@ -22,6 +22,7 @@ from backend.efhg.fluid import (
 )
 from backend.efhg.graph_gate import DEFAULT_PARAMS as GRAPH_DEFAULTS, GraphContext, score_graph, snap_and_trim
 from backend.efhg.hep import DEFAULT_PARAMS as HEP_DEFAULTS, score_span_hep
+from backend.headers.config import HEADER_GATE_MODE, STRICT_CONFLICT_ONLY
 from backend.headers.header_llm import (
     VerifiedHeader,
     VerifiedHeaders,
@@ -31,6 +32,7 @@ from backend.headers.header_llm import (
     parse_fenced_outline,
     verify_headers,
 )
+from backend.headers.header_scan import HeaderCandidate, promote_candidates, scan_candidates
 from backend.uf_chunker import HEADER_PATTERN, UFChunk, uf_chunk
 
 
@@ -43,6 +45,121 @@ class HeaderIndex:
     header_shards: List[Dict[str, Any]]
     output_dir: Path
 
+
+_PATTERN_PRIORITY = {
+    "appendix_top": 4,
+    "numeric_section": 3,
+    "appendix_sub_AN": 2,
+    "appendix_sub_AlN": 2,
+}
+
+
+@dataclass
+class SpanRecord:
+    seed_id: str
+    span: Span
+    candidate: HeaderCandidate | None
+    hep: Dict[str, Any]
+    graph_score: float
+    graph_penalties: Dict[str, float]
+    start_score: float
+    stop_score: float
+    final_score: float
+    decision: str
+    accepted: bool
+    promotion_reason: str | None = None
+    conflicts_resolved: List[Dict[str, Any]] = field(default_factory=list)
+    suppression_reason: str | None = None
+
+
+def _pattern_rank(record: SpanRecord) -> int:
+    if record.candidate:
+        return _PATTERN_PRIORITY.get(record.candidate.pattern, 1)
+    return 1
+
+
+def _priority_key(record: SpanRecord, llm_labels: Set[str]) -> Tuple[float, ...]:
+    candidate = record.candidate
+    font_size = 0.0
+    bold = 0
+    indent = 0.0
+    label = ""
+    if candidate:
+        style = candidate.style or {}
+        font_size = float(style.get("font_size") or 0.0)
+        bold = 1 if style.get("bold") else 0
+        indent = float(style.get("indent") or 0.0)
+        label = candidate.label
+    if not label:
+        label = _extract_label(record.span.text) or ""
+    llm_vote = 1 if label and label in llm_labels else 0
+    return (
+        float(_pattern_rank(record)),
+        font_size,
+        bold,
+        -indent,
+        llm_vote,
+        record.span.flow_total,
+        -float(record.span.span[0]),
+    )
+
+
+def _span_overlap(left: SpanRecord, right: SpanRecord) -> int:
+    a_start, a_end = left.span.span
+    b_start, b_end = right.span.span
+    return max(0, min(a_end, b_end) - max(a_start, b_start))
+
+
+def _resolve_conflicts(
+    records: List[SpanRecord],
+    llm_labels: Set[str],
+) -> Tuple[List[SpanRecord], List[SpanRecord]]:
+    accepted = [record for record in records if record.accepted]
+    for record in accepted:
+        record.conflicts_resolved.clear()
+        record.suppression_reason = None
+
+    sorted_records = sorted(
+        accepted,
+        key=lambda rec: _priority_key(rec, llm_labels),
+        reverse=True,
+    )
+
+    kept: List[SpanRecord] = []
+    suppressed: List[SpanRecord] = []
+    for record in sorted_records:
+        has_conflict = False
+        for winner in kept:
+            overlap = _span_overlap(winner, record)
+            if overlap <= 0:
+                continue
+            has_conflict = True
+            record.accepted = False
+            record.decision = "conflict_suppressed"
+            loser_label = record.candidate.label if record.candidate else _extract_label(record.span.text)
+            winner_label = winner.candidate.label if winner.candidate else _extract_label(winner.span.text)
+            record.suppression_reason = {
+                "reason": "span_collision",
+                "winner": winner_label,
+                "overlap": overlap,
+            }
+            winner.conflicts_resolved.append(
+                {
+                    "loser": loser_label,
+                    "overlap": overlap,
+                    "seed_id": record.seed_id,
+                }
+            )
+            suppressed.append(record)
+            break
+        if not has_conflict:
+            kept.append(record)
+
+    for winner in kept:
+        if winner.conflicts_resolved and not winner.promotion_reason:
+            winner.promotion_reason = "conflict_keep"
+
+    return kept, suppressed
 
 def _ensure_output_dir(doc_id: str, output_dir: str | Path | None) -> Path:
     if output_dir is None:
@@ -170,6 +287,13 @@ def run_headers(doc_id: str, decomp: Dict[str, Any]) -> HeaderIndex:
     output_dir = _ensure_output_dir(doc_id, decomp.get("output_dir"))
 
     uf_chunks = uf_chunk(decomp)
+    candidates = scan_candidates(uf_chunks)
+    promote_candidates(candidates, HEADER_GATE_MODE)
+    candidates_by_chunk: Dict[str, List[HeaderCandidate]] = {}
+    for candidate in candidates:
+        candidates_by_chunk.setdefault(candidate.chunk_id, []).append(candidate)
+    for cand_list in candidates_by_chunk.values():
+        cand_list.sort(key=lambda c: (not c.promoted, c.line_index, c.start_char))
     compute_entropy_features(uf_chunks)
     start_scores = score_starts(uf_chunks)
     stop_scores = score_stops(uf_chunks)
@@ -213,39 +337,109 @@ def run_headers(doc_id: str, decomp: Dict[str, Any]) -> HeaderIndex:
     seed_ids = [cid for cid in seed_candidates if chunk_lookup.get(cid) and chunk_lookup[cid].header_anchor]
     if not seed_ids:
         seed_ids = [chunk.id for chunk in uf_chunks if chunk.header_anchor]
-    spans_audit: List[Dict[str, Any]] = []
-    accepted_spans: List[Span] = []
+
+    promoted_seed_ids = [
+        cid
+        for cid, cand_list in candidates_by_chunk.items()
+        if cand_list and cand_list[0].promoted
+    ]
+    ordered = promoted_seed_ids + seed_ids
+    seen: Set[str] = set()
+    seed_ids = []
+    for cid in ordered:
+        if cid in chunk_lookup and cid not in seen:
+            seed_ids.append(cid)
+            seen.add(cid)
+
+    span_records: List[SpanRecord] = []
 
     for seed_id in seed_ids:
         span = grow_span_from_seed(seed_id, uf_chunks, edges, stop_scores)
         span = snap_and_trim(span, header_ctx, chunk_lookup)
+        candidate_list = candidates_by_chunk.get(seed_id, [])
+        candidate = candidate_list[0] if candidate_list else None
         hep_detail = score_span_hep(span, chunk_lookup)
         graph_score, graph_penalties = score_graph(span, header_ctx, chunk_lookup)
         final_score = hep_detail["S_HEP"] + span.flow_total - sum(graph_penalties.values())
-        decision = "rejected"
-        if hep_detail["S_HEP"] >= HEP_DEFAULTS["theta_hep"] and final_score >= GRAPH_DEFAULTS["theta_final"]:
-            decision = "accepted"
-            accepted_spans.append(span)
-        spans_audit.append(_span_to_audit(span, start_scores, stop_scores, hep_detail, graph_score, graph_penalties, decision))
+        promotion_reason = candidate.promotion_reason if candidate and candidate.promoted else None
+        accepted = bool(promotion_reason)
+        decision = "promoted" if promotion_reason else "rejected"
+        if not accepted and HEADER_GATE_MODE == "score_gate":
+            if hep_detail["S_HEP"] >= HEP_DEFAULTS["theta_hep"] and final_score >= GRAPH_DEFAULTS["theta_final"]:
+                accepted = True
+                decision = "accepted"
+        record = SpanRecord(
+            seed_id=seed_id,
+            span=span,
+            candidate=candidate,
+            hep=hep_detail,
+            graph_score=graph_score,
+            graph_penalties=graph_penalties,
+            start_score=start_scores.get(seed_id, 0.0),
+            stop_score=stop_scores.get(span.chunk_ids[-1], 0.0),
+            final_score=final_score,
+            decision=decision,
+            accepted=accepted,
+            promotion_reason=promotion_reason,
+        )
+        span_records.append(record)
+
+    llm_labels = {header.label for header in repaired_headers.headers}
+    if span_records:
+        _resolve_conflicts(span_records, llm_labels)
+
+    spans_audit = [
+        _span_to_audit(
+            record.span,
+            start_scores,
+            stop_scores,
+            record.hep,
+            record.graph_score,
+            record.graph_penalties,
+            record.decision,
+        )
+        for record in span_records
+    ]
+
+    accepted_records = [record for record in span_records if record.accepted]
 
     final_headers_map: Dict[str, VerifiedHeader] = {header.label: header for header in repaired_headers.headers}
-    for span in accepted_spans:
+    for record in accepted_records:
+        span = record.span
+        candidate = record.candidate
         label = _extract_label(span.text)
+        if candidate and candidate.label:
+            label = candidate.label
         if not label:
             continue
-        canonical_text = span.text.split(label, 1)[-1].strip()
+        existing = final_headers_map.get(label)
+        if existing and existing.source == "repair":
+            continue
+        if candidate:
+            remainder = candidate.text[len(candidate.label) :].lstrip("—-: \u2014 ").strip()
+            canonical_text = remainder or span.text.split(label, 1)[-1].strip()
+            span_range = (candidate.start_char, max(candidate.end_char, candidate.start_char + len(canonical_text)))
+        else:
+            canonical_text = span.text.split(label, 1)[-1].strip()
+            span_range = span.span
+        verification = {"status": "efhg"}
+        if record.promotion_reason:
+            verification["promotion_reason"] = record.promotion_reason
+        source = "pattern" if record.promotion_reason else "efhg"
+        confidence = 0.95 if record.promotion_reason == "pattern" else 0.9
         final_headers_map[label] = VerifiedHeader(
             label=label,
             text=canonical_text,
             page=span.page,
-            span=span.span,
-            verification={"status": "efhg"},
-            source="efhg",
-            confidence=0.9,
+            span=span_range,
+            verification=verification,
+            source=source,
+            confidence=confidence,
         )
 
     if llm_error and not final_headers_map:
-        for span in accepted_spans:
+        for record in accepted_records:
+            span = record.span
             label = _extract_label(span.text)
             if not label:
                 continue
@@ -276,6 +470,7 @@ def run_headers(doc_id: str, decomp: Dict[str, Any]) -> HeaderIndex:
         for header in final_headers
     ]
 
+    accepted_spans = [record.span for record in accepted_records]
     header_shards_payload = _build_header_shards(final_headers, accepted_spans, chunk_lookup)
 
     uf_records = [
@@ -297,19 +492,72 @@ def run_headers(doc_id: str, decomp: Dict[str, Any]) -> HeaderIndex:
 
     efhg_records = spans_audit
 
+    raw_candidate_payload = [candidate.to_dict() for candidate in candidates]
+    promoted_payload = [
+        {
+            "candidate_id": record.candidate.candidate_id if record.candidate else None,
+            "text": record.candidate.text if record.candidate else record.span.text,
+            "page": record.span.page,
+            "idx": record.candidate.line_index if record.candidate else None,
+            "pattern": record.candidate.pattern if record.candidate else None,
+            "promotion_reason": record.promotion_reason,
+            "stitched_span": {
+                "uf_start": record.span.chunk_ids[0],
+                "uf_end": record.span.chunk_ids[-1],
+            },
+            "efhg": {
+                "E": {"start": record.start_score, "stop": record.stop_score},
+                "F": {"flow": record.span.flow_total},
+                "H": record.hep,
+                "G": {"score": record.graph_score, "penalties": record.graph_penalties},
+            },
+            "conflicts_resolved": list(record.conflicts_resolved),
+        }
+        for record in accepted_records
+        if record.promotion_reason
+    ]
+    suppressed_payload = [
+        {
+            "candidate_id": record.candidate.candidate_id if record.candidate else None,
+            "pattern": record.candidate.pattern if record.candidate else None,
+            "page": record.span.page,
+            "reason": record.suppression_reason,
+        }
+        for record in span_records
+        if record.suppression_reason
+    ]
+    summary_rows = [
+        {
+            "page": record.span.page,
+            "idx": record.candidate.line_index if record.candidate else -1,
+            "pattern": record.candidate.pattern if record.candidate else "",
+            "decision": record.decision,
+            "reason": (
+                record.promotion_reason
+                if record.promotion_reason
+                else json.dumps(record.suppression_reason)
+                if record.suppression_reason
+                else ""
+            ),
+        }
+        for record in span_records
+    ]
+
     audit_payload = {
         "config": {
             "uf_max_tokens": 90,
             "uf_overlap": 12,
-        "entropy": {
-            "weights": dict(DEFAULT_WEIGHTS),
-            "seed_quantile": DEFAULT_SEED_QUANTILE,
-            "stop_quantile": DEFAULT_STOP_QUANTILE,
-        },
+            "entropy": {
+                "weights": dict(DEFAULT_WEIGHTS),
+                "seed_quantile": DEFAULT_SEED_QUANTILE,
+                "stop_quantile": DEFAULT_STOP_QUANTILE,
+            },
             "fluid": FLUID_DEFAULTS,
             "hep": HEP_DEFAULTS,
             "graph": GRAPH_DEFAULTS,
             "domain_hint": domain_hint,
+            "header_gate_mode": HEADER_GATE_MODE,
+            "strict_conflict_only": STRICT_CONFLICT_ONLY,
         },
         "uf_chunks": [
             {
@@ -337,6 +585,19 @@ def run_headers(doc_id: str, decomp: Dict[str, Any]) -> HeaderIndex:
         "final_headers": headers_payload,
         "header_shards": header_shards_payload,
     }
+
+    with (output_dir / "header_candidates_raw.json").open("w", encoding="utf-8") as handle:
+        json.dump(raw_candidate_payload, handle, ensure_ascii=False, indent=2)
+    with (output_dir / "headers_promoted.json").open("w", encoding="utf-8") as handle:
+        json.dump(promoted_payload, handle, ensure_ascii=False, indent=2)
+    with (output_dir / "headers_suppressed.json").open("w", encoding="utf-8") as handle:
+        json.dump(suppressed_payload, handle, ensure_ascii=False, indent=2)
+    with (output_dir / "headers_summary.tsv").open("w", encoding="utf-8") as handle:
+        handle.write("page\tidx\tpattern\tdecision\treason\n")
+        for row in summary_rows:
+            handle.write(
+                f"{row['page']}\t{row['idx']}\t{row['pattern']}\t{row['decision']}\t{row['reason']}\n"
+            )
 
     _persist_jsonl(output_dir / "uf_chunks.jsonl", uf_records)
     _persist_jsonl(output_dir / "efhg_spans.jsonl", efhg_records)

--- a/backend/uf_chunker.py
+++ b/backend/uf_chunker.py
@@ -7,7 +7,21 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 
-HEADER_PATTERN = re.compile(r"^(?:\d+\)|A\d+\.)")
+HEADER_PATTERN = re.compile(
+    r"""
+    ^
+    (?:
+        (?P<numeric_section>\d+\))
+        |
+        (?P<appendix_top>(?:Appendix|Annex)\s+[A-Z])
+        |
+        (?P<appendix_sub_AN>[A-Z]\d{1,3}\.)
+        |
+        (?P<appendix_sub_AlN>[A-Z]\.\d{1,3})
+    )
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
 MODAL_WORDS = {"may", "shall", "should", "must", "will", "can", "could", "would"}
 DOMAIN_KEYWORDS = {
     "safety": {"safety", "safe", "hazard"},

--- a/tests/test_header_pattern_autopromotion.py
+++ b/tests/test_header_pattern_autopromotion.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tests.header_pipeline_utils import run_header_pipeline
+
+
+def test_appendix_and_numeric_patterns_promote(tmp_path: Path) -> None:
+    text = (
+        "General overview Appendix B — Instrumentation scope details\n"
+        "Support systems include multiple feeds A5. Utilities Provided for operators\n"
+        "Follow-on narrative referencing A.1 Startup Procedure for commissioning\n"
+    )
+
+    output_dir = tmp_path / "patterns"
+    output_dir.mkdir()
+
+    result = run_header_pipeline("doc-patterns", text, output_dir)
+
+    labels = {header["label"] for header in result.headers}
+    assert "Appendix B" in labels
+    assert "A5." in labels
+    assert "A.1" in labels
+
+    promoted = json.loads((output_dir / "headers_promoted.json").read_text())
+    reasons = {entry.get("promotion_reason") for entry in promoted}
+    assert "pattern" in reasons
+    appendix_entries = [entry for entry in promoted if entry.get("pattern") == "appendix_top"]
+    assert appendix_entries, "Expected Appendix promotion to be logged"
+
+    suppressed = json.loads((output_dir / "headers_suppressed.json").read_text())
+    assert all(entry.get("pattern") == "appendix_top" for entry in suppressed)

--- a/tests/test_header_split_across_uf.py
+++ b/tests/test_header_split_across_uf.py
@@ -27,9 +27,9 @@ def test_header_split_across_uf(tmp_path: Path) -> None:
     accepted = [
         entry
         for entry in audit["efhg_header_spans"]
-        if entry["decision"] == "accepted" and entry.get("header_label") == "A5."
+        if entry.get("header_label") == "A5." and entry["decision"] in {"accepted", "promoted"}
     ]
-    assert accepted, "Expected accepted EFHG span for split header"
+    assert accepted, "Expected promoted EFHG span for split header"
     span_entry = accepted[0]
     assert span_entry["scores"]["fluid"]["Flow_total"] > 0
     assert span_entry["scores"]["hep"]["S_HEP"] >= HEP_DEFAULTS["theta_hep"]

--- a/tests/test_sequence_repair_appx_gap.py
+++ b/tests/test_sequence_repair_appx_gap.py
@@ -38,7 +38,7 @@ def test_sequence_repair_appx_gap(tmp_path: Path) -> None:
     audit = json.loads((output_dir / "candidate_audit.json").read_text())
     gap_entry = next((entry for entry in audit["sequence_repair"] if entry["gap"].startswith("A5")), None)
     assert gap_entry is not None
-    assert gap_entry["series"] == "APPX"
+    assert gap_entry["series"] == "A"
     assert gap_entry["before"]["text"].startswith("Prior")
     assert gap_entry["after"]["text"].startswith("Closing")
     assert gap_entry["result"], "Expected repair candidates logged"

--- a/tests/test_sequence_repair_numeric_gap.py
+++ b/tests/test_sequence_repair_numeric_gap.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tests.header_pipeline_utils import run_header_pipeline
+
+
+def test_sequence_repair_inserts_missing_numeric(tmp_path: Path) -> None:
+    text = (
+        "8) Scope overview\n"
+        "Background narrative.\n"
+        "9) Safety provisions and monitoring\n"
+        "Detailed considerations.\n"
+        "10) Closing remarks\n"
+    )
+
+    def fake_llm(_messages: object) -> str:
+        payload = {
+            "headers": [
+                {"label": "8)", "text": "Scope overview", "page": 1},
+                {"label": "10)", "text": "Closing remarks", "page": 1},
+            ]
+        }
+        return "```json\n" + json.dumps(payload) + "\n```"
+
+    output_dir = tmp_path / "numeric"
+    output_dir.mkdir()
+    result = run_header_pipeline("doc-numeric", text, output_dir, call_llm=fake_llm)
+
+    headers = {header["label"]: header for header in result.headers}
+    assert "9)" in headers
+    assert headers["9)"]["source"] == "repair"
+
+    audit = json.loads((output_dir / "candidate_audit.json").read_text())
+    repair_entries = [entry for entry in audit["sequence_repair"] if entry["series"] == "NUMERIC"]
+    assert repair_entries, "Expected numeric repair entry"
+    found = any(item["label"] == "9)" for entry in repair_entries for item in entry["result"])
+    assert found, "Numeric repair should record inserted header"


### PR DESCRIPTION
## Summary
- add configuration flags and a dedicated header scan module so numeric and appendix patterns auto-promote and are audited
- rework the header pipeline to rely on pattern promotion, resolve EFHG conflicts, emit new artifacts, and avoid clobbering repaired headers
- extend sequence repair and header pattern detection while adding regression tests for autopromotion, appendix gaps, and numeric repairs

## Testing
- pytest tests -q

------
https://chatgpt.com/codex/tasks/task_e_68d6d45361c083248e4dbf451133ba1a