### PR TITLE
Add Phase 1 notes within rag-app

### DIFF
--- a/rag-app/PHASE_1_NOTES.md
+++ b/rag-app/PHASE_1_NOTES.md
@@ -1,0 +1,38 @@
+# Phase 1 Notes — FluidRAG Foundations
+
+## Summary
+- Implemented FastAPI app factory (`backend/app/main.py`) with health endpoint and startup/shutdown logging.
+- Added environment-driven `Settings` with cached accessor plus structured logging, audit helpers, retry utilities, and common errors.
+- Created `run.py` launcher to boot backend and static frontend concurrently via multiprocessing.
+- Delivered static frontend shell with health check button and gradient styling.
+- Established tooling: requirements, `pyproject.toml` with `black` + `ruff`, pre-commit hook enforcing 500-line policy, and baseline tests.
+
+## Running the Stack
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+cp .env.example .env
+python run.py  # backend on :8000, frontend on :3000
+```
+
+## Testing
+```bash
+pytest -q
+```
+
+## Environment
+- Copy `.env.example` to `.env` within `rag-app` to customize runtime settings without committing secrets.
+- `FLUIDRAG_OFFLINE` defaults to `true` to disable outbound network calls; flip to `false` when integrations require external access.
+
+## Offline Mode
+- Backend: `backend.app.config.Settings.offline` exposes the offline flag for service and client guards.
+- Frontend: `index.html` ships with a `fluidrag-offline` meta tag, and `main.js` bypasses the health check fetch (with an inline notice) while offline.
+
+## Tooling
+- `pre-commit install` to enable ruff, black, and file-length guard.
+- `ruff check .` / `black --check .` for standalone linting/formatting verification.
+
+## Known Limitations
+- Domain services, orchestrator routes, and MVVM frontend layers are deferred to later phases.
+- `run.py` currently expects local execution; production-grade process supervision will be added alongside deployment work.


### PR DESCRIPTION
## Summary
- add the missing `rag-app/PHASE_1_NOTES.md` file expected by the Phase 1 stubs
- include setup, testing, offline mode, and tooling guidance directly from the Phase 1 documentation

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d95f46bae4832489f0dda639b7d926