### PR TITLE
Short-circuit EFHG spans in preprocess mode

### DIFF
--- a/chunking/efhg.py
+++ b/chunking/efhg.py
@@ -266,6 +266,9 @@ def compute_fluid_neighbors(chunks: Sequence[Mapping[str, object]]) -> List[Dict
 def run_efhg(chunks: Sequence[Mapping[str, object]]) -> List[Dict[str, object]]:
     """Compute EFHG spans for the provided UF chunks."""
 
+    if cfg.HEADER_MODE == "preprocess_only":
+        return []
+
     _assert_efhg_enabled()
 
     prepared = _prepare_chunks(chunks)


### PR DESCRIPTION
## Summary
- return immediately from `chunking.efhg.run_efhg` when header processing runs in preprocess-only mode so EFHG spans are never produced

## Testing
- pytest tests/test_preprocess_only_mode.py

------
https://chatgpt.com/codex/tasks/task_e_68d73621eb208324bbfbf16f25c9c55a