### PR TITLE
Stop writing candidate audits for header-only runs

### DIFF
--- a/backend/pipeline/preprocess.py
+++ b/backend/pipeline/preprocess.py
@@ -14,7 +14,6 @@ from ..parse.header_page_mode import (
     select_candidates,
     build_adjudication_prompt,
     dump_appendix_audit,
-    write_header_candidate_audit,
     write_header_debug_manifest,
     write_page_debug,
 )
@@ -486,10 +485,6 @@ async def detect_headers_page_mode(
         results,
         llm_selections=llm_selections,
     )
-    write_header_candidate_audit(
-        doc_tag,
-        debug_snapshots,
-        results,
-        debug=None,
-    )
+    # Candidate audit payloads are reserved for EFHG runs; header-only mode
+    # stops after manifest/debug generation.
     return results

--- a/backend/routes/headers.py
+++ b/backend/routes/headers.py
@@ -21,7 +21,6 @@ from ..parse.header_page_mode import (
     build_adjudication_prompt,
     dump_appendix_audit,
     select_candidates,
-    write_header_candidate_audit,
     write_header_debug_manifest,
     write_page_debug,
 )
@@ -491,13 +490,8 @@ def determine_headers():
                     results,
                     llm_selections=page_llm_selections,
                 )
-
-            write_header_candidate_audit(
-                doc_tag,
-                page_debug_snapshots,
-                results,
-                debug=getattr(session_state, "debug", None),
-            )
+            # Candidate audit payloads are emitted by the EFHG pipeline; the
+            # header-only route stops after writing optional debug manifests.
 
             response_payload = {
                 "ok": True,


### PR DESCRIPTION
## Summary
- remove the header-only calls to `write_header_candidate_audit` so audit payloads are emitted exclusively from EFHG runs
- add inline comments explaining that the audit artifact is now limited to the EFHG pipeline

## Testing
- pytest backend/tests/test_header_debug_exports.py

------
https://chatgpt.com/codex/tasks/task_e_68d7ecd8ce0c832495f3b4a5208ce091