### PR TITLE
Guard preprocess-only header mode

### DIFF
--- a/backend/headers/header_scan.py
+++ b/backend/headers/header_scan.py
@@ -8,7 +8,7 @@ from typing import Dict, Iterable, List, Mapping, Sequence
 import logging
 import re
 
-from backend.headers.config import HEADER_GATE_MODE
+from backend.headers import config as cfg
 from backend.uf_chunker import HEADER_PATTERN, UFChunk
 
 # Strong patterns that should always auto-promote regardless of EFHG scores.
@@ -259,7 +259,14 @@ def promote_candidates(
 ) -> List[HeaderCandidate]:
     """Apply promotion rules to header candidates."""
 
-    gate = gate_mode or HEADER_GATE_MODE
+    if cfg.HEADER_MODE == "preprocess_only":
+        # In preprocess-only mode we bypass post-processing entirely and the
+        # preprocess headers are considered authoritative. Downstream callers
+        # should not rely on EFHG scores or promotion flags, so we simply return
+        # the sequence as-is.
+        return list(candidates)
+
+    gate = gate_mode or cfg.HEADER_GATE_MODE
     promoted: List[HeaderCandidate] = []
     for candidate in candidates:
         if candidate.pattern in STRONG_PATTERNS:

--- a/docs/appendix_header_recovery.md
+++ b/docs/appendix_header_recovery.md
@@ -6,6 +6,17 @@ segmentation or typography is unreliable. Each technique maps to an existing
 stage in the FluidRAG pipeline so you can bolt it onto the current flow without
 a wholesale rewrite.
 
+## Preprocess-only header mode
+
+The header subsystem now exposes a `HEADER_MODE` flag in
+`backend.headers.config`. When set to `"preprocess_only"`, the pipeline
+trusts the preprocess payload as the single source of truth: the
+`run_headers_stage` wrapper returns the normalized preprocess headers and the
+canonical artifact persists as `headers_final.json`. Downstream components must
+consume that artifact (or the returned list) directly—no EFHG candidate audits,
+scores, or suppression heuristics run in this mode—ensuring appendix headers
+like A5/A6 remain intact.
+
 ## Pre-ingest (make the text exist the way you need)
 
 1. **Redundant line segmentation ensemble (vote & merge).**


### PR DESCRIPTION
## Summary
- short-circuit header candidate promotion when preprocess-only mode is active
- document the preprocess-only header contract for appendix header recovery consumers

## Testing
- pytest tests/test_preprocess_only_mode.py

------
https://chatgpt.com/codex/tasks/task_e_68d72bb24c148324902fba689594f33a