### PR TITLE
feat(phase-2): implement OpenRouter client integration per app_plan

### DIFF
--- a/PHASE_2_NOTES.md
+++ b/PHASE_2_NOTES.md
@@ -1,0 +1,28 @@
+# Phase 2 — OpenRouter Client Integration
+
+## Summary
+- Added OpenRouter utility modules (`backend/app/llm/utils.py`, `utils/envsafe.py`) for header masking, logging metadata, and Windows-friendly `curl` output.
+- Implemented the full OpenRouter client (`backend/app/llm/clients/openrouter.py`) with sync chat, async streaming, and embeddings plus jittered retries and idle timeout handling.
+- Created a thin wrapper in `backend/app/llm/openrouter.py` for downstream synchronous callers.
+- Expanded unit coverage with offline-safe tests for env helpers, retry logic, streaming, and embeddings.
+- Updated developer docs and `.env.example` with the new configuration knobs and smoke-test recipe.
+
+## Running Tests & Tooling
+```bash
+ruff --fix
+ruff check
+BLACK_CACHE_DIR=/tmp/black-cache black
+black --check
+FLUIDRAG_OFFLINE=true pytest -q
+```
+
+All tests mock outbound HTTP and respect the offline flag by default.
+
+## Configuration Checklist
+- Set `FLUIDRAG_OFFLINE=false` only when you intend to hit OpenRouter.
+- Populate `OPENROUTER_API_KEY`, `OPENROUTER_HTTP_REFERER`, and `OPENROUTER_APP_TITLE` in your local `.env` before running the smoke test or live requests.
+- Optional: override `OPENROUTER_BASE_URL` if targeting a mock server.
+
+## Known Limitations / Follow-ups
+- No live integration test is wired yet; future phases may add contract tests once the orchestrator routes exist.
+- Streaming output currently emits generic `delta` and `done` events; downstream consumers can enrich this schema once pipeline requirements are finalised.

--- a/PHASE_2_SCOPE.lock
+++ b/PHASE_2_SCOPE.lock
@@ -1,0 +1,18 @@
+Phase 2 Scope Selection (OpenRouter Client Integration)
+======================================================
+
+Files to create or modify:
+- PHASE_2_NOTES.md — implementation summary, runbook, and testing notes for Phase 2.
+- PHASE_2_SCOPE.lock — this scope declaration.
+- rag-app/.env.example — add OpenRouter-related environment variables and documentation.
+- rag-app/README.md — update setup instructions and smoke-test guidance for the OpenRouter client.
+- rag-app/backend/app/llm/__init__.py — expose client helpers for downstream imports.
+- rag-app/backend/app/llm/utils.py — helper utilities for logging and curl inspection.
+- rag-app/backend/app/llm/utils/envsafe.py — environment + masking utilities for headers.
+- rag-app/backend/app/llm/openrouter.py — thin sync wrapper raising typed errors.
+- rag-app/backend/app/llm/clients/__init__.py — package exports for the OpenRouter client.
+- rag-app/backend/app/llm/clients/openrouter.py — full client with retries, streaming, embeddings.
+- rag-app/backend/app/tests/unit/test_llm_envsafe.py — unit tests for env/header helpers.
+- rag-app/backend/app/tests/unit/test_openrouter_client.py — unit tests for retry/backoff, streaming, and offline guards.
+
+Rationale: This list covers the entire OpenRouter integration vertical slice defined for Phase 2, including utilities, client implementation, configuration, documentation, and regression tests, while leaving later pipeline services untouched.

--- a/rag-app/.env.example
+++ b/rag-app/.env.example
@@ -14,3 +14,10 @@ FRONTEND_PORT=3000
 LOG_LEVEL=info
 # Run without outbound network requests (true/false)
 FLUIDRAG_OFFLINE=true
+
+# OpenRouter configuration
+OPENROUTER_API_KEY=
+OPENROUTER_HTTP_REFERER=https://your-site.example
+OPENROUTER_APP_TITLE=FluidRAG Dev
+# Optional: override the default API endpoint
+# OPENROUTER_BASE_URL=https://openrouter.ai/api/v1

--- a/rag-app/README.md
+++ b/rag-app/README.md
@@ -1,10 +1,6 @@
-# FluidRAG — Phase 1 Foundations
+# FluidRAG — Phases 1 & 2 Foundations
 
