### PR TITLE
Add header pipeline tests for LLM integration

### DIFF
--- a/tests/test_header_audit_pipeline.py
+++ b/tests/test_header_audit_pipeline.py
@@ -43,10 +43,17 @@ def test_pipeline_writes_audit(tmp_path, monkeypatch):
     assert data["header_pass"]["llm"]["candidates"], "LLM candidates missing"
     assert data["header_pass"]["heuristic"]["candidates"], "heuristic candidates missing"
     assert data["header_pass"]["final"]["headers"], "final headers missing"
+    assert data["doc_meta"]["doc_id"] == "doc-1"
+    assert (
+        data["header_pass"]["llm"]["prompt_used"]
+        == "Please list all header sections of this document and provide the results in a json format"
+    )
+    assert data["header_pass"]["llm"]["parse_error"] is None
 
     final = result["final_headers"]
     assert len(final) == 1
     assert final[0].title.lower().startswith("introduction")
+    assert final[0].sources == ["heuristic", "llm"]
 
 
 def test_pipeline_handles_llm_parse_error(tmp_path, monkeypatch):
@@ -77,6 +84,7 @@ def test_pipeline_handles_llm_parse_error(tmp_path, monkeypatch):
     llm_block = data["header_pass"]["llm"]
     assert llm_block["raw_response"] == "not json"
     assert llm_block["parse_error"]
+    assert llm_block["prompt_used"] == "Please list all header sections of this document and provide the results in a json format"
 
     final_headers = result["final_headers"]
     assert len(final_headers) == 1

--- a/tests/test_llm_parse_bad.py
+++ b/tests/test_llm_parse_bad.py
@@ -9,5 +9,6 @@ def test_run_llm_header_pass_invalid_json(monkeypatch):
 
     result = llm_header_pass.run_llm_header_pass("sample text")
     assert result["parse_error"] is not None
+    assert "EXPECTING" in result["parse_error"].upper()
     assert result["candidates"] == []
     assert isinstance(result["raw_response"], str)

--- a/tests/test_llm_parse_ok.py
+++ b/tests/test_llm_parse_ok.py
@@ -10,4 +10,7 @@ def test_coerce_llm_candidates_from_json():
     assert candidate.title == "Introduction"
     assert candidate.page == 1
     assert candidate.level == 1
+    assert candidate.section_id == "1"
     assert candidate.judging.llm_confidence == 0.92
+    # Arbitrary keys from the JSON payload should be preserved for auditing.
+    assert candidate.judging.llm_raw_fields == {}

--- a/tests/test_merge_both_sources.py
+++ b/tests/test_merge_both_sources.py
@@ -60,3 +60,17 @@ def test_merge_candidates_collects_reason_metadata():
     assert "heuristic:numeric_pattern" in final.reasons
     assert "heuristic:bold_text" in final.reasons
     assert "llm:high_confidence" in final.reasons
+
+
+def test_merge_candidates_normalises_titles():
+    heur = _candidate("heuristic", "1 Introduction", "1", 0.6, 1)
+    llm = _candidate("llm", "Introduction", "1", 0.7, 1)
+
+    merged = merge_candidates([llm], [heur])
+    assert len(merged) == 1
+    final = merged[0]
+
+    # Title is de-duplicated to remove the numbering prefix.
+    assert final.title == "Introduction"
+    assert final.section_id == "1"
+    assert final.sources == ["heuristic", "llm"]


### PR DESCRIPTION
## Summary
- extend LLM parsing test to assert section ids and raw field preservation
- tighten invalid JSON test expectations
- add regression coverage for merged header sources and title normalisation
- verify preprocess audit output captures prompt, metadata, and merged sources

## Testing
- `pytest tests/test_llm_parse_ok.py tests/test_llm_parse_bad.py tests/test_merge_both_sources.py tests/test_header_audit_pipeline.py`


------
https://chatgpt.com/codex/tasks/task_e_68d81d1bb7588324a0353f0b43526334