### PR TITLE
Fix OpenRouter client resilience and header detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,17 @@
-{
-  "file_path": "rag-app/.gitignore",
-  "language": "text",
-  "imported_types": [],
-  "imports": [],
-  "declared_types": []
-}
+__pycache__/
+*.py[cod]
+*.so
+*.dylib
+*.egg-info/
+.eggs/
+build/
+dist/
+.env
+.env.*
+.venv/
+venv/
+.DS_Store
+node_modules/
+*.log
+.coverage
+.pytest_cache/

--- a/rag-app/backend/app/adapters/vectors.py
+++ b/rag-app/backend/app/adapters/vectors.py
@@ -1,10 +1,17 @@
-"""Vector search utilities."""
+"""Vector and sparse retrieval adapters."""
 from __future__ import annotations
 
 import math
+import uuid
 from collections import Counter, defaultdict
 from dataclasses import dataclass
-from typing import Dict, Iterable, List, Sequence, Tuple
+from pathlib import Path
+from typing import Dict, List, Sequence
+
+from backend.app.config import settings
+from backend.app.util.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 def _tokenize(text: str) -> List[str]:
@@ -12,142 +19,151 @@ def _tokenize(text: str) -> List[str]:
 
 
 @dataclass
-class EmbeddingModel:
-    dimension: int = 64
-
-    def embed_texts(self, texts: Sequence[str]) -> List[List[float]]:
-        import hashlib
-
-        embeddings: List[List[float]] = []
-        for text in texts:
-            digest = hashlib.sha256(text.encode("utf-8")).digest()
-            floats = [b / 255.0 for b in digest[: self.dimension]]
-            if len(floats) < self.dimension:
-                floats.extend([0.0] * (self.dimension - len(floats)))
-            embeddings.append(floats)
-        return embeddings
-
-
 class BM25Index:
-    def __init__(self, k1: float = 1.5, b: float = 0.75) -> None:
-        self.k1 = k1
-        self.b = b
-        self.documents: Dict[str, Counter[str]] = {}
-        self.doc_lengths: Dict[str, int] = {}
-        self.inverted_index: Dict[str, int] = defaultdict(int)
+    """In-memory BM25 index."""
+
+    k1: float = 1.5
+    b: float = 0.75
+
+    def __post_init__(self) -> None:
+        self._documents: Dict[str, Counter[str]] = {}
+        self._doc_lengths: Dict[str, int] = {}
+        self._inverted: Dict[str, int] = defaultdict(int)
 
     def add(self, doc_id: str, text: str) -> None:
         tokens = Counter(_tokenize(text))
-        self.documents[doc_id] = tokens
-        length = sum(tokens.values())
-        self.doc_lengths[doc_id] = length
+        self._documents[doc_id] = tokens
+        self._doc_lengths[doc_id] = sum(tokens.values())
         for token in tokens:
-            self.inverted_index[token] += 1
+            self._inverted[token] += 1
 
     def _idf(self, term: str) -> float:
-        n_docs = len(self.documents) + 1e-9
-        doc_freq = self.inverted_index.get(term, 0) + 1e-9
+        n_docs = len(self._documents) + 1e-9
+        doc_freq = self._inverted.get(term, 0) + 1e-9
         return math.log((n_docs - doc_freq + 0.5) / (doc_freq + 0.5) + 1.0)
 
-    def search(self, query: str, limit: int = 5) -> List[Tuple[str, float]]:
-        query_tokens = _tokenize(query)
+    def search(self, query: str, limit: int = 10) -> List[dict]:
+        tokens = _tokenize(query)
         scores: Dict[str, float] = defaultdict(float)
-        avgdl = sum(self.doc_lengths.values()) / (len(self.doc_lengths) or 1)
-        for term in query_tokens:
-            idf = self._idf(term)
-            for doc_id, tokens in self.documents.items():
-                freq = tokens.get(term, 0)
+        avgdl = sum(self._doc_lengths.values()) / (len(self._doc_lengths) or 1)
+        for token in tokens:
+            idf = self._idf(token)
+            for doc_id, doc_tokens in self._documents.items():
+                freq = doc_tokens.get(token, 0)
                 if freq == 0:
                     continue