-This repository currently contains the Phase 1 foundations for the FluidRAG project. The goal of this phase is to provide a reproducible development environment with:
-
-- A FastAPI backend that boots through `python run.py`.
-- A static frontend served from the same command for quick smoke tests.
-- Shared tooling (`black`, `ruff`, `pytest`, pre-commit) to keep the codebase healthy.
+Phase 1 established the project skeleton (tooling, boot scripts, static frontend). Phase 2 adds a production-ready OpenRouter client with retry logic, structured streaming, and embedding support while preserving the offline-first defaults.
 
 ## Getting Started
 
@@ -27,14 +23,47 @@ black --check .
 pytest -q
 ```
 
-All three commands are also wired into the `pre-commit` configuration along with a guard that fails when any source file exceeds 500 lines.
+All three commands are wired into the `pre-commit` configuration along with a guard that fails when any source file exceeds 500 lines.
 
 ## Configuration
 
 The application reads environment variables via `backend.app.config.Settings`. Copy `.env.example` to `.env` to override defaults for ports, reload mode, logging level, or the offline policy.
 
-- `FLUIDRAG_OFFLINE` (default: `true`) prevents any outbound network traffic when enabled. Set it to `false` in `.env` if you need to permit integrations that reach external services.
+Key variables for the OpenRouter integration:
+
+- `FLUIDRAG_OFFLINE` (default: `true`) prevents any outbound network traffic when enabled. Leave it `true` for local unit testing; flip to `false` only when you are ready to hit OpenRouter.
+- `OPENROUTER_API_KEY` — required bearer token for OpenRouter requests.
+- `OPENROUTER_HTTP_REFERER` — URL of the site/project registered with OpenRouter.
+- `OPENROUTER_APP_TITLE` — human-readable name sent in the `X-Title` header.
+- `OPENROUTER_BASE_URL` — optional override for the API endpoint (defaults to `https://openrouter.ai/api/v1`).
+
+## OpenRouter Client Smoke Test
+
+1. Ensure `FLUIDRAG_OFFLINE=false` in your local `.env` and populate the OpenRouter headers listed above.
+2. Run the quick chat smoke test (streams tokens to stdout):
+
+   ```bash
+   python - <<'PY'
+   import asyncio
+   from backend.app.llm.clients.openrouter import chat_stream_async
+
+   async def main() -> None:
+       async for chunk in chat_stream_async(
+           "openrouter/auto",
+           [{"role": "user", "content": "Say hello to FluidRAG"}],
+           temperature=0.2,
+           retries=1,
+       ):
+           if chunk["type"] == "delta":
+               content = chunk["data"].get("delta", {}).get("content")
+               if content:
+                   print(content, end="", flush=True)
+   asyncio.run(main())
+   PY
+   ```
+
+3. To test embeddings offline, run `pytest -q` which exercises the retry, masking, and idle timeout handling without real network calls.
 
 ## Next Steps
 
-Future phases will flesh out the service routes, adapters, and frontend MVVM components. The current foundation keeps that expansion ready by providing shared utilities, structured logging, and resilience helpers.
+Future phases will flesh out the service routes, adapters, and frontend MVVM components. With the OpenRouter client in place, downstream services can rely on deterministic retries, masked logging, and streaming primitives without duplicating integration logic.

--- a/rag-app/backend/app/llm/__init__.py
+++ b/rag-app/backend/app/llm/__init__.py
@@ -1,0 +1,36 @@
+"""OpenRouter client helpers."""
+
+from .clients.openrouter import (
+    OpenRouterAuthError as ClientAuthError,
+)
+from .clients.openrouter import (
+    OpenRouterError,
+    OpenRouterStreamError,
+    chat_stream_async,
+    chat_sync,
+    embed_sync,
+)
+from .clients.openrouter import (
+    OpenRouterHTTPError as ClientHTTPError,
+)
+from .openrouter import OpenRouterAuthError, OpenRouterHTTPError, chat
+from .utils import log_prompt, windows_curl
+from .utils.envsafe import mask_bearer, masked_headers, openrouter_headers
+
+__all__ = [
+    "chat",
+    "chat_sync",
+    "chat_stream_async",
+    "embed_sync",
+    "windows_curl",
+    "log_prompt",
+    "mask_bearer",
+    "openrouter_headers",
+    "masked_headers",
+    "OpenRouterError",
+    "OpenRouterAuthError",
+    "OpenRouterHTTPError",
+    "ClientAuthError",
+    "ClientHTTPError",
+    "OpenRouterStreamError",
+]

