### PR TITLE
Add coverage for header pipeline LLM parse fallback

### DIFF
--- a/tests/test_header_audit_pipeline.py
+++ b/tests/test_header_audit_pipeline.py
@@ -47,3 +47,37 @@ def test_pipeline_writes_audit(tmp_path, monkeypatch):
     final = result["final_headers"]
     assert len(final) == 1
     assert final[0].title.lower().startswith("introduction")
+
+
+def test_pipeline_handles_llm_parse_error(tmp_path, monkeypatch):
+    heuristics = [
+        {
+            "text": "1 Scope",
+            "page": 1,
+            "font_size": 13.5,
+            "is_bold": True,
+            "level": 1,
+            "level_numbering": 1,
+            "level_font": 1,
+        }
+    ]
+
+    monkeypatch.setattr(llm_header_pass, "call_llm", lambda _text: "not json")
+
+    audit_path = tmp_path / "Epf_Co.preprocess.json"
+    result = run_header_pipeline(
+        "1 Scope\nBody text",
+        heuristics,
+        doc_meta={"doc_id": "doc-parse-error"},
+        audit_path=str(audit_path),
+    )
+
+    assert audit_path.exists()
+    data = json.loads(audit_path.read_text(encoding="utf-8"))
+    llm_block = data["header_pass"]["llm"]
+    assert llm_block["raw_response"] == "not json"
+    assert llm_block["parse_error"]
+
+    final_headers = result["final_headers"]
+    assert len(final_headers) == 1
+    assert final_headers[0].sources == ["heuristic"]


### PR DESCRIPTION
## Summary
- add regression coverage to ensure the preprocess header pipeline logs LLM parse failures and falls back to heuristic results

## Testing
- pytest tests/test_header_audit_pipeline.py tests/test_llm_parse_bad.py tests/test_llm_parse_ok.py tests/test_merge_both_sources.py

------
https://chatgpt.com/codex/tasks/task_e_68d80e25fdb48324b9c967fe62ebd5fd