-                score = idf * (freq * (self.k1 + 1)) / (
-                    freq + self.k1 * (1 - self.b + self.b * (self.doc_lengths[doc_id] / (avgdl or 1)))
-                )
-                scores[doc_id] += score
-        return sorted(scores.items(), key=lambda item: item[1], reverse=True)[:limit]
+                numer = freq * (self.k1 + 1)
+                denom = freq + self.k1 * (1 - self.b + self.b * (self._doc_lengths[doc_id] / (avgdl or 1)))
+                scores[doc_id] += idf * numer / (denom or 1e-9)
+        ranked = sorted(scores.items(), key=lambda item: item[1], reverse=True)[:limit]
+        return [{"doc_id": doc_id, "score": score} for doc_id, score in ranked]
 
 
 class FaissIndex:
+    """FAISS wrapper with graceful degradation."""
+
     def __init__(self, dimension: int) -> None:
         try:
             import faiss  # type: ignore
         except ImportError as exc:  # pragma: no cover - optional dependency
             raise RuntimeError("faiss is not installed") from exc
-        self.faiss = faiss
-        self.dimension = dimension
-        self.index = faiss.IndexFlatIP(dimension)
-        self.ids: List[str] = []
+        self._faiss = faiss
+        self._dimension = dimension
+        self._index = faiss.IndexFlatIP(dimension)
+        self._ids: List[str] = []
 
     def add(self, doc_id: str, vector: Sequence[float]) -> None:
         import numpy as np
 
         arr = np.array([vector], dtype="float32")
-        self.index.add(arr)
-        self.ids.append(doc_id)
+        if arr.shape[1] != self._dimension:
+            raise ValueError("Vector dimension mismatch")
+        self._index.add(arr)
+        self._ids.append(doc_id)
 
-    def search(self, query: Sequence[float], limit: int = 5) -> List[Tuple[str, float]]:
+    def search(self, query_vec: Sequence[float], k: int = 20) -> List[dict]:
         import numpy as np
 
-        arr = np.array([query], dtype="float32")
-        scores, idxs = self.index.search(arr, limit)
-        hits: List[Tuple[str, float]] = []
-        for idx, score in zip(idxs[0], scores[0]):
-            if idx < 0 or idx >= len(self.ids):
+        arr = np.array([query_vec], dtype="float32")
+        scores, indices = self._index.search(arr, k)
+        hits: List[dict] = []
+        for idx, score in zip(indices[0], scores[0]):
+            if idx < 0 or idx >= len(self._ids):
                 continue
-            hits.append((self.ids[idx], float(score)))
+            hits.append({"doc_id": self._ids[idx], "score": float(score)})
         return hits
 
-    def save(self, path: str) -> None:
-        self.faiss.write_index(self.index, path)
+    def save(self, path: str | Path) -> None:
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._faiss.write_index(self._index, str(path))
 
 
 class QdrantIndex:
+    """Qdrant client adapter."""
+
     def __init__(self, collection: str, dimension: int) -> None:
         try:
             from qdrant_client import QdrantClient  # type: ignore
         except ImportError as exc:  # pragma: no cover - optional dependency
             raise RuntimeError("qdrant-client is not installed") from exc