--- a/rag-app/backend/app/llm/clients/__init__.py
+++ b/rag-app/backend/app/llm/clients/__init__.py
@@ -1,0 +1,21 @@
+"""OpenRouter client implementations."""
+
+from .openrouter import (
+    OpenRouterAuthError,
+    OpenRouterError,
+    OpenRouterHTTPError,
+    OpenRouterStreamError,
+    chat_stream_async,
+    chat_sync,
+    embed_sync,
+)
+
+__all__ = [
+    "OpenRouterError",
+    "OpenRouterAuthError",
+    "OpenRouterHTTPError",
+    "OpenRouterStreamError",
+    "chat_sync",
+    "chat_stream_async",
+    "embed_sync",
+]

--- a/rag-app/backend/app/llm/clients/openrouter.py
+++ b/rag-app/backend/app/llm/clients/openrouter.py
@@ -1,0 +1,348 @@
+"""OpenRouter client supporting sync calls, streaming, and embeddings."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import random
+import time
+from collections.abc import AsyncGenerator, Iterable
+from typing import Any
+
+import httpx
+
+from ...config import get_settings
+from ...util.logging import get_logger
+from ..utils import log_prompt, windows_curl
+from ..utils.envsafe import masked_headers, openrouter_headers
+
+logger = get_logger(__name__)
+
+_RETRY_STATUS = {408, 409, 425, 429, 500, 502, 503, 504}
+
+
+class OpenRouterError(Exception):
+    """Base error."""
+
+
+class OpenRouterAuthError(OpenRouterError):
+    """401 error."""
+
+
+class OpenRouterHTTPError(OpenRouterError):
+    """HTTP status/transport error."""
+
+
+class OpenRouterStreamError(OpenRouterError):
+    """Streaming idle/format error."""
+
+
+def _base_url() -> str:
+    return os.getenv("OPENROUTER_BASE_URL", "https://openrouter.ai/api/v1").rstrip("/")
+
+
+def _ensure_online() -> None:
+    if get_settings().offline:
+        raise OpenRouterHTTPError(
+            "OpenRouter client disabled while FLUIDRAG_OFFLINE is true."
+        )
+
+
+def _compose_payload(
+    model: str,
+    messages: list[dict[str, str]],
+    temperature: float,
+    top_p: float | None,
+    max_tokens: int | None,
+    extra: dict[str, Any] | None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "temperature": temperature,
+    }
+    if top_p is not None:
+        payload["top_p"] = top_p
+    if max_tokens is not None:
+        payload["max_tokens"] = max_tokens
+    if extra:
+        payload.update(extra)
+    return payload
+
+
+def _parse_error(response: httpx.Response) -> str:
+    try:
+        data = response.json()
+        if isinstance(data, dict) and data.get("error"):
+            if isinstance(data["error"], dict):
+                return data["error"].get("message", str(data["error"]))
+            return str(data["error"])
+    except json.JSONDecodeError:
+        pass
+    return response.text
+
+
+def _should_retry(status_code: int) -> bool:
+    return status_code in _RETRY_STATUS or 500 <= status_code < 600
+
+
+def _decorate_headers(headers: dict[str, str]) -> dict[str, str]:
+    merged = {"Accept": "application/json"}
+    merged.update(headers)
+    return merged
+
+
+def _sleep(delay: float) -> None:
+    if delay > 0:
+        time.sleep(delay)
+
+
+async def _async_sleep(delay: float) -> None:
+    if delay > 0:
+        await asyncio.sleep(delay)
+
+
+def _backoff(
+    retries: int = 3, base: float = 0.5, max_delay: float = 8.0
+) -> Iterable[float]:
+    """Yield jittered backoff durations."""
+    yield 0.0
+    for attempt in range(1, retries + 1):
+        cap = min(max_delay, base * (2 ** (attempt - 1)))
+        jitter = random.random() * (cap / 2)
+        yield min(max_delay, cap + jitter)
+
+
+def _readable_body(body: Any) -> str:
+    if isinstance(body, bytes):
+        return body.decode("utf-8", errors="ignore")
+    return str(body)
+
+
+def chat_sync(
+    model: str,
+    messages: list[dict[str, str]],
+    temperature: float = 0.0,
+    top_p: float | None = None,
+    max_tokens: int | None = None,
+    extra: dict[str, Any] | None = None,
+    timeout: float = 60.0,
+    retries: int = 3,
+) -> dict[str, Any]:
+    """Sync chat with retries and masked logging."""
+    _ensure_online()
+    payload = _compose_payload(model, messages, temperature, top_p, max_tokens, extra)
+    try:
+        headers = _decorate_headers(openrouter_headers())
+    except RuntimeError as exc:
+        raise OpenRouterHTTPError(str(exc)) from exc
+    url = f"{_base_url()}/chat/completions"
+    last_error: Exception | None = None
+
+    for delay in _backoff(retries):
+        _sleep(delay)
+        try:
+            logger.info(
+                "openrouter.chat_sync", extra=log_prompt("chat_sync", payload, headers)
+            )
+            with httpx.Client(timeout=timeout) as client:
+                response = client.post(url, headers=headers, json=payload)
+            if response.status_code == 401:
+                raise OpenRouterAuthError(_parse_error(response))
+            if _should_retry(response.status_code):
+                last_error = OpenRouterHTTPError(
+                    f"Retryable status {response.status_code}: {_parse_error(response)}"
+                )
+                continue
+            if response.status_code >= 400:
+                raise OpenRouterHTTPError(
+                    f"OpenRouter error {response.status_code}: {_parse_error(response)}"
+                )
+            return response.json()
+        except OpenRouterAuthError:
+            raise
+        except httpx.HTTPError as exc:
+            last_error = OpenRouterHTTPError(f"HTTP error: {exc}")
+        except OpenRouterHTTPError as exc:
+            last_error = exc
+    if last_error:
+        logger.error(
+            "openrouter.chat_sync.failure",
+            extra={
+                "error": str(last_error),
+                "curl": windows_curl(url, masked_headers(headers), payload),
+            },
+        )
+        raise last_error
+    raise OpenRouterHTTPError("OpenRouter chat failed without explicit error.")
+
+
+async def _iterate_stream(
+    response: httpx.Response, idle_timeout: float
+) -> AsyncGenerator[dict[str, Any], None]:
+    last_event = time.monotonic()
+    event = "delta"
+    async for raw in response.aiter_lines():
+        if raw == "":
+            if time.monotonic() - last_event > idle_timeout:
+                raise OpenRouterStreamError(
+                    f"Stream stalled for {idle_timeout:.1f}s without data."
+                )
+            continue
+        if raw.startswith("event:"):
+            event = raw.split(":", 1)[1].strip() or "delta"
+            continue
+        if not raw.startswith("data:"):
+            continue
+        data = raw.split(":", 1)[1].strip()
+        if data == "[DONE]":
+            yield {"type": "done"}
+            return
+        try:
+            parsed = json.loads(data)
+        except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+            raise OpenRouterStreamError("Malformed SSE payload.") from exc
+        kind = "delta" if event in {"delta", "message"} else event
+        yield {"type": kind, "data": parsed}
+        last_event = time.monotonic()
+        event = "delta"
+    yield {"type": "done"}
+
+
+async def chat_stream_async(
+    model: str,
+    messages: list[dict[str, str]],
+    temperature: float = 0.0,
+    top_p: float | None = None,
+    max_tokens: int | None = None,
+    extra: dict[str, Any] | None = None,
+    timeout: float = 60.0,
+    retries: int = 3,
+    idle_timeout: float = 30.0,
+) -> AsyncGenerator[dict[str, Any], None]:
+    """Async SSE streaming, yields deltas/meta/done."""
+    _ensure_online()
+    payload = _compose_payload(model, messages, temperature, top_p, max_tokens, extra)
+    payload["stream"] = True
+    try:
+        headers = _decorate_headers(openrouter_headers())
+    except RuntimeError as exc:
+        raise OpenRouterHTTPError(str(exc)) from exc
+    url = f"{_base_url()}/chat/completions"
+    last_error: Exception | None = None
+
+    for delay in _backoff(retries):
+        await _async_sleep(delay)
+        try:
+            logger.info(
+                "openrouter.chat_stream.start",
+                extra=log_prompt("chat_stream", payload, headers),
+            )
+            async with httpx.AsyncClient(timeout=timeout) as client:
+                async with client.stream(
+                    "POST", url, headers=headers, json=payload
+                ) as response:
+                    if response.status_code == 401:
+                        raise OpenRouterAuthError(_parse_error(response))
+                    if _should_retry(response.status_code):
+                        body = await response.aread()
+                        last_error = OpenRouterHTTPError(
+                            f"Retryable status {response.status_code}: {_readable_body(body)}"
+                        )
+                        continue
+                    if response.status_code >= 400:
+                        body = await response.aread()
+                        raise OpenRouterHTTPError(
+                            f"OpenRouter error {response.status_code}: {_readable_body(body)}"
+                        )
+                    async for item in _iterate_stream(response, idle_timeout):
+                        yield item
+                    return
+        except OpenRouterAuthError:
+            raise
+        except OpenRouterStreamError as exc:
+            last_error = exc
+        except httpx.HTTPError as exc:
+            last_error = OpenRouterHTTPError(f"HTTP error: {exc}")
+        except OpenRouterHTTPError as exc:
+            last_error = exc
+    if last_error:
+        logger.error(
+            "openrouter.chat_stream.failure",
+            extra={"error": str(last_error), "headers": masked_headers(headers)},
+        )
+        raise last_error
+    raise OpenRouterHTTPError("OpenRouter streaming failed without explicit error.")
+
+
+def embed_sync(
+    model: str,
+    inputs: list[str],
+    timeout: float = 60.0,
+    retries: int = 3,
+) -> list[list[float]]:
+    """Sync embeddings with retries."""
+    _ensure_online()
+    try:
+        headers = _decorate_headers(openrouter_headers())
+    except RuntimeError as exc:
+        raise OpenRouterHTTPError(str(exc)) from exc
+    url = f"{_base_url()}/embeddings"
+    payload = {"model": model, "input": inputs}
+    last_error: Exception | None = None
+
+    for delay in _backoff(retries):
+        _sleep(delay)
+        try:
+            logger.info(
+                "openrouter.embed_sync", extra={"model": model, "count": len(inputs)}
+            )
+            with httpx.Client(timeout=timeout) as client:
+                response = client.post(url, headers=headers, json=payload)
+            if response.status_code == 401:
+                raise OpenRouterAuthError(_parse_error(response))
+            if _should_retry(response.status_code):
+                last_error = OpenRouterHTTPError(
+                    f"Retryable status {response.status_code}: {_parse_error(response)}"
+                )
+                continue
+            if response.status_code >= 400:
+                raise OpenRouterHTTPError(
+                    f"OpenRouter error {response.status_code}: {_parse_error(response)}"
+                )
+            data = response.json().get("data", [])
+            embeddings: list[list[float]] = []
+            for row in data:
+                embedding = row.get("embedding")
+                if isinstance(embedding, list):
+                    embeddings.append([float(val) for val in embedding])
+            return embeddings
+        except OpenRouterAuthError:
+            raise
+        except httpx.HTTPError as exc:
+            last_error = OpenRouterHTTPError(f"HTTP error: {exc}")
+        except OpenRouterHTTPError as exc:
+            last_error = exc
+    if last_error:
+        logger.error(
+            "openrouter.embed_sync.failure",
+            extra={
+                "error": str(last_error),
+                "curl": windows_curl(url, masked_headers(headers), payload),
+            },
+        )
+        raise last_error
+    raise OpenRouterHTTPError("OpenRouter embeddings failed without explicit error.")
+
+
+__all__ = [
+    "OpenRouterError",
+    "OpenRouterAuthError",
+    "OpenRouterHTTPError",
+    "OpenRouterStreamError",
+    "_backoff",
+    "chat_sync",
+    "chat_stream_async",
+    "embed_sync",
+]

--- a/rag-app/backend/app/llm/openrouter.py
+++ b/rag-app/backend/app/llm/openrouter.py
@@ -1,0 +1,52 @@
+"""Thin wrapper around OpenRouter client for synchronous usage."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .clients.openrouter import (
+    OpenRouterAuthError as ClientAuthError,
+)
+from .clients.openrouter import (
+    OpenRouterHTTPError as ClientHTTPError,
+)
+from .clients.openrouter import (
+    chat_sync,
+)
+
+
+class OpenRouterAuthError(Exception):
+    """Auth error (401)."""
+
+
+class OpenRouterHTTPError(Exception):
+    """HTTP/transport error."""
+
+
+def chat(
+    model: str,
+    messages: list[dict[str, str]],
+    temperature: float = 0.0,
+    top_p: float | None = None,
+    max_tokens: int | None = None,
+    extra: dict[str, Any] | None = None,
+    timeout: float = 60.0,
+) -> dict[str, Any]:
+    """Synchronous chat call to OpenRouter /chat/completions."""
+    try:
+        return chat_sync(
+            model=model,
+            messages=messages,
+            temperature=temperature,
+            top_p=top_p,
+            max_tokens=max_tokens,
+            extra=extra,
+            timeout=timeout,
+        )
+    except ClientAuthError as exc:  # pragma: no cover - pass-through mapping
+        raise OpenRouterAuthError(str(exc)) from exc
+    except ClientHTTPError as exc:
+        raise OpenRouterHTTPError(str(exc)) from exc
+
+
+__all__ = ["OpenRouterAuthError", "OpenRouterHTTPError", "chat"]

