### PR TITLE
Add coverage for LLM header candidate coercion

### DIFF
--- a/tests/test_llm_parse_ok.py
+++ b/tests/test_llm_parse_ok.py
@@ -1,8 +1,23 @@
+import json
+
 from backend.headers.llm_header_pass import coerce_llm_candidates, parse_llm_json
 
 
 def test_coerce_llm_candidates_from_json():
-    raw = '{"headers": [{"title": "Introduction", "page": 1, "confidence": 0.92, "level": "1", "section_id": "1"}]}'
+    raw = json.dumps(
+        {
+            "headers": [
+                {
+                    "title": "Introduction",
+                    "page": 1,
+                    "confidence": 0.92,
+                    "level": "1",
+                    "section_id": "1",
+                    "summary": "preface",
+                }
+            ]
+        }
+    )
     items = parse_llm_json(raw)
     candidates = coerce_llm_candidates(items)
     assert len(candidates) == 1
@@ -13,4 +28,32 @@ def test_coerce_llm_candidates_from_json():
     assert candidate.section_id == "1"
     assert candidate.judging.llm_confidence == 0.92
     # Arbitrary keys from the JSON payload should be preserved for auditing.
-    assert candidate.judging.llm_raw_fields == {}
+    assert candidate.judging.llm_raw_fields == {"summary": "preface"}
+
+
+def test_parse_llm_json_with_wrapper_and_span():
+    raw = json.dumps(
+        {
+            "results": [
+                {
+                    "title": "Scope",
+                    "page": "2",
+                    "confidence": 0.81,
+                    "level": "2",
+                    "id": "1.1",
+                    "span_char": {"start": 5, "end": 17},
+                    "notes": "subsection",
+                }
+            ]
+        }
+    )
+    items = parse_llm_json(raw)
+    candidates = coerce_llm_candidates(items)
+    assert len(candidates) == 1
+    candidate = candidates[0]
+    assert candidate.section_id == "1.1"
+    assert candidate.level == 2
+    assert candidate.page == 2
+    assert candidate.span_char == (5, 17)
+    assert candidate.judging.llm_confidence == 0.81
+    assert candidate.judging.llm_raw_fields == {"notes": "subsection"}


### PR DESCRIPTION
## Summary
- extend the LLM parsing test to ensure arbitrary metadata fields are preserved for auditing
- add coverage for wrapper responses that include span_char data so coercion fills numeric fields

## Testing
- pytest tests/test_llm_parse_ok.py tests/test_llm_parse_bad.py tests/test_merge_both_sources.py tests/test_header_audit_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68d820e00610832498f813e195c60896