-        self.client = QdrantClient(path="./qdrant.db")
-        self.collection = collection
-        self.dimension = dimension
-        self.client.recreate_collection(collection_name=collection, vector_size=dimension, distance="Cosine")
-
-    def add(self, doc_id: str, vector: Sequence[float]) -> None:
-        self.client.upsert(
-            collection_name=self.collection,
-            points=[{"id": doc_id, "vector": list(vector), "payload": {"doc_id": doc_id}}],
+        self._client = QdrantClient(path=str(settings.storage_dir / "qdrant.db"))
+        self._collection = collection
+        self._dimension = dimension
+        self._client.recreate_collection(
+            collection_name=collection,
+            vector_size=dimension,
+            distance="Cosine",
         )
 
-    def search(self, query: Sequence[float], limit: int = 5) -> List[Tuple[str, float]]:
-        results = self.client.search(
-            collection_name=self.collection,
-            query_vector=list(query),
-            limit=limit,
+    def add(self, vectors: List[List[float]], payloads: List[dict] | None = None) -> None:
+        payloads = payloads or [{} for _ in vectors]
+        points = []
+        for vector, payload in zip(vectors, payloads):
+            point_id = payload.get("id") or str(uuid.uuid4())
+            points.append({"id": point_id, "vector": vector, "payload": payload})
+        self._client.upsert(collection_name=self._collection, points=points)
+
+    def search(self, query_vec: List[float], k: int = 20) -> List[dict]:
+        results = self._client.search(
+            collection_name=self._collection,
+            query_vector=query_vec,
+            limit=k,
         )
-        return [(point.payload["doc_id"], float(point.score)) for point in results]
+        return [
+            {"doc_id": hit.payload.get("doc_id") or hit.id, "score": float(hit.score)}
+            for hit in results
+        ]
 
 
 def hybrid_search(
-    bm25: BM25Index,
-    embeddings: Dict[str, List[float]],
+    bm25: BM25Index | None,
+    dense: FaissIndex | QdrantIndex | None,
     query: str,
+    query_vec: List[float] | None,
     *,
-    embedder: EmbeddingModel,
     alpha: float = 0.5,
-    limit: int = 5,
-) -> List[Tuple[str, float]]:
-    bm25_hits = bm25.search(query, limit=limit * 2)
-    query_vec = embedder.embed_texts([query])[0]
+    k: int = 20,
+) -> List[dict]:
+    """Fuse sparse+dense scores."""
 
-    def cosine(a: Sequence[float], b: Sequence[float]) -> float:
-        dot = sum(x * y for x, y in zip(a, b))
-        norm_a = math.sqrt(sum(x * x for x in a)) + 1e-9
-        norm_b = math.sqrt(sum(x * x for x in b)) + 1e-9
-        return dot / (norm_a * norm_b)
+    sparse_hits: Dict[str, float] = {}
+    if bm25:
+        for hit in bm25.search(query, limit=k * 2):
+            sparse_hits[hit["doc_id"]] = hit["score"]
 
-    dense_scores = {doc_id: cosine(query_vec, embeddings.get(doc_id, [])) for doc_id, _ in bm25_hits}
-    blended = []
-    for doc_id, sparse_score in bm25_hits:
-        dense_score = dense_scores.get(doc_id, 0.0)
-        score = alpha * sparse_score + (1 - alpha) * dense_score
-        blended.append((doc_id, score))
-    return sorted(blended, key=lambda item: item[1], reverse=True)[:limit]
+    dense_hits: Dict[str, float] = {}
+    if dense and query_vec is not None:
+        for hit in dense.search(query_vec, k=k * 2):
+            dense_hits[hit["doc_id"]] = hit["score"]
+
+    doc_ids = set(sparse_hits) | set(dense_hits)
+    fused = []
+    for doc_id in doc_ids:
+        sparse = sparse_hits.get(doc_id, 0.0)
+        dense_score = dense_hits.get(doc_id, 0.0)
+        score = alpha * sparse + (1 - alpha) * dense_score
+        fused.append({"doc_id": doc_id, "score": score})
+
+    fused.sort(key=lambda item: item["score"], reverse=True)
+    return fused[:k]

--- a/rag-app/backend/app/llm/clients/openrouter.py
+++ b/rag-app/backend/app/llm/clients/openrouter.py
@@ -1,120 +1,227 @@
-"""HTTP client for OpenRouter."""
+"""OpenRouter HTTP client implementations."""
 from __future__ import annotations
 
 import asyncio
-import time
-from typing import Any, AsyncGenerator, Dict, Iterable, List
+import json
+import random
+from typing import Any, AsyncGenerator, Dict, Iterable, Iterator, List
 
 import httpx
 
 from backend.app.config import settings
-from backend.app.util.logging import get_logger
+from backend.app.llm.utils import log_prompt
 from backend.app.llm.utils.envsafe import openrouter_headers
+from backend.app.util.logging import get_logger
+from backend.app.util.retry import RetryPolicy, with_retries
 
 logger = get_logger(__name__)
 
 
-class OpenRouterError(RuntimeError):
-    pass
+class OpenRouterError(Exception):
+    """Base error."""
 
 
 class OpenRouterAuthError(OpenRouterError):
-    pass
+    """401 error."""
 
 
 class OpenRouterHTTPError(OpenRouterError):
-    def __init__(self, status_code: int, message: str) -> None:
-        super().__init__(message)
-        self.status_code = status_code
+    """HTTP status/transport error."""
 
 
 class OpenRouterStreamError(OpenRouterError):
-    pass
+    """Streaming idle/format error."""
 
 
-def _backoff(retries: int, base: float = 0.5) -> Iterable[float]:
-    for attempt in range(retries):
-        yield base * (2 ** attempt)
+def _backoff(retries: int = 3, base: float = 0.5, max_delay: float = 8.0) -> Iterable[float]:
+    """Yield jittered backoff durations."""
+
+    delay = base
+    for _ in range(max(0, retries)):
+        jitter = random.uniform(0.75, 1.25)
+        yield min(max_delay, delay) * jitter
+        delay *= 2
 
 
-def _request_headers() -> Dict[str, str]:
-    headers = openrouter_headers(settings.openrouter_api_key)
-    headers.setdefault("Content-Type", "application/json")
-    return headers
+def _post_once(url: str, headers: Dict[str, str], payload: Dict[str, Any], timeout: float) -> Dict[str, Any]:
+    """Perform a single synchronous POST request."""
+
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            response = client.post(url, headers=headers, json=payload)
+    except httpx.TimeoutException as exc:  # pragma: no cover - network dependent
+        raise OpenRouterHTTPError("OpenRouter request timed out") from exc
+    except httpx.HTTPError as exc:
+        raise OpenRouterHTTPError(str(exc)) from exc
+
+    if response.status_code == 401:
+        raise OpenRouterAuthError("Unauthorized")
+    if response.status_code >= 400:
+        raise OpenRouterHTTPError(response.text)
+    try:
+        return response.json()
+    except ValueError as exc:
+        raise OpenRouterHTTPError("Invalid JSON response from OpenRouter") from exc
 
 
-def chat_sync(*, model: str, messages: List[Dict[str, str]], timeout: float = 60.0, retries: int = 3, **kwargs: Any) -> Dict[str, Any]:
+def chat_sync(
+    model: str,
+    messages: List[Dict[str, str]],
+    temperature: float = 0.0,
+    top_p: float | None = None,
+    max_tokens: int | None = None,
+    extra: Dict[str, Any] | None = None,
+    timeout: float = 60.0,
+    retries: int = 3,
+) -> Dict[str, Any]:
+    """Sync chat with retries and masked logging."""
+
+    payload: Dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "temperature": temperature,
+    }
+    if top_p is not None:
+        payload["top_p"] = top_p
+    if max_tokens is not None:
+        payload["max_tokens"] = max_tokens
+    if extra:
+        payload.update(extra)
+
+    headers = openrouter_headers()
+    logger.info("openrouter_chat_sync", extra=log_prompt("sync", payload, headers))
     url = f"{settings.openrouter_base_url}/chat/completions"
