### PR TITLE
Guard EFHG scoring when preprocess-only mode is active

### DIFF
--- a/backend/efhg/entropy.py
+++ b/backend/efhg/entropy.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 import math
 from typing import Dict, Iterable, List
 
-from backend.uf_chunker import UFChunk, HEADER_PATTERN
+from backend.headers import config as cfg
+from backend.uf_chunker import HEADER_PATTERN, UFChunk
+
+
+def _assert_efhg_enabled() -> None:
+    assert cfg.HEADER_MODE != "preprocess_only", "EFHG disabled for headers"
 
 DEFAULT_WEIGHTS = {
     "w1": 0.7,
@@ -36,6 +41,8 @@ def _entropy(values: Iterable[float]) -> float:
 
 def compute_entropy_features(uf_chunks: List[UFChunk]) -> None:
     """Annotate chunks with entropy-based features."""
+
+    _assert_efhg_enabled()
 
     for idx, chunk in enumerate(uf_chunks):
         tokens = _tokenize(chunk.text)
@@ -74,6 +81,7 @@ def _no_new_params_ahead(chunk: UFChunk) -> float:
 
 
 def score_starts(uf_chunks: List[UFChunk], weights: Dict[str, float] | None = None) -> Dict[str, float]:
+    _assert_efhg_enabled()
     weights = weights or DEFAULT_WEIGHTS
     scores: Dict[str, float] = {}
     for chunk in uf_chunks:
@@ -90,6 +98,7 @@ def score_starts(uf_chunks: List[UFChunk], weights: Dict[str, float] | None = No
 
 
 def score_stops(uf_chunks: List[UFChunk], weights: Dict[str, float] | None = None) -> Dict[str, float]:
+    _assert_efhg_enabled()
     weights = weights or DEFAULT_WEIGHTS
     scores: Dict[str, float] = {}
     for chunk in uf_chunks:
@@ -106,6 +115,7 @@ def score_stops(uf_chunks: List[UFChunk], weights: Dict[str, float] | None = Non
 
 
 def select_quantile_ids(scores: Dict[str, float], quantile: float) -> List[str]:
+    _assert_efhg_enabled()
     if not scores:
         return []
     values = sorted(scores.values())

--- a/backend/efhg/fluid.py
+++ b/backend/efhg/fluid.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, List, Mapping, Sequence, Tuple
 
+from backend.headers import config as cfg
 from backend.rag.embeddings import cosine
 from backend.uf_chunker import UFChunk
 
@@ -24,6 +25,10 @@ class Span:
     page: int
     span: Tuple[int, int]
     flow_total: float
+
+
+def _assert_efhg_enabled() -> None:
+    assert cfg.HEADER_MODE != "preprocess_only", "EFHG disabled for headers"
 
 
 def _style_similarity(a: UFChunk, b: UFChunk) -> float:
@@ -58,6 +63,7 @@ def _header_consistency(a: UFChunk, b: UFChunk) -> float:
 
 
 def build_edges(uf_chunks: List[UFChunk], params: Dict[str, float] | None = None) -> Dict[Tuple[str, str], float]:
+    _assert_efhg_enabled()
     params = params or DEFAULT_PARAMS
     edges: Dict[Tuple[str, str], float] = {}
     for i, left in enumerate(uf_chunks[:-1]):
@@ -86,6 +92,7 @@ def _span_text(chunk_lookup: Mapping[str, UFChunk], chunk_ids: Sequence[str]) ->
 
 
 def span_from_chunk_ids(chunk_lookup: Mapping[str, UFChunk], chunk_ids: Sequence[str]) -> Span:
+    _assert_efhg_enabled()
     text, span, page = _span_text(chunk_lookup, chunk_ids)
     return Span(chunk_ids=list(chunk_ids), text=text, page=page, span=span, flow_total=0.0)
 
@@ -97,6 +104,7 @@ def grow_span_from_seed(
     stop_scores: Dict[str, float],
     params: Dict[str, float] | None = None,
 ) -> Span:
+    _assert_efhg_enabled()
     params = params or DEFAULT_PARAMS
     chunk_lookup = {chunk.id: chunk for chunk in uf_chunks}
     ordered_ids = [chunk.id for chunk in uf_chunks]

--- a/backend/efhg/graph_gate.py
+++ b/backend/efhg/graph_gate.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, List, Sequence, Tuple
 
+from backend.headers import config as cfg
 from backend.efhg.fluid import Span, span_from_chunk_ids
 from backend.uf_chunker import HEADER_PATTERN, UFChunk
 
@@ -22,6 +23,10 @@ class GraphContext:
     references: List[Dict[str, object]]
     tables: List[Dict[str, object]]
     domain: str | None = None
+
+
+def _assert_efhg_enabled() -> None:
+    assert cfg.HEADER_MODE != "preprocess_only", "EFHG disabled for headers"
 
 
 def _dominant_header(span: Span, chunks: Dict[str, UFChunk], headers: Sequence[Dict[str, object]]) -> Tuple[str | None, float]:
@@ -53,6 +58,7 @@ def _collect_domain_hints(span: Span, chunks: Dict[str, UFChunk]) -> List[str]:
 
 
 def score_graph(span: Span, header_ctx: GraphContext, chunks: Dict[str, UFChunk], params: Dict[str, float] | None = None) -> Tuple[float, Dict[str, float]]:
+    _assert_efhg_enabled()
     params = params or DEFAULT_PARAMS
     penalties = {
         "header_mismatch": 0.0,
@@ -87,6 +93,7 @@ def score_graph(span: Span, header_ctx: GraphContext, chunks: Dict[str, UFChunk]
 
 
 def snap_and_trim(span: Span, header_ctx: GraphContext, chunks: Dict[str, UFChunk]) -> Span:
+    _assert_efhg_enabled()
     dominant_label, _ = _dominant_header(span, chunks, header_ctx.headers)
     chunk_ids = list(span.chunk_ids)
     if dominant_label:

--- a/backend/efhg/hep.py
+++ b/backend/efhg/hep.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from typing import Dict
 
-from backend.uf_chunker import UFChunk
+from backend.headers import config as cfg
 from backend.efhg.fluid import Span
+from backend.uf_chunker import UFChunk
 
 DEFAULT_PARAMS = {
     "a": 1.0,
@@ -20,6 +21,7 @@ def _span_has_feature(span: Span, chunks: Dict[str, UFChunk], predicate) -> bool
 
 
 def score_span_hep(span: Span, chunks: Dict[str, UFChunk], params: Dict[str, float] | None = None) -> Dict[str, object]:
+    assert cfg.HEADER_MODE != "preprocess_only", "EFHG disabled for headers"
     params = params or DEFAULT_PARAMS
     modal = _span_has_feature(span, chunks, lambda c: c.lex.get("has_modal"))
     constraints = _span_has_feature(span, chunks, lambda c: bool(c.lex.get("numbers")) and bool(c.lex.get("units")))


### PR DESCRIPTION
## Summary
- add global guards to EFHG scoring helpers so preprocess-only mode bypasses the pipeline
- assert against EFHG scoring entrypoints when preprocess-only headers are configured

## Testing
- pytest tests/test_preprocess_only_mode.py

------
https://chatgpt.com/codex/tasks/task_e_68d730a0fee88324aeb84452a0f7dccf