### PR TITLE
Add LLM-assisted header pipeline with audit artifacts

### DIFF
--- a/backend/audit/__init__.py
+++ b/backend/audit/__init__.py
@@ -1,0 +1,3 @@
+from .preprocess_writer import candidate_to_dict, final_to_dict, write_preprocess_audit
+
+__all__ = ["candidate_to_dict", "final_to_dict", "write_preprocess_audit"]

--- a/backend/audit/preprocess_writer.py
+++ b/backend/audit/preprocess_writer.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from typing import Dict, List, Optional
+
+from backend.models.headers import FinalHeader, HeaderCandidate
+
+
+def _normalise_span(value):
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple)) and len(value) == 2:
+        return [value[0], value[1]]
+    return list(value) if isinstance(value, (set,)) else value
+
+
+def candidate_to_dict(candidate: HeaderCandidate) -> Dict[str, object]:
+    payload = asdict(candidate)
+    payload["span_char"] = _normalise_span(payload.get("span_char"))
+    judging = payload.get("judging")
+    if isinstance(judging, dict):
+        judging["span_char"] = _normalise_span(judging.get("span_char"))
+    return payload
+
+
+def final_to_dict(final: FinalHeader) -> Dict[str, object]:
+    payload = asdict(final)
+    payload["span_char"] = _normalise_span(payload.get("span_char"))
+    return payload
+
+
+def write_preprocess_audit(
+    *,
+    doc_meta: Optional[Dict[str, object]],
+    llm_raw_response: str,
+    llm_parse_error: Optional[str],
+    llm_candidates: List[HeaderCandidate],
+    heuristic_candidates: List[HeaderCandidate],
+    final_headers: List[FinalHeader],
+    out_path: str = "Epf_Co.preprocess.json",
+) -> None:
+    payload = {
+        "doc_meta": doc_meta or {},
+        "header_pass": {
+            "llm": {
+                "prompt_used": "Please list all header sections of this document and provide the results in a json format",
+                "raw_response": llm_raw_response,
+                "parse_error": llm_parse_error,
+                "candidates": [candidate_to_dict(c) for c in llm_candidates],
+            },
+            "heuristic": {
+                "candidates": [candidate_to_dict(c) for c in heuristic_candidates],
+            },
+            "final": {
+                "headers": [final_to_dict(f) for f in final_headers],
+            },
+        },
+    }
+    with open(out_path, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, indent=2)
+
+
+__all__ = ["candidate_to_dict", "final_to_dict", "write_preprocess_audit"]