-    payload = {"model": model, "messages": messages, **kwargs}
-    last_exc: Exception | None = None
-    for delay in list(_backoff(retries)) + [None]:
-        try:
-            with httpx.Client(timeout=timeout) as http_client:
-                resp = http_client.post(url, json=payload, headers=_request_headers())
-            if resp.status_code == 401:
-                raise OpenRouterAuthError("Invalid OpenRouter credentials")
-            if resp.status_code >= 400:
-                raise OpenRouterHTTPError(resp.status_code, resp.text)
-            return resp.json()
-        except (httpx.RequestError, OpenRouterHTTPError, OpenRouterAuthError) as exc:
-            last_exc = exc
-            if delay is None:
-                break
-            logger.warning("OpenRouter chat retry", extra={"delay": delay, "error": str(exc)})
-            time.sleep(delay)
-    assert last_exc is not None
-    raise last_exc
+
+    policy = RetryPolicy(retries=retries, base_delay=0.5, max_delay=8.0)
+    return with_retries(
+        lambda: _post_once(url, headers, payload, timeout),
+        (OpenRouterHTTPError,),
+        policy=policy,
+    )
+
+
+async def _stream_once(
+    url: str,
+    headers: Dict[str, str],
+    payload: Dict[str, Any],
+    timeout: float,
+    idle_timeout: float,
+) -> AsyncGenerator[Dict[str, Any], None]:
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        async with client.stream("POST", url, headers=headers, json=payload) as response:
+            if response.status_code == 401:
+                raise OpenRouterAuthError("Unauthorized")
+            if response.status_code >= 400:
+                body = await response.aread()
+                raise OpenRouterHTTPError(body.decode("utf-8", errors="ignore"))
+
+            iterator = response.aiter_raw()
+            buffer = b""
+
+            while True:
+                try:
+                    chunk = await asyncio.wait_for(iterator.__anext__(), timeout=idle_timeout)
+                except StopAsyncIteration:
+                    break
+                except asyncio.TimeoutError as exc:
+                    raise OpenRouterStreamError("OpenRouter stream idle timeout") from exc
+
+                if not chunk:
+                    continue
+
+                buffer += chunk
+                while b"\n\n" in buffer:
+                    event_bytes, buffer = buffer.split(b"\n\n", 1)
+                    event_text = event_bytes.decode("utf-8", errors="ignore").strip()
+                    if not event_text:
+                        continue
+                    if not event_text.startswith("data:"):
+                        logger.debug("openrouter_stream_skip", extra={"event": event_text})
+                        continue
+                    data = event_text[len("data:") :].strip()
+                    if data == "[DONE]":
+                        yield {"event": "done"}
+                        return
+                    try:
+                        payload = json.loads(data)
+                    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+                        raise OpenRouterStreamError("Invalid JSON chunk") from exc
+                    yield {"event": "delta", "data": payload}
+
+            if buffer:
+                logger.debug("openrouter_stream_buffer", extra={"buffer": buffer.decode(errors="ignore")})
 
 
 async def chat_stream_async(
-    *,
     model: str,
     messages: List[Dict[str, str]],
+    temperature: float = 0.0,
+    top_p: float | None = None,
+    max_tokens: int | None = None,
+    extra: Dict[str, Any] | None = None,
     timeout: float = 60.0,
     retries: int = 3,
-    **kwargs: Any,
+    idle_timeout: float = 30.0,
 ) -> AsyncGenerator[Dict[str, Any], None]:
