### PR TITLE
chore: phase 1 stub remediation adjustments

### DIFF
--- a/PHASE_1_NOTES.md
+++ b/PHASE_1_NOTES.md
@@ -13,7 +13,7 @@ cd rag-app
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
-cp rag-app/.env.example rag-app/.env
+cp .env.example .env
 python run.py  # backend on :8000, frontend on :3000
 ```
 
@@ -24,7 +24,7 @@ pytest -q
 ```
 
 ## Environment
-- Copy `rag-app/.env.example` to `rag-app/.env` to customize runtime settings without committing secrets.
+- Copy `.env.example` to `.env` within `rag-app` to customize runtime settings without committing secrets.
 - `FLUIDRAG_OFFLINE` defaults to `true` to disable outbound network calls; flip to `false` when integrations require external access.
 
 ## Offline Mode

--- a/app_finalstubs/finalstubs_latest.json
+++ b/app_finalstubs/finalstubs_latest.json
@@ -58,11 +58,51 @@
     "declared_types": []
   },
   {
+    "file_path": "rag-app/PHASE_1_NOTES.md",
+    "language": "markdown",
+    "imported_types": [],
+    "imports": [],
+    "declared_types": [],
+    "spec_entry": true
+  },
+  {
     "file_path": "rag-app/.gitignore",
     "language": "text",
     "imported_types": [],
     "imports": [],
     "declared_types": []
+  },
+  {
+    "file_path": "rag-app/.pre-commit-config.yaml",
+    "language": "yaml",
+    "imported_types": [],
+    "imports": [],
+    "declared_types": [],
+    "spec_entry": true
+  },
+  {
+    "file_path": "rag-app/pyproject.toml",
+    "language": "toml",
+    "imported_types": [],
+    "imports": [],
+    "declared_types": [],
+    "spec_entry": true
+  },
+  {
+    "file_path": "rag-app/requirements.txt",
+    "language": "text",
+    "imported_types": [],
+    "imports": [],
+    "declared_types": [],
+    "spec_entry": true
+  },
+  {
+    "file_path": "rag-app/scripts/check_file_lengths.py",
+    "language": "python",
+    "imported_types": [],
+    "imports": [],
+    "declared_types": [],
+    "spec_entry": true
   },
   {
     "file_path": "rag-app/data/.gitkeep",

--- a/rag-app/README.md
+++ b/rag-app/README.md
@@ -12,7 +12,7 @@ This repository currently contains the Phase 1 foundations for the FluidRAG proj
 python -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt
-cp rag-app/.env.example rag-app/.env
+cp .env.example .env
 pre-commit install
 python run.py  # launches FastAPI on :8000 and static frontend on :3000
 ```

--- a/rag-app/backend/app/main.py
+++ b/rag-app/backend/app/main.py
@@ -12,7 +12,7 @@ logger = get_logger(__name__)
 
 
 def create_app() -> FastAPI:
-    """Build and configure the FastAPI application."""
+    """App factory; registers routers and returns FastAPI instance."""
     settings = get_settings()
     app = FastAPI(title=settings.app_name)
 

--- a/rag-app/pyproject.toml
+++ b/rag-app/pyproject.toml
@@ -22,5 +22,5 @@ quote-style = "double"
 indent-style = "space"
 
 [tool.pytest.ini_options]
-testpaths = ["rag-app/backend/app/tests"]
+testpaths = ["backend/app/tests"]
 pythonpath = ["rag-app"]

--- a/rag-app/run.py
+++ b/rag-app/run.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import multiprocessing
+import os
 import signal
 import sys
 from functools import partial
@@ -19,10 +20,10 @@ from backend.app.util.logging import get_logger
 logger = get_logger(__name__)
 
 
-def start_backend(reload_override: bool | None = None) -> None:
+def start_backend() -> None:
     """Start FastAPI backend using uvicorn."""
     settings = get_settings()
-    reload = settings.backend_reload if reload_override is None else reload_override
+    reload = settings.backend_reload
     config = uvicorn.Config(
         "backend.app.main:create_app",
         host=settings.backend_host,
@@ -88,9 +89,11 @@ def _terminate_processes(processes: list[multiprocessing.Process]) -> None:
 def main() -> None:
     args = parse_args()
 
+    if args.reload:
+        os.environ["BACKEND_RELOAD"] = "true"
+
     backend_proc = multiprocessing.Process(
         target=start_backend,
-        kwargs={"reload_override": args.reload},
         name="backend",
     )
     frontend_proc = multiprocessing.Process(


### PR DESCRIPTION
## Summary
- align the CLI launcher with Phase 1 stubs by removing the reload argument and preserving behavior via environment overrides
- restore the FastAPI factory docstring and extend the stub catalog to cover additional tracked files
- fix pytest configuration paths and correct `.env` copy instructions in the docs

## Testing
- `ruff check rag-app`
- `black --check rag-app`
- `FLUIDRAG_OFFLINE=true pytest -q -o cache_dir=/tmp/pytest_cache`


------
https://chatgpt.com/codex/tasks/task_e_68d95d4fe10883248bde26f449d02b97