--- a/backend/headers/heuristic_adapter.py
+++ b/backend/headers/heuristic_adapter.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Mapping, Optional
+
+from backend.models.headers import HeaderCandidate, Judging
+
+_NUMBER_PREFIX = re.compile(
+    r"^(?P<section>(?:\d+(?:\.\d+)*|[A-Za-z]\d{1,3}|[A-Za-z]\.\d{1,3}|(?:appendix|annex)\s+[A-Z]))[\s\.).:-]*",
+    re.IGNORECASE,
+)
+
+
+def _infer_section_id(title: str, fallback: Optional[str] = None) -> Optional[str]:
+    if fallback:
+        return str(fallback).strip() or None
+    match = _NUMBER_PREFIX.match(title)
+    if not match:
+        return None
+    section = match.group("section") or ""
+    section = section.strip()
+    if not section:
+        return None
+    # Normalise Appendix/Annex prefixes
+    lowered = section.lower()
+    if lowered.startswith("appendix") or lowered.startswith("annex"):
+        parts = section.split()
+        if len(parts) >= 2:
+            return f"{parts[0].title()} {parts[1].upper()}"
+    return section
+
+
+def _typography_score(record: Mapping[str, Any], font_ranks: Dict[float, int] | None) -> Optional[float]:
+    try:
+        font_size = float(record.get("font_size"))
+    except Exception:
+        font_size = None
+    rank = None
+    if font_ranks and font_size is not None:
+        rank = font_ranks.get(round(font_size, 2))
+    if rank is None:
+        rank = record.get("level_font")
+    try:
+        rank_value = int(rank) if rank is not None else None
+    except Exception:
+        rank_value = None
+    if rank_value is None or rank_value <= 0:
+        return None
+    return max(0.0, min(1.0, 1.0 / float(rank_value)))
+
+
+def _heuristic_confidence(record: Mapping[str, Any]) -> float:
+    base = 0.55
+    if record.get("is_bold"):
+        base += 0.1
+    if record.get("level_numbering"):
+        base += 0.15
+    if record.get("level") and isinstance(record.get("level"), int):
+        base += 0.05
+    return max(0.0, min(1.0, base))
+
+
+def run_heuristic_header_pass(
+    heuristic_records: List[Dict[str, Any]],
+    doc_meta: Optional[Dict[str, Any]] = None,
+) -> List[HeaderCandidate]:
+    """Convert raw heuristic header rows into :class:`HeaderCandidate` objects."""
+
+    font_ranks = None
+    if doc_meta:
+        raw_ranks = doc_meta.get("font_rank")
+        if isinstance(raw_ranks, dict):
+            font_ranks = {
+                float(k) if not isinstance(k, float) else k: int(v)
+                for k, v in raw_ranks.items()
+                if isinstance(v, (int, float))
+            }
+
+    candidates: List[HeaderCandidate] = []
+    for record in heuristic_records:
+        title = str(record.get("text") or "").strip()
+        if not title:
+            continue
+
+        page = record.get("page")
+        try:
+            page_num = int(page) if page is not None else None
+        except Exception:
+            page_num = None
+
+        level = record.get("level")
+        try:
+            level_val = int(level) if level is not None else None
+        except Exception:
+            level_val = None
+
+        section_id = _infer_section_id(title, record.get("section_number"))
+
+        typo_score = _typography_score(record, font_ranks)
+        conf = _heuristic_confidence(record)
+        pattern_id = None
+        reasons: List[str] = []
+        if record.get("level_numbering"):
+            pattern_id = "numbering"
+            reasons.append("numeric_pattern")
+        if record.get("is_bold"):
+            reasons.append("bold_text")
+        if typo_score:
+            reasons.append("large_font")
+
+        judging = Judging(
+            typography_score=typo_score,
+            heuristic_confidence=conf,
+            page=page_num,
+            pattern_id=pattern_id,
+            reasons=reasons,
+        )
+
+        candidates.append(
+            HeaderCandidate(
+                source="heuristic",
+                section_id=section_id,
+                title=title,
+                level=level_val,
+                page=page_num,
+                span_char=None,
+                judging=judging,
+            )
+        )
+
+    return candidates
+
+
+__all__ = ["run_heuristic_header_pass"]

