### PR TITLE
Capture merge rationale in header audit output

### DIFF
--- a/backend/headers/merge_headers.py
+++ b/backend/headers/merge_headers.py
@@ -92,9 +92,24 @@ def merge_candidates(
         all_scores = [_candidate_score(cand) for cand in group]
         merged_conf = sum(all_scores) / len(all_scores) if all_scores else 0.5
         reasons: List[str] = []
+
+        def add_reason(value: str | None) -> None:
+            if not value:
+                return
+            if value not in reasons:
+                reasons.append(value)
+
+        for source in sources:
+            add_reason(f"source:{source}")
+
+        for cand in group:
+            cand_reasons = getattr(cand.judging, "reasons", None) or []
+            for reason in cand_reasons:
+                add_reason(f"{cand.source}:{reason}")
+
         if len(sources) > 1:
             merged_conf = min(1.0, merged_conf + 0.1)
-            reasons.append("supported_by_both_sources")
+            add_reason("supported_by_both_sources")
 
         finals.append(
             FinalHeader(

--- a/tests/test_merge_both_sources.py
+++ b/tests/test_merge_both_sources.py
@@ -2,11 +2,20 @@ from backend.headers.merge_headers import merge_candidates
 from backend.models.headers import HeaderCandidate, Judging
 
 
-def _candidate(source: str, title: str, section_id: str | None, confidence: float, page: int) -> HeaderCandidate:
+def _candidate(
+    source: str,
+    title: str,
+    section_id: str | None,
+    confidence: float,
+    page: int,
+    *,
+    reasons: list[str] | None = None,
+) -> HeaderCandidate:
     judging = Judging(
         heuristic_confidence=confidence if source == "heuristic" else None,
         llm_confidence=confidence if source == "llm" else None,
         page=page,
+        reasons=list(reasons or []),
     )
     return HeaderCandidate(
         source=source,
@@ -30,3 +39,24 @@ def test_merge_candidates_prefers_both_sources():
     assert final.sources == ["heuristic", "llm"]
     assert final.confidence > 0.7
     assert "supported_by_both_sources" in final.reasons
+
+
+def test_merge_candidates_collects_reason_metadata():
+    heur = _candidate(
+        "heuristic",
+        "Introduction",
+        "1",
+        0.65,
+        1,
+        reasons=["numeric_pattern", "bold_text"],
+    )
+    llm = _candidate("llm", "Introduction", "1", 0.8, 1, reasons=["high_confidence"])
+
+    merged = merge_candidates([llm], [heur])
+    final = merged[0]
+
+    assert "source:heuristic" in final.reasons
+    assert "source:llm" in final.reasons
+    assert "heuristic:numeric_pattern" in final.reasons
+    assert "heuristic:bold_text" in final.reasons
+    assert "llm:high_confidence" in final.reasons


### PR DESCRIPTION
## Summary
- carry source attribution and candidate reasoning into merged header explanations
- extend merge header tests to cover the new metadata aggregation

## Testing
- pytest tests/test_merge_both_sources.py
- pytest tests/test_header_audit_pipeline.py
- pytest tests/test_llm_parse_ok.py tests/test_llm_parse_bad.py

------
https://chatgpt.com/codex/tasks/task_e_68d8137928188324a67e4ece02936d47