+    """Async SSE streaming, yields deltas/meta/done."""
+
+    payload: Dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "temperature": temperature,
+        "stream": True,
+    }
+    if top_p is not None:
+        payload["top_p"] = top_p
+    if max_tokens is not None:
+        payload["max_tokens"] = max_tokens
+    if extra:
+        payload.update(extra)
+
+    headers = openrouter_headers()
+    logger.info("openrouter_chat_stream", extra=log_prompt("stream", payload, headers))
     url = f"{settings.openrouter_base_url}/chat/completions"
-    payload = {"model": model, "messages": messages, "stream": True, **kwargs}
-    for delay in list(_backoff(retries)) + [None]:
+
+    delays: Iterator[float] = iter(_backoff(retries=retries))
+    attempt = 0
+    while True:
+        attempt += 1
         try:
-            async with httpx.AsyncClient(timeout=timeout) as http_client:
-                async with http_client.stream("POST", url, json=payload, headers=_request_headers()) as resp:
-                    if resp.status_code == 401:
-                        raise OpenRouterAuthError("Invalid OpenRouter credentials")
-                    if resp.status_code >= 400:
-                        raise OpenRouterHTTPError(resp.status_code, await resp.aread())
-                    async for line in resp.aiter_lines():
-                        if not line:
-                            continue
-                        yield {"event": "delta", "data": line}
-                    return
-        except (httpx.RequestError, OpenRouterError) as exc:
-            if delay is None:
-                raise OpenRouterStreamError(str(exc)) from exc
-            logger.warning("OpenRouter stream retry", extra={"delay": delay, "error": str(exc)})
+            async for event in _stream_once(url, headers, payload, timeout, idle_timeout):
+                yield event
+            return
+        except (OpenRouterHTTPError, OpenRouterStreamError, httpx.HTTPError) as exc:
+            logger.warning(
+                "openrouter_stream_retry",
+                extra={"attempt": attempt, "error": str(exc)},
+            )
+            try:
+                delay = next(delays)
+            except StopIteration:
+                raise OpenRouterHTTPError(str(exc)) from exc
             await asyncio.sleep(delay)
 
 