--- a/backend/headers/llm_header_pass.py
+++ b/backend/headers/llm_header_pass.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from typing import Any, Dict, List
+
+from backend.llm.factory import create_llm_client, provider_default_model
+from backend.models.headers import HeaderCandidate, Judging
+
+LOGGER = logging.getLogger(__name__)
+
+LLM_PROMPT = "Please list all header sections of this document and provide the results in a json format"
+
+
+def call_llm(raw_text: str) -> str:
+    """Invoke the project LLM client and return the raw string response."""
+
+    provider = os.environ.get("HEADER_LLM_PROVIDER")
+    model = (
+        os.environ.get("HEADER_LLM_MODEL")
+        or provider_default_model(provider)
+        or os.environ.get("OPENROUTER_DEFAULT_MODEL")
+        or "openai/gpt-4o-mini"
+    )
+
+    client = create_llm_client(provider)
+
+    user_prompt = LLM_PROMPT
+    raw_text = raw_text.strip()
+    if raw_text:
+        user_prompt = f"{LLM_PROMPT}\n\n{raw_text}"
+
+    loop = asyncio.new_event_loop()
+    try:
+        previous_loop = asyncio.get_event_loop()
+    except Exception:
+        previous_loop = None
+    try:
+        asyncio.set_event_loop(loop)
+        result = loop.run_until_complete(
+            client.acomplete(
+                model=model,
+                system=None,
+                user=user_prompt,
+                temperature=0.0,
+                max_tokens=2048,
+                stream=False,
+            )
+        )
+    finally:
+        try:
+            loop.close()
+        finally:
+            # Restore previous loop if possible
+            try:
+                if previous_loop is not None:
+                    asyncio.set_event_loop(previous_loop)
+                else:
+                    asyncio.set_event_loop(None)  # type: ignore[arg-type]
+            except Exception:
+                pass
+
+    return result if isinstance(result, str) else str(result)
+
+
+def parse_llm_json(raw_response: str) -> List[Dict[str, Any]]:
+    """Parse the LLM response into a list of header descriptor dictionaries."""
+
+    obj = json.loads(raw_response)
+    if isinstance(obj, dict):
+        for key in ("headers", "sections", "results", "items"):
+            value = obj.get(key)
+            if isinstance(value, list):
+                return value
+        raise ValueError("No list found in LLM JSON object.")
+    if isinstance(obj, list):
+        return obj
+    raise ValueError("Unexpected LLM JSON structure.")
+
+
+def coerce_llm_candidates(llm_items: List[Dict[str, Any]]) -> List[HeaderCandidate]:
+    """Convert generic LLM JSON entries into :class:`HeaderCandidate` objects."""
+
+    candidates: List[HeaderCandidate] = []
+    for item in llm_items:
+        if not isinstance(item, dict):
+            continue
+        section_id = item.get("section_id") or item.get("id") or item.get("number")
+        title = (item.get("title") or item.get("name") or "").strip()
+        if not title:
+            continue
+
+        level_raw = item.get("level")
+        try:
+            level = int(level_raw) if level_raw is not None else None
+        except Exception:
+            level = None
+
+        page_raw = item.get("page")
+        try:
+            page = int(page_raw) if page_raw is not None else None
+        except Exception:
+            page = None
+
+        span_raw = item.get("span_char") or item.get("span") or item.get("char_span")
+        span_char = None
+        if isinstance(span_raw, (list, tuple)) and len(span_raw) == 2:
+            span_char = (span_raw[0], span_raw[1])  # type: ignore[arg-type]
+        elif isinstance(span_raw, dict):
+            start = span_raw.get("start") or span_raw.get("begin")
+            end = span_raw.get("end") or span_raw.get("stop")
+            if start is not None and end is not None:
+                span_char = (start, end)  # type: ignore[arg-type]
+
+        confidence_raw = item.get("confidence")
+        llm_conf = None
+        if isinstance(confidence_raw, (int, float)):
+            llm_conf = float(confidence_raw)
+
+        extra_fields: Dict[str, str] = {}
+        for key, value in item.items():
+            if key in {
+                "title",
+                "name",
+                "level",
+                "page",
+                "span_char",
+                "span",
+                "char_span",
+                "id",
+                "number",
+                "section_id",
+                "confidence",
+            }:
+                continue
+            extra_fields[key] = str(value)
+
+        judging = Judging(
+            llm_confidence=llm_conf,
+            llm_raw_fields=extra_fields,
+            page=page,
+            span_char=span_char,
+        )
+
+        candidates.append(
+            HeaderCandidate(
+                source="llm",
+                section_id=str(section_id) if section_id is not None else None,
+                title=title,
+                level=level,
+                page=page,
+                span_char=span_char,
+                judging=judging,
+            )
+        )
+    return candidates
+
+
+def run_llm_header_pass(full_normalized_text: str) -> Dict[str, Any]:
+    """Execute the LLM header pass and return raw output + coerced candidates."""
+
+    raw_response = ""
+    parse_error: str | None = None
+    candidates: List[HeaderCandidate] = []
+
+    try:
+        raw_response = call_llm(full_normalized_text)
+        if raw_response:
+            items = parse_llm_json(raw_response)
+            candidates = coerce_llm_candidates(items)
+    except Exception as exc:  # pragma: no cover - defensive logging path
+        parse_error = str(exc)
+        LOGGER.warning("LLM header pass failed: %s", exc)
+
+    return {
+        "raw_response": raw_response,
+        "parse_error": parse_error,
+        "candidates": candidates,
+    }
+
+
+__all__ = [
+    "LLM_PROMPT",
+    "call_llm",
+    "coerce_llm_candidates",
+    "parse_llm_json",
+    "run_llm_header_pass",
+]

