### PR TITLE
Enhance UF line metadata and header gating

### DIFF
--- a/backend/headers/header_scan.py
+++ b/backend/headers/header_scan.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, Iterable, List, Sequence
+from typing import Dict, Iterable, List, Mapping, Sequence
 
+import logging
 import re
 
 from backend.headers.config import HEADER_GATE_MODE
@@ -42,6 +43,9 @@ _PATTERN_FINDER = {
 }
 
 
+LOGGER = logging.getLogger(__name__)
+
+
 @dataclass
 class HeaderCandidate:
     """Represents a single line (or inline segment) that resembles a header."""
@@ -60,6 +64,7 @@ class HeaderCandidate:
     promoted: bool = False
     promotion_reason: str | None = None
     total: float = 0.0
+    para_evidence: Dict[str, object] = field(default_factory=dict)
 
     def to_dict(self) -> Dict[str, object]:
         return {
@@ -77,7 +82,66 @@ class HeaderCandidate:
             "promoted": self.promoted,
             "promotion_reason": self.promotion_reason,
             "score_total": self.total,
+            "para_evidence": dict(self.para_evidence),
         }
+
+
+def _build_para_evidence(line_meta: Mapping[str, object] | None) -> Dict[str, object]:
+    if not line_meta:
+        return {
+            "virtual_blank_lines_before": 0,
+            "para_start": False,
+            "y_gap": 0.0,
+            "style_jump": {"font_delta": 0.0, "bold_flip": False, "left_x_delta": 0.0},
+            "list_context": "none",
+        }
+    style_jump_raw = line_meta.get("style_jump")
+    if not isinstance(style_jump_raw, Mapping):
+        style_jump_raw = {}
+    evidence = {
+        "virtual_blank_lines_before": int(line_meta.get("virtual_blank_lines_before") or 0),
+        "para_start": bool(line_meta.get("para_start")),
+        "y_gap": float(line_meta.get("y_gap") or 0.0),
+        "style_jump": {
+            "font_delta": float(style_jump_raw.get("font_delta") or 0.0),
+            "bold_flip": bool(style_jump_raw.get("bold_flip")),
+            "left_x_delta": float(style_jump_raw.get("left_x_delta") or 0.0),
+        },
+        "list_context": str(line_meta.get("list_context") or "none"),
+    }
+    return evidence
+
+
+def _passes_prefilter(
+    pattern: str,
+    evidence: Mapping[str, object],
+    *,
+    line_meta: Mapping[str, object] | None,
+    chunk_meta: Mapping[str, object] | None,
+) -> tuple[bool, List[str]]:
+    reasons: List[str] = []
+    blank_lines = int(evidence.get("virtual_blank_lines_before") or 0)
+    if not blank_lines and chunk_meta:
+        try:
+            blank_lines = int(chunk_meta.get("blank_lines_before") or 0)
+        except Exception:
+            blank_lines = 0
+    if chunk_meta:
+        para_start = bool(evidence.get("para_start")) or bool(chunk_meta.get("para_start"))
+    else:
+        para_start = bool(evidence.get("para_start"))
+    list_ctx = str(evidence.get("list_context") or "none")
+    if list_ctx == "none" and line_meta:
+        list_ctx = str(line_meta.get("list_context") or "none")
+    if list_ctx == "none" and chunk_meta:
+        list_ctx = str(chunk_meta.get("list_context") or "none")
+
+    if pattern == "numeric_section" and not (para_start or blank_lines >= 1):
+        reasons.append("no_paragraph_break")
+    if list_ctx == "table_row":
+        reasons.append("inside_table_row?")
+
+    return (not reasons, reasons)
 
 
 def _scan_line(
@@ -86,6 +150,8 @@ def _scan_line(
     line_index: int,
     base_offset: int,
     raw_line: str,
+    line_meta: Mapping[str, object] | None,
+    chunk_meta: Mapping[str, object] | None,
 ) -> Iterable[HeaderCandidate]:
     """Yield header candidates discovered within a single chunk line."""
 
@@ -114,6 +180,22 @@ def _scan_line(
             end_char = start_char + len(trimmed)
             label_match = HEADER_PATTERN.match(trimmed)
             label = label_match.group(0).strip() if label_match else trimmed.split(" ")[0]
+            evidence = _build_para_evidence(line_meta)
+            keep, reasons = _passes_prefilter(pattern, evidence, line_meta=line_meta, chunk_meta=chunk_meta or {})
+            if not keep:
+                if reasons:
+                    LOGGER.debug(
+                        "[header_scan] %s",
+                        {
+                            "event": "candidate_skip",
+                            "chunk_id": chunk.id,
+                            "line_index": line_index,
+                            "pattern": pattern,
+                            "reason": reasons,
+                            "para_evidence": evidence,
+                        },
+                    )
+                continue
             candidate = HeaderCandidate(
                 chunk_id=chunk.id,
                 chunk_index=chunk_index,
@@ -126,6 +208,7 @@ def _scan_line(
                 end_char=int(end_char),
                 style=dict(chunk.style or {}),
             )
+            candidate.para_evidence = dict(evidence)
             results.append(candidate)
             # Avoid emitting duplicate candidates for the same segment by
             # breaking after the first anchored match per pattern.
@@ -142,8 +225,27 @@ def scan_candidates(chunks: Sequence[UFChunk]) -> List[HeaderCandidate]:
         if not text.strip():
             continue
         offset = 0
+        chunk_meta = chunk.meta if isinstance(getattr(chunk, "meta", None), Mapping) else {}
+        line_metas = []
+        if isinstance(chunk_meta.get("line_metas"), Sequence):
+            line_metas = list(chunk_meta.get("line_metas") or [])
         for line_index, line in enumerate(text.splitlines(keepends=True)):
-            found = list(_scan_line(chunk, chunk_index, line_index, offset, line))
+            line_meta = None
+            if line_metas and line_index < len(line_metas):
+                candidate_meta = line_metas[line_index]
+                if isinstance(candidate_meta, Mapping):
+                    line_meta = candidate_meta
+            found = list(
+                _scan_line(
+                    chunk,
+                    chunk_index,
+                    line_index,
+                    offset,
+                    line,
+                    line_meta,
+                    chunk_meta,
+                )
+            )
             candidates.extend(found)
             offset += len(line)
     for idx, candidate in enumerate(candidates):

--- a/backend/pipeline/uf_pipeline.py
+++ b/backend/pipeline/uf_pipeline.py
@@ -21,6 +21,8 @@ import inspect
 import json
 import logging
 import os
+import statistics
+from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple
@@ -46,6 +48,40 @@ _SPACE_VARIANTS = "\u00A0\u2002\u2003\u2009\u200A\u202F\u205F\u3000"
 _ZERO_WIDTH = "\u200B\u200C\u200D\u2060\uFEFF"
 _TOKEN_RX = re.compile(r"\p{L}[\p{L}\p{Mn}\p{Mc}\p{Pd}\p{Pc}\p{Nd}]*|\p{N}+|[^\s]", re.UNICODE)
 _HEADER_MARK_RX = re.compile(r"^\s*(?:\d+\)|[A-Z]\d+\.)")
+_FILL_LINE_RX = re.compile(r"_{3,}\s*$")
+_BULLET_RX = re.compile(r"^\s*(?:[-*\u2022\u2023\u2043]|[A-Za-z]{1,3}\)|[A-Za-z]{1,3}\.)\s+")
+_NUMBERED_RX = re.compile(r"^\s*(?:\d{1,3}(?:[.)]|(?:\.\d+)*\.)|\d{1,3}\))\s+")
+_TABLE_ROW_RX = re.compile(r"(?:\t|\s{2,}\S)\s{2,}\S")
+_GUTTER_TOLERANCE = 8.0
+
+
+def _classify_trailing_punct(text: str) -> Optional[str]:
+    if not text:
+        return None
+    stripped = text.rstrip()
+    if not stripped:
+        return None
+    if _FILL_LINE_RX.search(stripped):
+        return "_FILL"
+    tail = stripped[-1]
+    if tail in {".", ",", ":", ";", ")", "]"}:
+        return tail
+    return None
+
+
+def _detect_list_context(text: str) -> str:
+    if not text:
+        return "none"
+    stripped = text.strip()
+    if not stripped:
+        return "none"
+    if _TABLE_ROW_RX.search(text):
+        return "table_row"
+    if _BULLET_RX.match(stripped):
+        return "bullet"
+    if _NUMBERED_RX.match(stripped):
+        return "numbered"
+    return "none"
 
 
 def _normalise_spaces(text: str) -> str:
@@ -92,6 +128,7 @@ class PageRecord:
     norm_text: str
     lines: List[str]
     line_styles: List[Mapping[str, Any]]
+    line_models: List[Mapping[str, Any]]
     line_offsets: List[int]
     tokens: List[Dict[str, Any]]
 
@@ -264,49 +301,220 @@ def _ingest_pdf(
     jsonl_rows: List[Dict[str, Any]] = []
 
     for page_idx, lines in enumerate(pages_lines, start=1):
-        styles = page_styles[page_idx - 1] if page_idx - 1 < len(page_styles) else [{} for _ in lines]
+        styles_src = page_styles[page_idx - 1] if page_idx - 1 < len(page_styles) else [{} for _ in lines]
         joined = "\n".join(lines)
         norm = _normalise_text(joined)
         offsets: List[int] = []
         tokens: List[Dict[str, Any]] = []
         cursor = 0
         line_entries: List[Dict[str, Any]] = []
+        line_models: List[Dict[str, Any]] = []
+        styles_out: List[Dict[str, Any]] = []
+        prev_meta: Optional[Dict[str, Any]] = None
+        median_buf: deque[float] = deque(maxlen=25)
+        prev_end_offset = 0
         for line_idx, line in enumerate(lines):
-            style = styles[line_idx] if line_idx < len(styles) else {}
-            offsets.append(cursor)
-            line_tokens = _tokenise_with_offsets(line, base_offset=cursor)
+            base_style = styles_src[line_idx] if line_idx < len(styles_src) else {}
+            style = dict(base_style or {})
+            start_offset = cursor
+            offsets.append(start_offset)
+            line_tokens = _tokenise_with_offsets(line, base_offset=start_offset)
             tokens.extend({**token, "line_idx": line_idx} for token in line_tokens)
-            line_entries.append(
+
+            bbox = style.get("bbox") if isinstance(style, Mapping) else None
+            left_x = None
+            y_top = None
+            y_bottom = None
+            if isinstance(bbox, (list, tuple)) and len(bbox) >= 4:
+                try:
+                    left_x = float(bbox[0])
+                except Exception:  # pragma: no cover - defensive
+                    left_x = None
+                try:
+                    y_top = float(bbox[1])
+                    y_bottom = float(bbox[3])
+                except Exception:  # pragma: no cover - defensive
+                    y_top = y_bottom = None
+
+            font_pt_raw = style.get("font_pt", style.get("font_size"))
+            try:
+                font_pt = float(font_pt_raw) if font_pt_raw is not None else 0.0
+            except Exception:
+                font_pt = 0.0
+            bold_flag = bool(style.get("bold"))
+
+            line_height = 0.0
+            if y_top is not None and y_bottom is not None:
+                line_height = float(y_bottom - y_top)
+            elif prev_meta and prev_meta.get("line_height"):
+                line_height = float(prev_meta["line_height"])
+
+            if median_buf:
+                median_gap = statistics.median(median_buf)
+            else:
+                baseline = prev_meta.get("line_height") if prev_meta else None
+                median_gap = float(baseline) if baseline else (line_height if line_height > 0 else 1.0)
+            if median_gap <= 0:
+                median_gap = line_height if line_height > 0 else 1.0
+
+            prev_trailing = prev_meta.get("trailing_punct") if prev_meta else None
+            prev_font = prev_meta.get("font_pt") if prev_meta else None
+            prev_left = prev_meta.get("left_x") if prev_meta else None
+            prev_bottom = prev_meta.get("y_bottom") if prev_meta else None
+
+            if prev_font is not None:
+                try:
+                    font_delta = float(font_pt - float(prev_font))
+                except Exception:
+                    font_delta = 0.0
+            else:
+                font_delta = 0.0
+            bold_flip = bool(prev_meta and bool(prev_meta.get("bold")) != bold_flag)
+            if left_x is not None and prev_left is not None:
+                try:
+                    left_x_delta = float(left_x - float(prev_left))
+                except Exception:
+                    left_x_delta = 0.0
+            else:
+                left_x_delta = 0.0
+
+            if y_top is not None and prev_bottom is not None:
+                try:
+                    y_gap = float(y_top - float(prev_bottom))
+                except Exception:
+                    y_gap = 0.0
+            else:
+                y_gap = 0.0
+
+            big_gap = y_gap > 1.6 * median_gap if median_gap > 0 else y_gap > 0
+            hard_newline = (start_offset - prev_end_offset) >= 2 if line_idx > 0 else False
+            style_break = bool(bold_flip or abs(font_delta) >= 1.0 or abs(left_x_delta) > _GUTTER_TOLERANCE)
+
+            virtual_blanks = 1 if big_gap else 0
+            if hard_newline:
+                virtual_blanks += 1
+            if median_gap > 0:
+                huge_gap = y_gap > 2.2 * median_gap
+            else:
+                huge_gap = y_gap > 0
+            if huge_gap:
+                virtual_blanks = max(virtual_blanks, 2)
+
+            para_start = bool(
+                hard_newline
+                or big_gap
+                or style_break
+                or (prev_trailing in {".", "_FILL", ":"})
+            )
+
+            is_blank = not (line.strip())
+            list_context = _detect_list_context(line)
+            newline_count = (start_offset - prev_end_offset) if line_idx > 0 else 0
+
+            style_jump = {
+                "font_delta": font_delta,
+                "bold_flip": bold_flip,
+                "left_x_delta": left_x_delta,
+            }
+
+            style.setdefault("font_pt", font_pt)
+            if left_x is not None:
+                style.setdefault("left_x", left_x)
+            if line_height:
+                style.setdefault("line_height", line_height)
+            styles_out.append(dict(style))
+
+            line_entry = {
+                "page": page_idx,
+                "index": line_idx,
+                "text": line,
+                "norm_text": _normalise_text(line),
+                "style": style,
+                "tokens": line_tokens,
+                "break_reason": "line_break",
+                "is_blank": bool(is_blank),
+                "newline_count": int(newline_count),
+                "y_gap": float(y_gap),
+                "line_height": float(line_height),
+                "virtual_blank_lines_before": int(virtual_blanks),
+                "style_jump": dict(style_jump),
+                "para_start": bool(para_start),
+                "prev_trailing_punct": prev_trailing,
+                "list_context": list_context,
+                "left_x": float(left_x) if left_x is not None else None,
+                "font_pt": float(font_pt),
+                "bold": bool(bold_flag),
+            }
+            line_entries.append(line_entry)
+
+            line_models.append(
                 {
+                    "page": page_idx,
                     "index": line_idx,
                     "text": line,
-                    "norm_text": _normalise_text(line),
-                    "style": style,
-                    "tokens": line_tokens,
-                    "break_reason": "line_break",
+                    "norm_text": line_entry["norm_text"],
+                    "is_blank": bool(is_blank),
+                    "newline_count": int(newline_count),
+                    "y_gap": float(y_gap),
+                    "line_height": float(line_height),
+                    "virtual_blank_lines_before": int(virtual_blanks),
+                    "style_jump": dict(style_jump),
+                    "para_start": bool(para_start),
+                    "prev_trailing_punct": prev_trailing,
+                    "list_context": list_context,
+                    "left_x": float(left_x) if left_x is not None else None,
+                    "font_pt": float(font_pt),
+                    "bold": bool(bold_flag),
                 }
             )
+
             indent = None
-            bbox = style.get("bbox") if isinstance(style, Mapping) else None
-            if isinstance(bbox, (list, tuple)) and len(bbox) >= 1:
-                try:
-                    indent = float(bbox[0])
-                except Exception:  # pragma: no cover - defensive
-                    indent = None
+            if left_x is not None:
+                indent = left_x
             part = {
                 "doc_id": doc_id,
                 "text": line,
                 "page": page_idx,
                 "line_idx": line_idx,
-                "font_size": style.get("font_size"),
+                "font_size": style.get("font_size", font_pt),
+                "font_pt": font_pt,
                 "font_weight": style.get("font_weight"),
-                "bold": style.get("bold"),
+                "bold": bold_flag,
                 "indent": indent,
                 "break_reason": "line_break",
                 "header_anchor": bool(_HEADER_MARK_RX.match(line.strip())),
+                "is_blank": bool(is_blank),
+                "newline_count": int(newline_count),
+                "y_gap": float(y_gap),
+                "line_height": float(line_height),
+                "virtual_blank_lines_before": int(virtual_blanks),
+                "style_jump": dict(style_jump),
+                "para_start": bool(para_start),
+                "prev_trailing_punct": prev_trailing,
+                "list_context": list_context,
+                "left_x": float(left_x) if left_x is not None else None,
             }
             parts.append(part)
-            cursor += len(line) + 1
+
+            current_trailing = _classify_trailing_punct(line)
+            prev_meta = {
+                "font_pt": font_pt,
+                "bold": bold_flag,
+                "left_x": left_x,
+                "y_bottom": y_bottom,
+                "line_height": line_height,
+                "trailing_punct": current_trailing,
+            }
+            prev_end_offset = start_offset + len(line)
+            cursor = prev_end_offset + 1
+
+            if line_height > 0:
+                median_buf.append(float(line_height))
+            elif prev_meta.get("line_height"):
+                try:
+                    median_buf.append(float(prev_meta["line_height"]))
+                except Exception:  # pragma: no cover - defensive
+                    median_buf.append(0.0)
 
         jsonl_rows.append(
             {
@@ -322,7 +530,8 @@ def _ingest_pdf(
                 raw_text=joined,
                 norm_text=norm,
                 lines=list(lines),
-                line_styles=[dict(style) for style in styles],
+                line_styles=styles_out,
+                line_models=line_models,
                 line_offsets=offsets,
                 tokens=tokens,
             )

--- a/backend/uf_chunker.py
+++ b/backend/uf_chunker.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import hashlib
 import math
 import re
+from collections import Counter
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
 
 
 HEADER_PATTERN = re.compile(
@@ -32,6 +33,20 @@ DOMAIN_KEYWORDS = {
 }
 
 
+def _majority_vote(values: Sequence[Any], default: Any = None, skip: Optional[Sequence[Any]] = None) -> Any:
+    skip_set = set(skip or [])
+    filtered = [value for value in values if value not in skip_set]
+    if not filtered:
+        return default
+    counts = Counter(filtered)
+    best = max(counts.values()) if counts else 0
+    winners = {value for value, count in counts.items() if count == best}
+    for value in filtered:
+        if value in winners:
+            return value
+    return filtered[0] if filtered else default
+
+
 @dataclass
 class UFChunk:
     """Container for an Ultrafine chunk."""
@@ -47,6 +62,7 @@ class UFChunk:
     domain_hint: Optional[str] = None
     entropy: Dict[str, float] = field(default_factory=dict)
     header_anchor: bool = False
+    meta: Dict[str, Any] = field(default_factory=dict)
 
     def preview(self, max_len: int = 80) -> str:
         text = self.text.strip().replace("\n", " ")
@@ -179,6 +195,88 @@ def uf_chunk(doc_decomp: Dict[str, Any], max_tokens: int = 90, overlap: int = 12
                 domain_hint=_infer_domain_hint(text),
                 header_anchor=header_anchor,
             )
+
+            page_lines = page.get("lines") or []
+            line_indices = sorted(
+                {
+                    int(tok.get("line_idx"))
+                    for tok in chunk_tokens
+                    if isinstance(tok.get("line_idx"), int)
+                }
+            )
+            chunk_line_meta: List[Dict[str, Any]] = []
+            blank_scores: List[int] = []
+            para_flags: List[bool] = []
+            prev_puncts: List[Any] = []
+            list_contexts: List[str] = []
+
+            for line_idx in line_indices:
+                entry = None
+                if isinstance(page_lines, Sequence) and 0 <= line_idx < len(page_lines):
+                    candidate = page_lines[line_idx]
+                    if isinstance(candidate, Mapping):
+                        entry = candidate
+                if entry is None and isinstance(page_lines, Sequence):
+                    for candidate in page_lines:
+                        if isinstance(candidate, Mapping) and int(candidate.get("index", -1)) == line_idx:
+                            entry = candidate
+                            break
+                if entry is None:
+                    continue
+
+                style_jump_raw = entry.get("style_jump") or {}
+                style_jump = {
+                    "font_delta": float(style_jump_raw.get("font_delta") or 0.0),
+                    "bold_flip": bool(style_jump_raw.get("bold_flip")),
+                    "left_x_delta": float(style_jump_raw.get("left_x_delta") or 0.0),
+                }
+                virtual_blank = int(entry.get("virtual_blank_lines_before") or 0)
+                para_flag = bool(entry.get("para_start"))
+                prev_punct = entry.get("prev_trailing_punct")
+                list_ctx = str(entry.get("list_context") or "none")
+                y_gap = float(entry.get("y_gap") or 0.0)
+                line_height = float(entry.get("line_height") or 0.0)
+                newline_count = int(entry.get("newline_count") or 0)
+                left_x_val = entry.get("left_x")
+                try:
+                    left_x = float(left_x_val) if left_x_val is not None else None
+                except Exception:
+                    left_x = None
+                font_pt_val = entry.get("font_pt")
+                try:
+                    font_pt = float(font_pt_val) if font_pt_val is not None else 0.0
+                except Exception:
+                    font_pt = 0.0
+
+                chunk_line_meta.append(
+                    {
+                        "text": entry.get("text"),
+                        "index": line_idx,
+                        "is_blank": bool(entry.get("is_blank")),
+                        "newline_count": newline_count,
+                        "y_gap": y_gap,
+                        "line_height": line_height,
+                        "virtual_blank_lines_before": virtual_blank,
+                        "style_jump": style_jump,
+                        "para_start": para_flag,
+                        "prev_trailing_punct": prev_punct,
+                        "list_context": list_ctx,
+                        "left_x": left_x,
+                        "font_pt": font_pt,
+                        "bold": bool(entry.get("bold")),
+                    }
+                )
+                blank_scores.append(virtual_blank)
+                para_flags.append(para_flag)
+                prev_puncts.append(prev_punct)
+                list_contexts.append(list_ctx)
+
+            chunk.meta["blank_lines_before"] = int(max(blank_scores) if blank_scores else 0)
+            chunk.meta["para_start"] = any(para_flags)
+            chunk.meta["prev_trailing_punct"] = _majority_vote(prev_puncts, default=None, skip={None, ""})
+            chunk.meta["list_context"] = _majority_vote(list_contexts, default="none", skip={None, ""})
+            chunk.meta["line_metas"] = chunk_line_meta
+            chunk.meta["line_indices"] = line_indices
             chunks.append(chunk)
             chunk_index += 1
             if j >= len(tokens):

--- a/ingest/microchunker.py
+++ b/ingest/microchunker.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import hashlib
+from collections import Counter
 from dataclasses import dataclass
 from typing import (
     Any,
@@ -49,6 +50,7 @@ class MicroChunk(TypedDict, total=False):
     lex: Dict[str, object]
     emb: List[float]
     domain_hint: Optional[str]
+    meta: Dict[str, object]
 
 
 @dataclass
@@ -343,6 +345,69 @@ def _microchunk_from_window(
     chunk["lex"] = _extract_lex(raw_text)
     chunk["emb"] = _compute_embedding(norm_text)
     chunk["domain_hint"] = _infer_domain_hint(norm_text)
+
+    line_meta_entries: List[Dict[str, object]] = []
+    blank_scores: List[int] = []
+    para_flags: List[bool] = []
+    prev_puncts: List[object] = []
+    list_contexts: List[str] = []
+    for idx in part_indices:
+        part = parts[idx]
+        style_jump_raw = part.get("style_jump") or {}
+        style_jump = {
+            "font_delta": float(style_jump_raw.get("font_delta") or 0.0),
+            "bold_flip": bool(style_jump_raw.get("bold_flip")),
+            "left_x_delta": float(style_jump_raw.get("left_x_delta") or 0.0),
+        }
+        virtual_blank = int(part.get("virtual_blank_lines_before") or 0)
+        para_flag = bool(part.get("para_start"))
+        prev_punct = part.get("prev_trailing_punct")
+        list_ctx = str(part.get("list_context") or "none")
+        y_gap = float(part.get("y_gap") or 0.0)
+        line_height = float(part.get("line_height") or 0.0)
+        newline_count = int(part.get("newline_count") or 0)
+        left_x_val = part.get("left_x")
+        try:
+            left_x = float(left_x_val) if left_x_val is not None else None
+        except Exception:
+            left_x = None
+        font_pt_val = part.get("font_pt", part.get("font_size"))
+        try:
+            font_pt = float(font_pt_val) if font_pt_val is not None else 0.0
+        except Exception:
+            font_pt = 0.0
+        line_meta_entries.append(
+            {
+                "text": part.get("text"),
+                "page": part.get("page"),
+                "line_idx": part.get("line_idx"),
+                "is_blank": bool(part.get("is_blank")),
+                "newline_count": newline_count,
+                "y_gap": y_gap,
+                "line_height": line_height,
+                "virtual_blank_lines_before": virtual_blank,
+                "style_jump": style_jump,
+                "para_start": para_flag,
+                "prev_trailing_punct": prev_punct,
+                "list_context": list_ctx,
+                "left_x": left_x,
+                "font_pt": font_pt,
+                "bold": bool(part.get("bold")),
+            }
+        )
+        blank_scores.append(virtual_blank)
+        para_flags.append(para_flag)
+        prev_puncts.append(prev_punct)
+        list_contexts.append(list_ctx)
+
+    meta: Dict[str, object] = dict(chunk.get("meta") or {})
+    meta["blank_lines_before"] = int(max(blank_scores) if blank_scores else 0)
+    meta["para_start"] = any(para_flags)
+    meta["prev_trailing_punct"] = _majority_vote(prev_puncts, default=None, skip={None, ""})
+    meta["list_context"] = _majority_vote(list_contexts, default="none", skip={None, ""})
+    meta["line_metas"] = line_meta_entries
+    meta["line_part_indices"] = list(part_indices)
+    chunk["meta"] = meta
     return chunk
 
 
@@ -419,3 +484,15 @@ def microchunk_text(
 
 
 __all__ = ["MicroChunk", "microchunk_text"]
+def _majority_vote(values: Sequence[object], default: object | None = None, *, skip: Optional[Sequence[object]] = None) -> object | None:
+    skip_set = set(skip or [])
+    filtered = [value for value in values if value not in skip_set]
+    if not filtered:
+        return default
+    counts = Counter(filtered)
+    best = max(counts.values()) if counts else 0
+    winners = {value for value, count in counts.items() if count == best}
+    for value in filtered:
+        if value in winners:
+            return value
+    return filtered[0] if filtered else default


### PR DESCRIPTION
## Summary
- add layout-derived paragraph metadata to preprocess line records, including gap heuristics, style deltas, and list context
- propagate the new line signals into microchunk and UF chunk meta so downstream consumers can inspect paragraph evidence
- gate header candidates with the new metadata, logging skip reasons and attaching structured para evidence for audits

## Testing
- pytest backend/tests/test_preprocess_debug_exports.py


------
https://chatgpt.com/codex/tasks/task_e_68d70127dc78832481bad807e8f62230