-def embed_sync(*, model: str, inputs: List[str], timeout: float = 60.0, retries: int = 3) -> List[List[float]]:
+def embed_sync(
+    model: str,
+    inputs: List[str],
+    timeout: float = 60.0,
+    retries: int = 3,
+) -> List[List[float]]:
+    """Sync embeddings with retries."""
+
+    payload: Dict[str, Any] = {"model": model, "input": inputs}
+    headers = openrouter_headers()
     url = f"{settings.openrouter_base_url}/embeddings"
-    payload = {"model": model, "input": inputs}
-    last_exc: Exception | None = None
-    for delay in list(_backoff(retries)) + [None]:
-        try:
-            with httpx.Client(timeout=timeout) as http_client:
-                resp = http_client.post(url, json=payload, headers=_request_headers())
-            if resp.status_code == 401:
-                raise OpenRouterAuthError("Invalid OpenRouter credentials")
-            if resp.status_code >= 400:
-                raise OpenRouterHTTPError(resp.status_code, resp.text)
-            data = resp.json()
-            return [item["embedding"] for item in data.get("data", [])]
-        except (httpx.RequestError, OpenRouterError) as exc:
-            last_exc = exc
-            if delay is None:
-                break
-            logger.warning("OpenRouter embeddings retry", extra={"delay": delay, "error": str(exc)})
-            time.sleep(delay)
-    assert last_exc is not None
-    raise last_exc
+    logger.info("openrouter_embed", extra=log_prompt("embed", payload, headers))
+
+    policy = RetryPolicy(retries=retries, base_delay=0.5, max_delay=8.0)
+
+    def _embed_once() -> List[List[float]]:
+        response = _post_once(url, headers, payload, timeout)
+        vectors = [item["embedding"] for item in response.get("data", [])]
+        if not vectors:
+            logger.warning("openrouter_embed_empty")
+        return vectors
+
+    return with_retries(_embed_once, (OpenRouterHTTPError,), policy=policy)

--- a/rag-app/backend/app/llm/openrouter.py
+++ b/rag-app/backend/app/llm/openrouter.py
@@ -1,29 +1,35 @@
-"""Thin sync wrapper for OpenRouter chat."""
+"""Thin OpenRouter wrapper used by adapters."""
 from __future__ import annotations
 
 from typing import Any, Dict, List
 
-from ..config import settings
-from ..util.logging import get_logger
-from .clients import openrouter as client
-
-logger = get_logger(__name__)
-
-
-class OpenRouterAuthError(RuntimeError):
-    pass
+from backend.app.llm.clients.openrouter import (
+    OpenRouterAuthError,
+    OpenRouterHTTPError,
+    chat_sync,
+)
 
 
-class OpenRouterHTTPError(RuntimeError):
-    pass
+def chat(
+    model: str,
+    messages: List[Dict[str, str]],
+    temperature: float = 0.0,
+    top_p: float | None = None,
+    max_tokens: int | None = None,
+    extra: Dict[str, Any] | None = None,
+    timeout: float = 60.0,
+) -> Dict[str, Any]:
+    """Synchronous chat call to OpenRouter /chat/completions."""
+
+    return chat_sync(
+        model=model,
+        messages=messages,
+        temperature=temperature,
+        top_p=top_p,
+        max_tokens=max_tokens,
+        extra=extra,
+        timeout=timeout,
+    )
 
 
-def chat(*, model: str, messages: List[Dict[str, str]], **kwargs: Any) -> Dict[str, Any]:
-    if not settings.openrouter_api_key:
-        raise OpenRouterAuthError("OPENROUTER_API_KEY missing")
-    try:
-        return client.chat_sync(model=model, messages=messages, **kwargs)
-    except client.OpenRouterAuthError as exc:  # type: ignore[attr-defined]
-        raise OpenRouterAuthError(str(exc)) from exc
-    except client.OpenRouterHTTPError as exc:  # type: ignore[attr-defined]
-        raise OpenRouterHTTPError(str(exc)) from exc
+__all__ = ["chat", "OpenRouterAuthError", "OpenRouterHTTPError"]

--- a/rag-app/backend/app/services/header_service/header_controller.py
+++ b/rag-app/backend/app/services/header_service/header_controller.py
@@ -1,60 +1,143 @@
 """Header controller."""
 from __future__ import annotations
 
