### PR TITLE
Normalize preprocess header ordering in preprocess-only mode

### DIFF
--- a/backend/headers/header_finalize.py
+++ b/backend/headers/header_finalize.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, Iterable, Mapping
+from typing import Any, Iterable, Mapping, Optional
 
 
 def _iter_header_dicts(payload: object) -> Iterable[Mapping[str, object]]:
@@ -61,6 +61,17 @@ def _extract_preprocess_payload(doc: object) -> object:
     return []
 
 
+def _to_int(value: object) -> Optional[int]:
+    """Return ``value`` coerced to ``int`` when possible."""
+
+    try:
+        if value is None:
+            return None
+        return int(value)
+    except (TypeError, ValueError):  # pragma: no cover - defensive guard
+        return None
+
+
 def _normalize_headers(doc: object) -> list[dict[str, object]]:
     headers_payload: Any = _extract_preprocess_payload(doc)
 
@@ -74,10 +85,11 @@ def _normalize_headers(doc: object) -> list[dict[str, object]]:
         text = str(entry.get("text") or entry.get("name") or "").strip()
         if not text:
             continue
+        line_idx = _to_int(entry.get("line_idx"))
         normalized.append(
             {
                 "page": page_num,
-                "line_idx": entry.get("line_idx"),
+                "line_idx": line_idx,
                 "text": text,
                 "bold": entry.get("bold"),
                 "font_pt": entry.get("font_pt"),
@@ -103,7 +115,7 @@ def finalize_headers_preprocess_only(doc: object) -> list[dict[str, object]]:
     final: list[dict[str, object]] = []
     for header in raw_entries:
         page = header.get("page")
-        line_idx = header.get("line_idx")
+        line_idx = _to_int(header.get("line_idx"))
         text = str(header.get("text", "")).strip()
         key = (int(page), line_idx, text)
         if key in seen:

--- a/tests/test_preprocess_only_mode.py
+++ b/tests/test_preprocess_only_mode.py
@@ -33,7 +33,8 @@ class _DocFixture:
     def __init__(self, base_dir: Path) -> None:
         headers = [
             {"page": 6, "line_idx": 19, "text": "A1. Robot & EOAT"},
-            {"page": 6, "line_idx": 20, "text": "A2. Vision/Sensing"},
+            # String ``line_idx`` ensures normalization coerces to integers.
+            {"page": 6, "line_idx": "20", "text": "A2. Vision/Sensing"},
             {"page": 7, "line_idx": 1, "text": "A3. Conveyors & Pallet Handling"},
             {"page": 7, "line_idx": 2, "text": "A4. Controls & Electrical"},
             {"page": 7, "line_idx": 3, "text": "A5. Utilities & Consumption"},
@@ -90,4 +91,17 @@ def test_appendix_a_from_preprocess_only(doc_loaded_from_fixtures: _DocFixture, 
     assert final_path.exists(), "final headers artifact not written"
     payload = json.loads(final_path.read_text(encoding="utf-8"))
     assert payload.get("headers_final"), "headers_final.json should contain data"
+
+    # Order should be stable by (page, line_idx) with numeric comparison.
+    sorted_headers = sorted(
+        headers,
+        key=lambda item: (
+            item["page"],
+            item.get("line_idx") if item.get("line_idx") is not None else 1_000_000,
+        ),
+    )
+    assert headers == sorted_headers, "Headers must retain preprocess ordering"
+
+    tsv_path = doc_loaded_from_fixtures.artifacts.base_dir / "headers_final.tsv"
+    assert tsv_path.exists(), "headers_final.tsv should be written for inspection"
 


### PR DESCRIPTION
## Summary
- coerce preprocess header line indices to integers before deduplication and ordering in preprocess-only mode
- expand the preprocess-only integration test to cover string indices, verify ordering stability, and ensure TSV artifacts are emitted

## Testing
- pytest tests/test_preprocess_only_mode.py


------
https://chatgpt.com/codex/tasks/task_e_68d72e8e94e483248a75c0dcb98a819c