--- a/backend/headers/merge_headers.py
+++ b/backend/headers/merge_headers.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import re
+from typing import Dict, Iterable, List, Optional, Tuple
+
+from backend.models.headers import FinalHeader, HeaderCandidate
+
+
+def _strip_leading_numbering(title: str, section_id: Optional[str]) -> str:
+    text = (title or "").strip()
+    if not text:
+        return text
+    if section_id:
+        escaped = re.escape(section_id.strip())
+        match = re.match(rf"^{escaped}[\s\.).:-]*", text, flags=re.IGNORECASE)
+        if match:
+            remainder = text[match.end():].strip()
+            if remainder:
+                return remainder
+    match_generic = re.match(r"^[A-Za-z]?\d+[\s\.).:-]+(.+)$", text)
+    if match_generic:
+        candidate = match_generic.group(1).strip()
+        if candidate:
+            return candidate
+    return text
+
+
+def normalize_section_id(section_id: Optional[str], title: str) -> Optional[str]:
+    if section_id:
+        token = re.sub(r"\s+", "", str(section_id))
+        token = token.replace("Section", "").replace("section", "")
+        token = token.replace(":", "")
+        token = token.strip()
+        return token or None
+    match = re.match(r"^\s*([A-Z]\d+|\d+(?:\.\d+)+|[A-Z]\.\d+)\b", title)
+    if match:
+        return match.group(1)
+    return None
+
+
+def normalize_title(title: str) -> str:
+    cleaned = re.sub(r"\s+", " ", title or "").strip().rstrip(".")
+    return cleaned.lower()
+
+
+def _candidate_score(candidate: HeaderCandidate) -> float:
+    llm_conf = candidate.judging.llm_confidence
+    heur_conf = candidate.judging.heuristic_confidence
+    values = [v for v in (llm_conf, heur_conf) if isinstance(v, (int, float))]
+    if values:
+        base = sum(values) / len(values)
+    else:
+        base = 0.5
+    if candidate.source == "heuristic":
+        base += 0.05
+    return max(0.0, min(1.0, float(base)))
+
+
+def merge_candidates(
+    llm_candidates: Iterable[HeaderCandidate],
+    heuristic_candidates: Iterable[HeaderCandidate],
+) -> List[FinalHeader]:
+    buckets: Dict[Tuple[Optional[str], str], List[HeaderCandidate]] = {}
+
+    def key_for(candidate: HeaderCandidate) -> Tuple[Optional[str], str]:
+        norm_id = normalize_section_id(candidate.section_id, candidate.title)
+        norm_title = normalize_title(candidate.title)
+        if norm_id:
+            return (norm_id, "")
+        return (None, norm_title)
+
+    for candidate in list(llm_candidates) + list(heuristic_candidates):
+        buckets.setdefault(key_for(candidate), []).append(candidate)
+
+    finals: List[FinalHeader] = []
+    for (norm_id, norm_title), group in buckets.items():
+        sources = sorted({cand.source for cand in group})
+        representative = max(group, key=_candidate_score)
+        page = representative.page
+        span_char = representative.span_char
+        level = next((cand.level for cand in group if cand.level is not None), None)
+        heuristic_title = next(
+            (cand.title for cand in group if cand.source == "heuristic" and cand.title),
+            None,
+        )
+        if heuristic_title:
+            title_choice = heuristic_title
+        else:
+            title_choice = representative.title
+        title_choice = _strip_leading_numbering(title_choice, norm_id)
+
+        all_scores = [_candidate_score(cand) for cand in group]
+        merged_conf = sum(all_scores) / len(all_scores) if all_scores else 0.5
+        reasons: List[str] = []
+        if len(sources) > 1:
+            merged_conf = min(1.0, merged_conf + 0.1)
+            reasons.append("supported_by_both_sources")
+
+        finals.append(
+            FinalHeader(
+                section_id=norm_id,
+                title=title_choice,
+                level=level,
+                page=page,
+                span_char=span_char,
+                sources=sources,
+                confidence=merged_conf,
+                reasons=reasons,
+            )
+        )
+
+    def sort_key(header: FinalHeader):
+        section = header.section_id or ""
+        if section and re.match(r"^\d+(?:\.\d+)*$", section):
+            parts = [int(part) for part in section.split(".")]
+            return (0, parts, header.page or 10**9, header.title.lower())
+        return (1, [ord(c) for c in section], header.page or 10**9, header.title.lower())
+
+    finals.sort(key=sort_key)
+    return finals
+
+
+__all__ = ["merge_candidates", "normalize_section_id", "normalize_title"]