-import json
-from dataclasses import asdict
-from pathlib import Path
+import re
+from dataclasses import dataclass
 from typing import Dict, List
 
-from pydantic import BaseModel
-
-from backend.app.contracts.chunking import Chunk
-from backend.app.contracts.headers import Header
+from backend.app.adapters import storage
+from backend.app.contracts.headers import Header, HeaderChunk
 from backend.app.util.errors import AppError
+from backend.app.util.logging import get_logger
 
-from .packages.heur.regex_bank import find_header_candidates
+from .packages.heur.regex_bank import header_patterns
 from .packages.join.stitcher import stitch_headers
 from .packages.rechunk.by_headers import rechunk_by_headers
 from .packages.repair.sequence import repair_sequence
-from .packages.score.typo_features import score_typo
+from .packages.score.typo_features import score_chunk
+
+logger = get_logger(__name__)
+
+_STOPWORDS = {"the", "and", "with", "for", "from", "into", "onto", "using"}
 
 
-class HeaderJoinInternal(BaseModel):
+@dataclass
+class HeaderJoinInternal:
+    """Internal header join result."""
+
     doc_id: str
+    headers_path: str
+    header_chunks_path: str
     headers: List[Header]
-    sections: Dict[str, List[str]]
-
-
-def _load_chunks(chunks_artifact: str) -> List[Chunk]:
-    path = Path(chunks_artifact)
-    chunks: List[Chunk] = []
-    for line in path.read_text(encoding="utf-8").splitlines():
-        if not line.strip():
-            continue
-        payload = json.loads(line)
-        chunks.append(Chunk(**payload))
-    return chunks
-
-
-def join_and_rechunk(*, doc_id: str, chunks_artifact: str) -> HeaderJoinInternal:
-    chunks = _load_chunks(chunks_artifact)
-    candidates = find_header_candidates(chunks)
-    scored = [score_typo(candidate) for candidate in candidates]
-    stitched = stitch_headers(scored)
-    repaired = repair_sequence(stitched)
-    sections = rechunk_by_headers(repaired, chunks)
-    header_payload = {
-        "doc_id": doc_id,
-        "headers": [asdict(header) for header in repaired],
-        "sections": sections,
-    }
-    Path(chunks_artifact).parent.joinpath("headers.json").write_text(
-        json.dumps(header_payload, indent=2, sort_keys=True), encoding="utf-8"
-    )
-    return HeaderJoinInternal(doc_id=doc_id, headers=repaired, sections=sections)
+    header_chunks: List[HeaderChunk]
 
 
 def handle_header_errors(e: Exception) -> None:
+    """Normalize and raise header errors."""
+
     if isinstance(e, AppError):
