### PR TITLE
Disable header LLM usage and bypass EFHG gating

### DIFF
--- a/backend/headers/config.py
+++ b/backend/headers/config.py
@@ -14,7 +14,7 @@ HEADER_LEGACY_PROFILE = "preprocess_truth"
 
 # EFHG gate mode controls whether scoring is allowed to block promotions
 # when the pipeline relies on score-based gating.
-# "bypass" => strong patterns auto-promote, scores only inform logging.
+# "bypass" => promote all candidates without EFHG score gating.
 # "score_gate" => legacy behaviour where EFHG scores gate weaker patterns.
 HEADER_GATE_MODE = "bypass"
 

--- a/backend/headers/header_scan.py
+++ b/backend/headers/header_scan.py
@@ -280,8 +280,14 @@ def promote_candidates(
         else:
             if gate == "score_gate":
                 candidate.promoted = candidate.total > 0.0
+                if candidate.promoted and not candidate.promotion_reason:
+                    candidate.promotion_reason = "score_gate"
             else:
-                candidate.promoted = False
+                candidate.promoted = True
+                if not candidate.promotion_reason:
+                    candidate.promotion_reason = "gate_bypass"
+            if candidate.promoted:
+                promoted.append(candidate)
     return promoted
 
 

--- a/backend/headers/pipeline.py
+++ b/backend/headers/pipeline.py
@@ -32,10 +32,6 @@ from backend.headers.header_llm import (
     VerifiedHeader,
     VerifiedHeaders,
     aggressive_sequence_repair,
-    build_header_prompt,
-    call_llm,
-    parse_fenced_outline,
-    verify_headers,
 )
 from backend.headers.header_scan import (
     STRONG_PATTERNS,
@@ -881,17 +877,8 @@ def run_headers(doc_id: str, decomp: Dict[str, Any]) -> HeaderIndex:
         candidates,
     )
 
-    messages = build_header_prompt(pages_norm)
-    llm_raw = ""
-    verified_headers: VerifiedHeaders
     llm_error: str | None = None
-    try:
-        llm_raw = call_llm(messages)
-        parsed = parse_fenced_outline(llm_raw)
-        verified_headers = verify_headers(parsed, pages_norm, pages_raw)
-    except Exception as exc:  # pylint: disable=broad-except
-        llm_error = str(exc)
-        verified_headers = VerifiedHeaders()
+    verified_headers = VerifiedHeaders()
 
     repaired_headers = aggressive_sequence_repair(verified_headers, pages_norm, tokens_per_page)
     if preprocess_truth_active and preprocess_headers:
@@ -1290,9 +1277,8 @@ def run_headers(doc_id: str, decomp: Dict[str, Any]) -> HeaderIndex:
             for chunk in uf_chunks
         ],
         "llm_headers": {
-            "raw_fenced_json": llm_raw,
+            "enabled": False,
             "verified": _serialize_verified(verified_headers),
-            "error": llm_error,
         },
         "sequence_repair": repaired_headers.repair_log,
         "efhg_header_spans": spans_audit,

--- a/tests/header_pipeline_utils.py
+++ b/tests/header_pipeline_utils.py
@@ -44,15 +44,14 @@ def run_header_pipeline(
     if legacy_profile_supported:
         cfg.HEADER_LEGACY_PROFILE = "raw_truth"
 
-    if call_llm is None:
+    from backend.headers import pipeline as pipeline_module
+    if call_llm is None or not hasattr(pipeline_module, "call_llm"):
         try:
             return run_headers(doc_id, decomp)
         finally:
             cfg.HEADER_MODE = original_mode
             if legacy_profile_supported:
                 cfg.HEADER_LEGACY_PROFILE = original_profile
-
-    from backend.headers import pipeline as pipeline_module
 
     original_call = pipeline_module.call_llm
     pipeline_module.call_llm = call_llm  # type: ignore[assignment]


### PR DESCRIPTION
## Summary
- remove the legacy LLM invocation from the header pipeline and emit disabled metadata in the audit payload
- treat the bypass gate mode as auto-promoting candidates so EFHG scores no longer block acceptance
- make the header test helper resilient when the pipeline exposes no `call_llm`

## Testing
- pytest tests/test_header_pattern_autopromotion.py tests/test_header_split_across_uf.py

------
https://chatgpt.com/codex/tasks/task_e_68d7e81a8edc83248164d1d2b170ddcb