--- a/backend/headers/pipeline.py
+++ b/backend/headers/pipeline.py
@@ -32,6 +32,10 @@ from backend.headers.header_llm import (
     VerifiedHeader,
     VerifiedHeaders,
     aggressive_sequence_repair,
+    build_header_prompt,
+    call_llm as _default_call_llm,
+    parse_fenced_outline,
+    verify_headers,
 )
 from backend.headers.header_scan import (
     STRONG_PATTERNS,
@@ -925,7 +929,17 @@ def run_headers(doc_id: str, decomp: Dict[str, Any]) -> HeaderIndex:
     )
 
     llm_error: str | None = None
+    llm_raw_fenced: str = ""
     verified_headers = VerifiedHeaders()
+    if raw_truth_active:
+        try:
+            messages = build_header_prompt(pages_norm)
+            llm_raw_fenced = call_llm(messages)
+            payload = parse_fenced_outline(llm_raw_fenced)
+            verified_headers = verify_headers(payload, pages_norm, pages_raw)
+        except Exception as exc:
+            llm_error = str(exc)
+            verified_headers = VerifiedHeaders()
 
     repaired_headers = aggressive_sequence_repair(verified_headers, pages_norm, tokens_per_page)
     if preprocess_truth_active and preprocess_headers:
@@ -1332,8 +1346,10 @@ def run_headers(doc_id: str, decomp: Dict[str, Any]) -> HeaderIndex:
             for chunk in uf_chunks
         ],
         "llm_headers": {
-            "enabled": False,
+            "enabled": bool(getattr(verified_headers, "headers", [])),
+            "raw_fenced_json": llm_raw_fenced,
             "verified": _serialize_verified(verified_headers),
+            "error": llm_error,
         },
         "sequence_repair": repaired_headers.repair_log,
         "efhg_header_spans": spans_audit,
@@ -1421,3 +1437,5 @@ def run_headers_stage(doc: object) -> List[Dict[str, Any]]:
 
 
 __all__ = ["run_headers", "run_headers_stage", "HeaderIndex"]
+call_llm = _default_call_llm
+

--- a/backend/headers/preprocess_pipeline.py
+++ b/backend/headers/preprocess_pipeline.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+
+from backend.audit.preprocess_writer import write_preprocess_audit
+from backend.headers.heuristic_adapter import run_heuristic_header_pass
+from backend.headers.llm_header_pass import run_llm_header_pass
+from backend.headers.merge_headers import merge_candidates
+def run_header_pipeline(
+    full_normalized_text: str,
+    heuristic_records: List[Dict[str, object]],
+    doc_meta: Optional[Dict[str, object]] = None,
+    *,
+    audit_path: Optional[str] = None,
+) -> Dict[str, object]:
+    """Run heuristic + LLM header passes and write the preprocess audit."""
+
+    doc_meta_copy = dict(doc_meta or {})
+    heuristic_candidates = run_heuristic_header_pass(heuristic_records, doc_meta=doc_meta_copy)
+    llm_result = run_llm_header_pass(full_normalized_text)
+    llm_candidates = llm_result.get("candidates", [])
+    final_headers = merge_candidates(llm_candidates, heuristic_candidates)
+
+    write_preprocess_audit(
+        doc_meta=doc_meta_copy,
+        llm_raw_response=llm_result.get("raw_response", ""),
+        llm_parse_error=llm_result.get("parse_error"),
+        llm_candidates=llm_candidates,
+        heuristic_candidates=heuristic_candidates,
+        final_headers=final_headers,
+        out_path=audit_path or "Epf_Co.preprocess.json",
+    )
+
+    return {
+        "heuristic_candidates": heuristic_candidates,
+        "llm_result": llm_result,
+        "final_headers": final_headers,
+    }
+
+
+__all__ = ["run_header_pipeline"]

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,0 +1,3 @@
+from .headers import FinalHeader, HeaderCandidate, Judging
+
+__all__ = ["FinalHeader", "HeaderCandidate", "Judging"]