-        raise e
-    raise AppError(str(e)) from e
+        raise
+    logger.exception("header_error", exc_info=e)
+    raise AppError("Header detection failed") from e
+
+
+def _clean_token(token: str) -> str:
+    return token.strip(".,:;()[]{}")
+
+
+def _sentence_candidates(text: str) -> List[List[str]]:
+    segments = re.split(r"(?<=\.)\s+|\n+", text)
+    words: List[List[str]] = []
+    for segment in segments:
+        tokens = [_clean_token(tok) for tok in segment.strip().split() if tok.strip()]
+        if tokens:
+            words.append(tokens)
+    return words
+
+
+def _extract_candidates(doc_id: str, record: Dict[str, str], index_offset: int) -> List[Dict[str, object]]:
+    candidates: List[Dict[str, object]] = []
+    page = record.get("page", 1)
+    chunk_id = record.get("chunk_id", f"{doc_id}-chunk")
+    for tokens in _sentence_candidates(record.get("text", "")):
+        if not tokens:
+            continue
+        first = tokens[0]
+        header_words: List[str] = []
+        level = 1
+        if first.isupper() and len(first) >= 4:
+            header_words = [first.title()]
+        elif first.replace(".", "").isdigit() and len(tokens) > 1:
+            header_words.append(first)
+            extras = 0
+            for token in tokens[1:]:
+                clean = token
+                if not clean:
+                    break
+                if clean.lower() in _STOPWORDS:
+                    break
+                if not clean[0].isupper():
+                    break
+                header_words.append(clean)
+                extras += 1
+                if extras >= 2:
+                    break
+            if len(header_words) <= 1:
+                continue
+            level = first.count(".") + 1 if "." in first else 1
+        else:
+            continue
+
+        header_text = " ".join(header_words)
+        header_id = f"{doc_id}-header-{index_offset + len(candidates)}"
+        temp_chunk = HeaderChunk(
+            header_id=header_id,
+            chunk_id=chunk_id,
+            text=header_text,
+            page=page,
+        )
+        confidence = score_chunk(temp_chunk)
+        candidates.append(
+            {
+                "header_id": header_id,
+                "text": header_text,
+                "level": level,
+                "page": page,
+                "confidence": confidence,
+            }
+        )
+    return candidates
+
+
+def join_and_rechunk(doc_id: str, chunks_artifact: str) -> HeaderJoinInternal:
+    """Controller: regex/typo scoring, stitching, repair, emit headers & rechunk."""
+
+    try:
+        chunk_records = storage.read_jsonl(chunks_artifact)
+        patterns = header_patterns()
+        candidates: List[Dict[str, object]] = []
+        for record in chunk_records:
+            text = record.get("text", "")
+            if any(pattern.search(text) for pattern in patterns):
+                candidates.extend(_extract_candidates(doc_id, record, len(candidates)))
+        stitched = stitch_headers(candidates)
+        repaired = repair_sequence(stitched)
+        headers = [Header(**header) for header in repaired]
+        headers_path = f"{doc_id}/headers/headers.json"
+        storage.write_json(headers_path, [header.to_dict() for header in headers])
+        header_chunks = [
+            HeaderChunk(**chunk)
+            for chunk in rechunk_by_headers(chunks_artifact, [header.to_dict() for header in headers])
+        ]
+        header_chunks_path = f"{doc_id}/headers/header_chunks.jsonl"
+        storage.write_jsonl(header_chunks_path, [chunk.to_dict() for chunk in header_chunks])
+        return HeaderJoinInternal(
+            doc_id=doc_id,
+            headers_path=headers_path,
+            header_chunks_path=header_chunks_path,
+            headers=headers,
+            header_chunks=header_chunks,
+        )
+    except Exception as exc:
+        handle_header_errors(exc)
+        raise

--- a/rag-app/backend/app/services/header_service/packages/heur/regex_bank.py
+++ b/rag-app/backend/app/services/header_service/packages/heur/regex_bank.py
@@ -1,23 +1,14 @@
-"""Regex heuristics for headers."""
+"""Header regex heuristics."""
 from __future__ import annotations
 
 import re
-from typing import List, Tuple
-
-from backend.app.contracts.chunking import Chunk
-
-_HEADER_RE = re.compile(r"^(\d+(?:\.\d+)*)?\s*(.+)$")
+from typing import List, Pattern
 
 
-def find_header_candidates(chunks: List[Chunk]) -> List[Tuple[Chunk, int]]:
-    candidates: List[Tuple[Chunk, int]] = []
-    for chunk in chunks:
-        first_line = chunk.text.strip().splitlines()[0] if chunk.text.strip() else ""
-        match = _HEADER_RE.match(first_line)
-        if not match:
-            continue
-        numbering, title = match.groups()
-        level = numbering.count(".") + 1 if numbering else 1
-        if len(title.split()) <= 12:
-            candidates.append((chunk, level))
-    return candidates
+def header_patterns() -> List[Pattern[str]]:
+    """Return permissive regexes to identify potential headings."""
+
+    return [
+        re.compile(r"(\d+(?:\.\d+)*)\s+[A-Z][^\n]{2,}"),
+        re.compile(r"[A-Z]{3,}(?:\s+[A-Z]{3,})*"),
+    ]


### PR DESCRIPTION
## Summary
- harden the OpenRouter sync and streaming clients, providing consistent wrappers and retries
- clean up storage and vector adapters and update FastAPI header heuristics to extract headings reliably
- refresh project ignore rules to unblock developer tooling

## Testing
- PYTHONPATH=rag-app pytest rag-app/backend/app/tests

------
https://chatgpt.com/codex/tasks/task_e_68d8962b04b88324b628ea7864414916