### PR TITLE
chore: align llm utils with stubs

### DIFF
--- a/rag-app/backend/app/llm/utils.py
+++ b/rag-app/backend/app/llm/utils.py
@@ -15,7 +15,7 @@ from .envsafe import masked_headers
 
 
 def windows_curl(url: str, headers: dict[str, str], payload: dict[str, Any]) -> str:
-    """Build a Windows-friendly ``curl`` command for debugging."""
+    """Build Windows-friendly curl command."""
     escaped_headers = " ^\n  ".join(
         f'-H "{_escape_quotes(key)}: {_escape_quotes(value)}"'
         for key, value in headers.items()
@@ -31,7 +31,7 @@ def windows_curl(url: str, headers: dict[str, str], payload: dict[str, Any]) -> 
 def log_prompt(
     prefix: str, payload: dict[str, Any], hdrs: dict[str, str]
 ) -> dict[str, Any]:
-    """Return compact metadata describing a prompt for logging."""
+    """Build compact request meta for logging."""
     messages = payload.get("messages", []) or []
     last = messages[-1] if messages else {}
     preview = last.get("content", "")

--- a/rag-app/backend/app/llm/utils/envsafe.py
+++ b/rag-app/backend/app/llm/utils/envsafe.py
@@ -6,7 +6,7 @@ import os
 
 
 def mask_bearer(token: str | None) -> str:
-    """Mask a bearer token for log output."""
+    """Mask bearer tokens for logs."""
     if not token:
         return ""
     raw = token.strip()
@@ -16,7 +16,7 @@ def mask_bearer(token: str | None) -> str:
 
 
 def openrouter_headers() -> dict[str, str]:
-    """Build OpenRouter headers from environment variables."""
+    """Build OpenRouter headers from env."""
     api_key = os.getenv("OPENROUTER_API_KEY", "").strip()
     if not api_key:
         raise RuntimeError("OPENROUTER_API_KEY is required for OpenRouter calls.")
@@ -37,7 +37,7 @@ def openrouter_headers() -> dict[str, str]:
 
 
 def masked_headers(headers: dict[str, str]) -> dict[str, str]:
-    """Return a copy of ``headers`` with Authorization masked."""
+    """Return a copy with Authorization masked."""
     sanitized = dict(headers)
     auth_header = sanitized.get("Authorization")
     if auth_header:

--- a/rag-app/pyproject.toml
+++ b/rag-app/pyproject.toml
@@ -13,9 +13,11 @@ target-version = ["py310"]
 
 [tool.ruff]
 line-length = 88
+exclude = ["rag-app/frontend", "rag-app/data"]
+
+[tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "C4", "RET"]
 ignore = ["E203", "E266", "E501"]
-exclude = ["rag-app/frontend", "rag-app/data"]
 
 [tool.ruff.format]
 quote-style = "double"


### PR DESCRIPTION
## Summary
- align LLM utility docstrings with the final stubs so Phase 2 contracts stay in sync
- move Ruff lint configuration into the new `[tool.ruff.lint]` table to remove CLI warnings

## Testing
- ruff check rag-app
- black --check rag-app
- FLUIDRAG_OFFLINE=true pytest -q -o cache_dir=/tmp/pytest_cache

------
https://chatgpt.com/codex/tasks/task_e_68d981409d2483248edcb50983f2967f