--- a/backend/models/headers.py
+++ b/backend/models/headers.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+
+@dataclass
+class Judging:
+    """Scoring metadata for header candidates from any source."""
+
+    regex_match: Optional[float] = None
+    typography_score: Optional[float] = None
+    position_score: Optional[float] = None
+    page: Optional[int] = None
+    span_char: Optional[Tuple[int, int]] = None
+    pattern_id: Optional[str] = None
+    llm_confidence: Optional[float] = None
+    llm_raw_fields: Dict[str, str] = field(default_factory=dict)
+    heuristic_confidence: Optional[float] = None
+    reasons: List[str] = field(default_factory=list)
+
+
+@dataclass
+class HeaderCandidate:
+    """Unified representation of candidate headers from LLM or heuristics."""
+
+    source: str  # "llm" or "heuristic"
+    section_id: Optional[str]
+    title: str
+    level: Optional[int]
+    page: Optional[int]
+    span_char: Optional[Tuple[int, int]]
+    judging: Judging = field(default_factory=Judging)
+
+
+@dataclass
+class FinalHeader:
+    """Merged header entry after combining LLM and heuristic candidates."""
+
+    section_id: Optional[str]
+    title: str
+    level: Optional[int]
+    page: Optional[int]
+    span_char: Optional[Tuple[int, int]]
+    sources: List[str]
+    confidence: float
+    reasons: List[str] = field(default_factory=list)
+
+
+__all__ = [
+    "Judging",
+    "HeaderCandidate",
+    "FinalHeader",
+]

--- a/backend/routes/pdf_headers.py
+++ b/backend/routes/pdf_headers.py
@@ -8,6 +8,9 @@ import re
 from statistics import median
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
+from backend.audit.preprocess_writer import candidate_to_dict, final_to_dict
+from backend.headers.preprocess_pipeline import run_header_pipeline
+
 from flask import Blueprint, jsonify, request
 
 try:
@@ -216,20 +219,59 @@ def extract_headers(pdf_bytes: bytes) -> Dict[str, Any]:
         headers, size_median, font_rank = _filter_headers(pages)
         toc = _get_toc(doc)
 
+    page_texts: List[str] = []
+    for page_lines in pages:
+        page_segments = [str(span.get("text") or "").strip() for span in page_lines if span.get("text")]
+        page_texts.append("\n".join(segment for segment in page_segments if segment))
+
+    normalized_text = "\n\n".join(segment for segment in page_texts if segment)
+    audit_path = os.path.abspath("Epf_Co.preprocess.json")
+    doc_meta = {
+        "page_count": len(pages),
+        "median_font_size": size_median,
+        "font_rank": font_rank,
+    }
+    pipeline_result = run_header_pipeline(
+        normalized_text,
+        headers,
+        doc_meta=doc_meta,
+        audit_path=audit_path,
+    )
+    final_headers = pipeline_result["final_headers"]
+    heuristic_candidates = pipeline_result["heuristic_candidates"]
+    llm_result = pipeline_result["llm_result"]
+
+    final_payload = [final_to_dict(header) for header in final_headers]
+    heuristic_payload = [candidate_to_dict(candidate) for candidate in heuristic_candidates]
+    llm_candidates_payload = [candidate_to_dict(candidate) for candidate in llm_result.get("candidates", [])]
+
     font_rank_list = [{"size": size, "rank": rank} for size, rank in sorted(font_rank.items(), key=lambda item: item[1])]
+
+    llm_parse_error = llm_result.get("parse_error")
+    notes = {
+        "extraction": "PyMuPDF heuristics merged with LLM header pass.",
+        "thresholds": {
+            "size_median": size_median,
+            "font_ranks": font_rank_list,
+        },
+        "audit_file": audit_path,
+        "llm": {
+            "parse_error": llm_parse_error,
+            "candidate_count": len(llm_candidates_payload),
+        },
+    }
+    if llm_parse_error:
+        notes["llm"]["raw_response_preview"] = (llm_result.get("raw_response") or "")[:200]
 
     return {
         "ok": True,
-        "count": len(headers),
-        "headers": headers,
+        "count": len(final_headers),
+        "headers": final_payload,
+        "heuristic_headers": headers,
+        "heuristic_candidates": heuristic_payload,
+        "llm_candidates": llm_candidates_payload,
         "toc": toc,
-        "notes": {
-            "extraction": "PyMuPDF deterministic (no LLM).",
-            "thresholds": {
-                "size_median": size_median,
-                "font_ranks": font_rank_list,
-            },
-        },
+        "notes": notes,
     }
 
 

