### PR TITLE
Phase 1 remediation: align retry policy and env/test specs

### DIFF
--- a/PHASE_1_NOTES.md
+++ b/PHASE_1_NOTES.md
@@ -13,6 +13,7 @@ cd rag-app
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
+cp rag-app/.env.example rag-app/.env
 python run.py  # backend on :8000, frontend on :3000
 ```
 

--- a/app_finalstubs/finalstubs_latest.json
+++ b/app_finalstubs/finalstubs_latest.json
@@ -44,7 +44,7 @@
     ]
   },
   {
-    "file_path": "rag-app/.env",
+    "file_path": "rag-app/.env.example",
     "language": "text",
     "imported_types": [],
     "imports": [],
@@ -183,7 +183,7 @@
         "name": "run_pipeline",
         "type": "function",
         "line": 1,
-        "docstring": "Execute full pipeline: upload→parse→chunk→headers→passes.",
+        "docstring": "Execute full pipeline: upload\u2192parse\u2192chunk\u2192headers\u2192passes.",
         "modifiers": [],
         "decorators": [],
         "extends": [],
@@ -4369,6 +4369,221 @@
         },
         "members": []
       }
+    ]
+  },
+  {
+    "file_path": "rag-app/backend/app/tests/unit/test_config.py",
+    "language": "python",
+    "imported_types": [],
+    "imports": [],
+    "declared_types": [
+      {
+        "name": "reset_settings_cache",
+        "type": "function",
+        "line": 1,
+        "docstring": "",
+        "modifiers": [],
+        "decorators": [],
+        "extends": [],
+        "args": [],
+        "returns": {
+          "type": "None",
+          "description": ""
+        },
+        "members": []
+      },
+      {
+        "name": "test_settings_defaults",
+        "type": "function",
+        "line": 1,
+        "docstring": "",
+        "modifiers": [],
+        "decorators": [],
+        "extends": [],
+        "args": [
+          {
+            "name": "monkeypatch",
+            "type": "pytest.MonkeyPatch"
+          }
+        ],
+        "returns": {
+          "type": "None",
+          "description": ""
+        },
+        "members": []
+      },
+      {
+        "name": "test_environment_overrides",
+        "type": "function",
+        "line": 1,
+        "docstring": "",
+        "modifiers": [],
+        "decorators": [],
+        "extends": [],
+        "args": [
+          {
+            "name": "monkeypatch",
+            "type": "pytest.MonkeyPatch"
+          }
+        ],
+        "returns": {
+          "type": "None",
+          "description": ""
+        },
+        "members": []
+      },
+      {
+        "name": "test_uvicorn_and_frontend_options",
+        "type": "function",
+        "line": 1,
+        "docstring": "",
+        "modifiers": [],
+        "decorators": [],
+        "extends": [],
+        "args": [
+          {
+            "name": "monkeypatch",
+            "type": "pytest.MonkeyPatch"
+          }
+        ],
+        "returns": {
+          "type": "None",
+          "description": ""
+        },
+        "members": []
+      }
+    ],
+    "spec_entry": true,
+    "test_functions": [
+      "test_settings_defaults",
+      "test_environment_overrides",
+      "test_uvicorn_and_frontend_options"
+    ]
+  },
+  {
+    "file_path": "rag-app/backend/app/tests/unit/test_retry.py",
+    "language": "python",
+    "imported_types": [],
+    "imports": [],
+    "declared_types": [
+      {
+        "name": "test_retry_policy_generates_backoff_sequence",
+        "type": "function",
+        "line": 1,
+        "docstring": "",
+        "modifiers": [],
+        "decorators": [],
+        "extends": [],
+        "args": [],
+        "returns": {
+          "type": "None",
+          "description": ""
+        },
+        "members": []
+      },
+      {
+        "name": "test_with_retries_eventually_succeeds",
+        "type": "function",
+        "line": 1,
+        "docstring": "",
+        "modifiers": [],
+        "decorators": [],
+        "extends": [],
+        "args": [
+          {
+            "name": "monkeypatch",
+            "type": "pytest.MonkeyPatch"
+          }
+        ],
+        "returns": {
+          "type": "None",
+          "description": ""
+        },
+        "members": []
+      },
+      {
+        "name": "test_with_retries_raises_after_exhaustion",
+        "type": "function",
+        "line": 1,
+        "docstring": "",
+        "modifiers": [],
+        "decorators": [],
+        "extends": [],
+        "args": [
+          {
+            "name": "monkeypatch",
+            "type": "pytest.MonkeyPatch"
+          }
+        ],
+        "returns": {
+          "type": "None",
+          "description": ""
+        },
+        "members": []
+      },
+      {
+        "name": "test_circuit_breaker_trips_and_resets",
+        "type": "function",
+        "line": 1,
+        "docstring": "",
+        "modifiers": [],
+        "decorators": [],
+        "extends": [],
+        "args": [
+          {
+            "name": "monkeypatch",
+            "type": "pytest.MonkeyPatch"
+          }
+        ],
+        "returns": {
+          "type": "None",
+          "description": ""
+        },
+        "members": []
+      }
+    ],
+    "spec_entry": true,
+    "test_functions": [
+      "test_retry_policy_generates_backoff_sequence",
+      "test_with_retries_eventually_succeeds",
+      "test_with_retries_raises_after_exhaustion",
+      "test_circuit_breaker_trips_and_resets"
+    ]
+  },
+  {
+    "file_path": "rag-app/backend/app/tests/unit/test_logging.py",
+    "language": "python",
+    "imported_types": [],
+    "imports": [],
+    "declared_types": [
+      {
+        "name": "test_get_logger_emits_json",
+        "type": "function",
+        "line": 1,
+        "docstring": "",
+        "modifiers": [],
+        "decorators": [],
+        "extends": [],
+        "args": [
+          {
+            "name": "capsys",
+            "type": "pytest.CaptureFixture[str]"
+          },
+          {
+            "name": "monkeypatch",
+            "type": "pytest.MonkeyPatch"
+          }
+        ],
+        "returns": {
+          "type": "None",
+          "description": ""
+        },
+        "members": []
+      }
+    ],
+    "spec_entry": true,
+    "test_functions": [
+      "test_get_logger_emits_json"
     ]
   }
 ]

--- a/rag-app/backend/app/util/logging.py
+++ b/rag-app/backend/app/util/logging.py
@@ -72,7 +72,7 @@ def _configure_root_logger(level: str) -> None:
     _LOGGER_INITIALIZED = True
 
 
-def get_logger(name: str | None = None) -> logging.Logger:
+def get_logger(name: str = None) -> logging.Logger:
     """Return configured JSON logger."""
     try:
         from ..config import get_settings  # Local import to avoid circular dependency.

--- a/rag-app/backend/app/util/retry.py
+++ b/rag-app/backend/app/util/retry.py
@@ -21,6 +21,21 @@ class RetryPolicy:
     jitter: bool = True
     _rng: random.Random = field(default_factory=random.Random, repr=False)
 
+    def __init__(
+        self,
+        retries: int = 3,
+        base_delay: float = 0.5,
+        max_delay: float = 8.0,
+        jitter: bool = True,
+    ) -> None:
+        """Initialize policy"""
+        self.retries = retries
+        self.base_delay = base_delay
+        self.max_delay = max_delay
+        self.jitter = jitter
+        self._rng = random.Random()
+        self.__post_init__()
+
     def __post_init__(self) -> None:
         if self.retries < 1:
             raise ValueError("retries must be >= 1")

--- a/rag-app/requirements.txt
+++ b/rag-app/requirements.txt
@@ -1,5 +1,5 @@
-fastapi==0.110.0
-uvicorn[standard]==0.27.1
+fastapi>=0.111,<1.0
+uvicorn[standard]>=0.22,<1.0
 pydantic==2.6.4
 pydantic-settings==2.2.1
 python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- implement the explicit `RetryPolicy.__init__` required by the stub catalog and tighten the logging utility signature
- align environment artifacts and stub metadata, including `.env.example` and coverage for unit tests
- update FastAPI/Uvicorn constraints to ensure the runtime dependencies are available for pytest collection

## Testing
- ruff check --fix rag-app
- BLACK_CACHE_DIR=/tmp/black-cache black rag-app
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d95740ac6c8324b3716839f1b82813