### PR TITLE
Document preprocess-only header contract

### DIFF
--- a/backend/headers/config.py
+++ b/backend/headers/config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 # Overall header mode determines the promotion strategy.
 # "preprocess_only" => trust preprocess headers as the final list with zero post-processing.
 # "legacy" => fall back to the historical EFHG pipeline (see ``HEADER_LEGACY_PROFILE``).
-HEADER_MODE = "preprocess_only"
+HEADER_MODE = "preprocess_only"  # options: "preprocess_only", "legacy"
 
 # When running the legacy pipeline additional strategy hints are required.
 # "preprocess_truth" => promote preprocess headers directly (with optional stitching).

--- a/backend/headers/header_finalize.py
+++ b/backend/headers/header_finalize.py
@@ -71,7 +71,14 @@ def _normalize_headers(doc: object) -> list[dict[str, object]]:
 
 
 def finalize_headers_preprocess_only(doc: object) -> list[dict[str, object]]:
-    """Use preprocess headers as the single source of truth for final headers."""
+    """Use preprocess headers as the single source of truth for final headers.
+
+    The resulting list is considered canonical when ``HEADER_MODE`` is set to
+    ``"preprocess_only"``. Downstream systems should consume either the
+    returned list or the persisted ``headers_final.json`` artifact and must not
+    expect EFHG scoring, audits, or suppression heuristics to have been
+    applied.
+    """
 
     raw_entries = _normalize_headers(doc)
 

--- a/backend/headers/pipeline.py
+++ b/backend/headers/pipeline.py
@@ -48,6 +48,16 @@ from backend.uf_chunker import HEADER_PATTERN, UFChunk, uf_chunk
 
 @dataclass
 class HeaderIndex:
+    """Materialized header payload for downstream consumers.
+
+    In ``HEADER_MODE == "preprocess_only"`` callers must treat the
+    preprocess payload (returned directly from
+    :func:`finalize_headers_preprocess_only`) as the canonical list of final
+    headers. No EFHG metadata or audit records are produced in that mode and
+    ``headers_final.json`` is the artifact of record. The ``truth`` field is
+    retained for legacy compatibility when the EFHG pipeline runs.
+    """
+
     doc_id: str
     headers: List[Dict[str, Any]]
     uf_chunks: List[UFChunk]
@@ -1347,7 +1357,14 @@ def _decomp_from_doc(doc: object) -> Mapping[str, Any]:
 
 
 def run_headers_stage(doc: object) -> List[Dict[str, Any]]:
-    """Return the finalized headers list for ``doc`` based on configuration."""
+    """Return the finalized headers list for ``doc`` based on configuration.
+
+    When ``HEADER_MODE`` is ``"preprocess_only"`` this is a thin wrapper that
+    exposes the preprocess headers as the definitive, ordered header list. In
+    that configuration callers should read ``headers_final.json`` (or reuse the
+    returned in-memory list) rather than attempting to inspect EFHG audit data,
+    which is not produced.
+    """
 
     if cfg.HEADER_MODE == "preprocess_only":
         return finalize_headers_preprocess_only(doc)


### PR DESCRIPTION
## Summary
- document the preprocess-only header mode contract for downstream consumers
- note headers_final.json as the canonical artifact when post-processing is disabled

## Testing
- pytest tests/test_preprocess_only_mode.py

------
https://chatgpt.com/codex/tasks/task_e_68d72a3356848324b11dcc41c421e5ae