--- a/tests/test_header_audit_pipeline.py
+++ b/tests/test_header_audit_pipeline.py
@@ -1,0 +1,49 @@
+import json
+
+from backend.headers import llm_header_pass
+from backend.headers.preprocess_pipeline import run_header_pipeline
+
+
+def test_pipeline_writes_audit(tmp_path, monkeypatch):
+    heuristics = [
+        {
+            "text": "1 Introduction",
+            "page": 1,
+            "font_size": 14.0,
+            "is_bold": True,
+            "level": 1,
+            "level_numbering": 1,
+            "level_font": 1,
+        }
+    ]
+    llm_payload = json.dumps(
+        [
+            {
+                "title": "Introduction",
+                "page": 1,
+                "confidence": 0.9,
+                "level": 1,
+                "section_id": "1",
+            }
+        ]
+    )
+
+    monkeypatch.setattr(llm_header_pass, "call_llm", lambda _text: llm_payload)
+
+    audit_path = tmp_path / "Epf_Co.preprocess.json"
+    result = run_header_pipeline(
+        "1 Introduction\nBody text",
+        heuristics,
+        doc_meta={"doc_id": "doc-1"},
+        audit_path=str(audit_path),
+    )
+
+    assert audit_path.exists()
+    data = json.loads(audit_path.read_text(encoding="utf-8"))
+    assert data["header_pass"]["llm"]["candidates"], "LLM candidates missing"
+    assert data["header_pass"]["heuristic"]["candidates"], "heuristic candidates missing"
+    assert data["header_pass"]["final"]["headers"], "final headers missing"
+
+    final = result["final_headers"]
+    assert len(final) == 1
+    assert final[0].title.lower().startswith("introduction")

--- a/tests/test_llm_parse_bad.py
+++ b/tests/test_llm_parse_bad.py
@@ -1,0 +1,13 @@
+from backend.headers import llm_header_pass
+
+
+def test_run_llm_header_pass_invalid_json(monkeypatch):
+    def fake_call(_text: str) -> str:
+        return "not json"
+
+    monkeypatch.setattr(llm_header_pass, "call_llm", fake_call)
+
+    result = llm_header_pass.run_llm_header_pass("sample text")
+    assert result["parse_error"] is not None
+    assert result["candidates"] == []
+    assert isinstance(result["raw_response"], str)

--- a/tests/test_llm_parse_ok.py
+++ b/tests/test_llm_parse_ok.py
@@ -1,0 +1,13 @@
+from backend.headers.llm_header_pass import coerce_llm_candidates, parse_llm_json
+
+
+def test_coerce_llm_candidates_from_json():
+    raw = '{"headers": [{"title": "Introduction", "page": 1, "confidence": 0.92, "level": "1", "section_id": "1"}]}'
+    items = parse_llm_json(raw)
+    candidates = coerce_llm_candidates(items)
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert candidate.title == "Introduction"
+    assert candidate.page == 1
+    assert candidate.level == 1
+    assert candidate.judging.llm_confidence == 0.92

--- a/tests/test_merge_both_sources.py
+++ b/tests/test_merge_both_sources.py
@@ -1,0 +1,32 @@
+from backend.headers.merge_headers import merge_candidates
+from backend.models.headers import HeaderCandidate, Judging
+
+
+def _candidate(source: str, title: str, section_id: str | None, confidence: float, page: int) -> HeaderCandidate:
+    judging = Judging(
+        heuristic_confidence=confidence if source == "heuristic" else None,
+        llm_confidence=confidence if source == "llm" else None,
+        page=page,
+    )
+    return HeaderCandidate(
+        source=source,
+        section_id=section_id,
+        title=title,
+        level=1,
+        page=page,
+        span_char=None,
+        judging=judging,
+    )
+
+
+def test_merge_candidates_prefers_both_sources():
+    heur = _candidate("heuristic", "Introduction", "1", 0.7, 1)
+    llm = _candidate("llm", "Introduction", "1", 0.8, 1)
+
+    merged = merge_candidates([llm], [heur])
+    assert len(merged) == 1
+    final = merged[0]
+    assert final.section_id == "1"
+    assert final.sources == ["heuristic", "llm"]
+    assert final.confidence > 0.7
+    assert "supported_by_both_sources" in final.reasons


### PR DESCRIPTION
## Summary
- add a reusable header data model along with an LLM header pass, heuristic adapter, merge logic, and preprocess pipeline
- integrate the new pipeline into the PDF header route and emit a detailed Epf_Co.preprocess.json audit
- extend the legacy header pipeline to record LLM metadata and add unit tests for parsing, merging, and audit generation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d808a414ac83249270d73d5b3198da