### PR TITLE
Ensure preprocess-only headers remain canonical

### DIFF
--- a/backend/headers/header_finalize.py
+++ b/backend/headers/header_finalize.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable, Mapping
+from typing import Any, Iterable, Mapping
 
 
 def _iter_header_dicts(payload: object) -> Iterable[Mapping[str, object]]:
@@ -29,23 +29,40 @@ def _iter_header_dicts(payload: object) -> Iterable[Mapping[str, object]]:
                 yield item
 
 
-def _normalize_headers(doc: object) -> list[dict[str, object]]:
+def _extract_preprocess_payload(doc: object) -> object:
+    """Return the raw preprocess headers payload from ``doc``."""
+
     preprocess = getattr(doc, "preprocess", None)
-    headers_payload = None
     if preprocess is not None:
-        headers_payload = getattr(preprocess, "headers_by_page", None)
-        if headers_payload is None:
-            headers_payload = getattr(preprocess, "headers", None)
-    if headers_payload is None and isinstance(doc, Mapping):
-        preprocess = doc.get("preprocess") if isinstance(doc, Mapping) else None
+        for attr in ("headers_by_page", "headers"):
+            payload = getattr(preprocess, attr, None)
+            if payload:
+                return payload
+
+    for attr in ("decomp", "payload", "data"):
+        candidate = getattr(doc, attr, None)
+        if isinstance(candidate, Mapping):
+            payload = _extract_preprocess_payload(candidate)
+            if payload:
+                return payload
+
+    if isinstance(doc, Mapping):
+        preprocess = doc.get("preprocess")
         if isinstance(preprocess, Mapping):
-            headers_payload = (
-                preprocess.get("headers_by_page")
-                or preprocess.get("headers")
-                or preprocess.get("pages")
-            )
-    if headers_payload is None:
-        headers_payload = []
+            for key in ("headers_by_page", "headers", "pages"):
+                payload = preprocess.get(key)
+                if payload:
+                    return payload
+        for key in ("preprocess_headers", "headers", "headers_by_page", "header_pages"):
+            payload = doc.get(key)
+            if payload:
+                return payload
+
+    return []
+
+
+def _normalize_headers(doc: object) -> list[dict[str, object]]:
+    headers_payload: Any = _extract_preprocess_payload(doc)
 
     normalized: list[dict[str, object]] = []
     for entry in _iter_header_dicts(headers_payload):

--- a/tests/test_preprocess_only_mode.py
+++ b/tests/test_preprocess_only_mode.py
@@ -40,6 +40,8 @@ class _DocFixture:
             {"page": 7, "line_idx": 4, "text": "A6. Performance"},
             {"page": 7, "line_idx": 5, "text": "A7. Layout"},
             {"page": 7, "line_idx": 6, "text": "A8. Options (pricing separate)"},
+            # Duplicate entry that should be de-duplicated by the finalizer.
+            {"page": 7, "line_idx": 4, "text": "A6. Performance"},
         ]
         self.doc_id = "doc-fixture"
         self.preprocess = SimpleNamespace(headers_by_page=headers)
@@ -78,6 +80,11 @@ def test_appendix_a_from_preprocess_only(doc_loaded_from_fixtures: _DocFixture, 
         (7, "A8. Options (pricing separate)"),
     }
     assert want.issubset(got), f"Missing headers: {want - got}"
+
+    unique_keys = {
+        (header["page"], header.get("line_idx"), header["text"]) for header in headers
+    }
+    assert len(headers) == len(unique_keys), "Duplicate headers should be removed"
 
     final_path = doc_loaded_from_fixtures.artifacts.base_dir / "headers_final.json"
     assert final_path.exists(), "final headers artifact not written"


### PR DESCRIPTION
## Summary
- update the preprocess finalizer to locate header payloads across common document layouts before normalizing them
- extend the preprocess-only integration test with a duplicate entry assertion to guard against regressions

## Testing
- pytest tests/test_preprocess_only_mode.py

------
https://chatgpt.com/codex/tasks/task_e_68d72caca5d083248753d3862fd42a7d