### PR TITLE
Add coverage ensuring preprocess truth headers reach final output

### DIFF
--- a/tests/test_preprocess_truth_mode.py
+++ b/tests/test_preprocess_truth_mode.py
@@ -109,4 +109,13 @@ def test_appendix_headers_follow_preprocess_truth(tmp_path):
     assert [row["page"] for row in truth_rows[2:]] == [7] * 6
 
     assert [row["text"] for row in result.truth] == expected_sequence
-    assert len(result.headers) == len(expected_sequence)
+    assert [
+        (item["page"], f"{item['label']} {item['text']}".strip())
+        for item in result.headers
+    ] == [
+        (6, line)
+        for line in page6_lines
+    ] + [
+        (7, line)
+        for line in page7_lines
+    ]


### PR DESCRIPTION
## Summary
- tighten the preprocess truth mode integration test to assert the final header payload preserves the raw appendix sequence

## Testing
- pytest tests/test_preprocess_truth_mode.py

------
https://chatgpt.com/codex/tasks/task_e_68d724114cd883248e7894df1afba353