--- a/rag-app/backend/app/llm/utils.py
+++ b/rag-app/backend/app/llm/utils.py
@@ -1,0 +1,62 @@
+"""Utility helpers for OpenRouter interactions."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+__path__ = [str(Path(__file__).with_name("utils"))]
+if __spec__ is not None:  # pragma: no cover - package wiring
+    __spec__.submodule_search_locations = __path__
+    __package__ = __spec__.parent  # type: ignore[assignment]
+
+from .envsafe import masked_headers
+
+
+def windows_curl(url: str, headers: dict[str, str], payload: dict[str, Any]) -> str:
+    """Build a Windows-friendly ``curl`` command for debugging."""
+    escaped_headers = " ^\n  ".join(
+        f'-H "{_escape_quotes(key)}: {_escape_quotes(value)}"'
+        for key, value in headers.items()
+    )
+    body = _escape_quotes(json.dumps(payload, ensure_ascii=False))
+    parts = [f'curl -X POST "{_escape_quotes(url)}"']
+    if escaped_headers:
+        parts.append(escaped_headers)
+    parts.append(f'-d "{body}"')
+    return " ^\n  ".join(parts)
+
+
+def log_prompt(
+    prefix: str, payload: dict[str, Any], hdrs: dict[str, str]
+) -> dict[str, Any]:
+    """Return compact metadata describing a prompt for logging."""
+    messages = payload.get("messages", []) or []
+    last = messages[-1] if messages else {}
+    preview = last.get("content", "")
+    if preview and len(preview) > 120:
+        preview = f"{preview[:117]}..."
+    meta = {
+        "stage": prefix,
+        "model": payload.get("model"),
+        "temperature": payload.get("temperature"),
+        "messages": len(messages),
+        "headers": masked_headers(hdrs),
+    }
+    if preview:
+        meta["last"] = preview
+    if payload.get("max_tokens") is not None:
+        meta["max_tokens"] = payload["max_tokens"]
+    if payload.get("top_p") is not None:
+        meta["top_p"] = payload["top_p"]
+    if payload.get("extra"):
+        meta["has_extra"] = True
+    return meta
+
+
+def _escape_quotes(value: str) -> str:
+    return value.replace('"', '\\"')
+
+
+__all__ = ["windows_curl", "log_prompt"]

--- a/rag-app/backend/app/llm/utils/envsafe.py
+++ b/rag-app/backend/app/llm/utils/envsafe.py
@@ -1,0 +1,53 @@
+"""Environment helpers for OpenRouter integration."""
+
+from __future__ import annotations
+
+import os
+
+
+def mask_bearer(token: str | None) -> str:
+    """Mask a bearer token for log output."""
+    if not token:
+        return ""
+    raw = token.strip()
+    if len(raw) <= 8:
+        return "*" * len(raw)
+    return f"{raw[:4]}...{raw[-4:]}"
+
+
+def openrouter_headers() -> dict[str, str]:
+    """Build OpenRouter headers from environment variables."""
+    api_key = os.getenv("OPENROUTER_API_KEY", "").strip()
+    if not api_key:
+        raise RuntimeError("OPENROUTER_API_KEY is required for OpenRouter calls.")
+
+    referer = os.getenv("OPENROUTER_HTTP_REFERER", "").strip()
+    title = os.getenv("OPENROUTER_APP_TITLE", "FluidRAG").strip()
+
+    headers: dict[str, str] = {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {api_key}",
+    }
+    if referer:
+        headers["HTTP-Referer"] = referer
+    if title:
+        headers["X-Title"] = title
+    return headers
+
+
+def masked_headers(headers: dict[str, str]) -> dict[str, str]:
+    """Return a copy of ``headers`` with Authorization masked."""
+    sanitized = dict(headers)
+    auth_header = sanitized.get("Authorization")
+    if auth_header:
+        scheme, token = (auth_header.split(" ", 1) + [""])[:2]
+        masked = mask_bearer(token) if token else mask_bearer(auth_header)
+        if token:
+            sanitized["Authorization"] = f"{scheme} {masked}".strip()
+        else:
+            sanitized["Authorization"] = masked
+    return sanitized
+
+
+__all__ = ["mask_bearer", "openrouter_headers", "masked_headers"]

--- a/rag-app/backend/app/tests/unit/test_llm_envsafe.py
+++ b/rag-app/backend/app/tests/unit/test_llm_envsafe.py
@@ -1,0 +1,48 @@
+"""Tests for OpenRouter env helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from ...llm.utils.envsafe import mask_bearer, masked_headers, openrouter_headers
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_HTTP_REFERER", raising=False)
+    monkeypatch.delenv("OPENROUTER_APP_TITLE", raising=False)
+
+
+def test_mask_bearer_masks_middle() -> None:
+    assert mask_bearer("abcd1234efgh5678") == "abcd...5678"
+
+
+def test_mask_bearer_handles_short_values() -> None:
+    assert mask_bearer("abc") == "***"
+    assert mask_bearer(None) == ""
+
+
+def test_openrouter_headers_requires_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    with pytest.raises(RuntimeError):
+        openrouter_headers()
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENROUTER_HTTP_REFERER", "https://example.com")
+    monkeypatch.setenv("OPENROUTER_APP_TITLE", "FluidRAG Test")
+    headers = openrouter_headers()
+    assert headers["Authorization"] == "Bearer sk-test"
+    assert headers["HTTP-Referer"] == "https://example.com"
+    assert headers["X-Title"] == "FluidRAG Test"
+    assert headers["Content-Type"] == "application/json"
+    assert headers["Accept"] == "application/json"
+
+
+def test_masked_headers_masks_authorization(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OPENROUTER_API_KEY", "secret-key-9876")
+    headers = openrouter_headers()
+    masked = masked_headers(headers)
+    assert masked["Authorization"].startswith("Bearer ")
+    assert "..." in masked["Authorization"]
+    # ensure original dict not mutated
+    assert headers["Authorization"].endswith("9876")
+    assert headers["Authorization"] != masked["Authorization"]

--- a/rag-app/backend/app/tests/unit/test_openrouter_client.py
+++ b/rag-app/backend/app/tests/unit/test_openrouter_client.py
@@ -1,0 +1,227 @@
+"""Unit tests for the OpenRouter client helpers."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import pytest
+
+from ...config import get_settings
+from ...llm.clients import openrouter as client_module
+from ...llm.clients.openrouter import (
+    OpenRouterAuthError,
+    OpenRouterHTTPError,
+    OpenRouterStreamError,
+    chat_stream_async,
+    chat_sync,
+    embed_sync,
+)
+
+
+class DummyResponse:
+    def __init__(self, status_code: int, payload: dict[str, Any] | None = None) -> None:
+        self.status_code = status_code
+        self._payload = payload or {}
+        self.text = json.dumps(self._payload)
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+class MockClient:
+    queue: list[Any] = []
+
+    def __init__(
+        self, *args: Any, **kwargs: Any
+    ) -> None:  # pragma: no cover - init stub
+        pass
+
+    def __enter__(self) -> MockClient:  # pragma: no cover - context stub
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # pragma: no cover - context stub
+        return None
+
+    def post(
+        self, url: str, headers: dict[str, str], json: dict[str, Any]
+    ) -> DummyResponse:
+        if not self.queue:
+            raise AssertionError("MockClient queue exhausted")
+        response = self.queue.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+class DummyStreamResponse:
+    def __init__(
+        self, status_code: int, lines: list[Any], body: bytes | str = b""
+    ) -> None:
+        self.status_code = status_code
+        self._lines = lines
+        self._body = body if isinstance(body, bytes) else str(body).encode()
+
+    async def __aenter__(
+        self,
+    ) -> DummyStreamResponse:  # pragma: no cover - context stub
+        return self
+
+    async def __aexit__(
+        self, exc_type, exc, tb
+    ) -> None:  # pragma: no cover - context stub
+        return None
+
+    def aiter_lines(self):
+        async def _gen():
+            for item in self._lines:
+                if isinstance(item, float):
+                    await asyncio.sleep(item)
+                    yield ""
+                else:
+                    yield item
+
+        return _gen()
+
+    async def aread(self) -> bytes:
+        return self._body
+
+
+class MockAsyncClient:
+    queue: list[Any] = []
+
+    def __init__(
+        self, *args: Any, **kwargs: Any
+    ) -> None:  # pragma: no cover - init stub
+        pass
+
+    async def __aenter__(self) -> MockAsyncClient:  # pragma: no cover - context stub
+        return self
+
+    async def __aexit__(
+        self, exc_type, exc, tb
+    ) -> None:  # pragma: no cover - context stub
+        return None
+
+    def stream(
+        self, method: str, url: str, headers: dict[str, str], json: dict[str, Any]
+    ) -> DummyStreamResponse:
+        if not self.queue:
+            raise AssertionError("MockAsyncClient queue exhausted")
+        response = self.queue.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+@pytest.fixture(autouse=True)
+def _reset_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+    monkeypatch.delenv("FLUIDRAG_OFFLINE", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_HTTP_REFERER", raising=False)
+    monkeypatch.delenv("OPENROUTER_APP_TITLE", raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _patch_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(client_module, "_sleep", lambda delay: None)
+
+    async def _noop(delay: float) -> None:
+        return None
+
+    monkeypatch.setattr(client_module, "_async_sleep", _noop)
+
+
+@pytest.fixture()
+def online_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FLUIDRAG_OFFLINE", "false")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENROUTER_HTTP_REFERER", "https://example.com")
+    monkeypatch.setenv("OPENROUTER_APP_TITLE", "FluidRAG Tests")
+    get_settings.cache_clear()
+
+
+def test_chat_sync_offline_guard(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("FLUIDRAG_OFFLINE", "true")
+    get_settings.cache_clear()
+    with pytest.raises(OpenRouterHTTPError):
+        chat_sync("gpt", [{"role": "user", "content": "hi"}])
+
+
+def test_chat_sync_retries_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch, online_env
+) -> None:
+    monkeypatch.setattr(client_module.httpx, "Client", MockClient)
+    MockClient.queue = [
+        DummyResponse(429, {"error": {"message": "retry"}}),
+        DummyResponse(200, {"id": "ok", "choices": []}),
+    ]
+    result = chat_sync("gpt", [{"role": "user", "content": "hello"}], retries=1)
+    assert result["id"] == "ok"
+
+
+def test_chat_stream_async_yields_events(
+    monkeypatch: pytest.MonkeyPatch, online_env
+) -> None:
+    monkeypatch.setattr(client_module.httpx, "AsyncClient", MockAsyncClient)
+    MockAsyncClient.queue = [
+        DummyStreamResponse(
+            200,
+            [
+                'data: {"delta": {"content": "hi"}}',
+                "data: [DONE]",
+            ],
+        )
+    ]
+
+    async def _collect() -> list[dict[str, Any]]:
+        events: list[dict[str, Any]] = []
+        async for chunk in chat_stream_async(
+            "gpt", [{"role": "user", "content": "hi"}], retries=0
+        ):
+            events.append(chunk)
+        return events
+
+    events = asyncio.run(_collect())
+    assert events[0]["type"] == "delta"
+    assert events[0]["data"]["delta"]["content"] == "hi"
+    assert events[-1]["type"] == "done"
+
+
+def test_chat_stream_idle_timeout(monkeypatch: pytest.MonkeyPatch, online_env) -> None:
+    monkeypatch.setattr(client_module.httpx, "AsyncClient", MockAsyncClient)
+    MockAsyncClient.queue = [DummyStreamResponse(200, [0.05])]
+
+    async def _consume() -> None:
+        async for _ in chat_stream_async(
+            "gpt",
+            [{"role": "user", "content": "hi"}],
+            retries=0,
+            idle_timeout=0.01,
+        ):
+            pass
+
+    with pytest.raises(OpenRouterStreamError):
+        asyncio.run(_consume())
+
+
+def test_embed_sync_parses_vectors(monkeypatch: pytest.MonkeyPatch, online_env) -> None:
+    monkeypatch.setattr(client_module.httpx, "Client", MockClient)
+    MockClient.queue = [
+        DummyResponse(200, {"data": [{"embedding": [1, 2, 3]}]}),
+    ]
+    result = embed_sync("text-embed", ["a", "b"], retries=0)
+    assert result == [[1.0, 2.0, 3.0]]
+
+
+def test_chat_sync_propagates_auth_error(
+    monkeypatch: pytest.MonkeyPatch, online_env
+) -> None:
+    monkeypatch.setattr(client_module.httpx, "Client", MockClient)
+    MockClient.queue = [DummyResponse(401, {"error": {"message": "bad key"}})]
+    with pytest.raises(OpenRouterAuthError):
+        chat_sync("gpt", [{"role": "user", "content": "hi"}], retries=0)


### PR DESCRIPTION
## Summary
- add OpenRouter utilities and environment helpers to build masked headers, curl snippets, and logging metadata for downstream use
- implement the OpenRouter client with sync chat, async streaming, embeddings, and retry/backoff logic while exposing a thin wrapper
- update developer docs and env template plus add offline-safe unit tests for env helpers and client behaviour

## Testing
- ruff check .
- black --check .
- FLUIDRAG_OFFLINE=true pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68d97b61f5ac8324b90e2c6684744eaf