### PR TITLE
feat: sync phase-2 stub catalog with OpenRouter slice

### DIFF
--- a/PHASE_2_SCOPE.lock
+++ b/PHASE_2_SCOPE.lock
@@ -1,18 +1,20 @@
-Phase 2 Scope Selection (OpenRouter Client Integration)
-======================================================
+Phase 2 Scope Selection — OpenRouter Vertical Slice
+===================================================
 
-Files to create or modify:
-- PHASE_2_NOTES.md — implementation summary, runbook, and testing notes for Phase 2.
-- PHASE_2_SCOPE.lock — this scope declaration.
-- rag-app/.env.example — add OpenRouter-related environment variables and documentation.
-- rag-app/README.md — update setup instructions and smoke-test guidance for the OpenRouter client.
+Files confirmed in-scope for implementation + verification:
+- PHASE_2_NOTES.md — runbook + testing recap.
+- PHASE_2_SCOPE.lock — scope declaration (this file).
+- app_finalstubs/finalstubs_latest.json — sync spec entries with the realized modules/tests.
+- rag-app/.env.example — document OpenRouter env variables.
+- rag-app/README.md — update setup + smoke test guidance.
 - rag-app/backend/app/llm/__init__.py — expose client helpers for downstream imports.
-- rag-app/backend/app/llm/utils.py — helper utilities for logging and curl inspection.
-- rag-app/backend/app/llm/utils/envsafe.py — environment + masking utilities for headers.
+- rag-app/backend/app/llm/utils.py — logging metadata + curl helpers.
+- rag-app/backend/app/llm/utils/envsafe.py — env/header masking utilities.
 - rag-app/backend/app/llm/openrouter.py — thin sync wrapper raising typed errors.
 - rag-app/backend/app/llm/clients/__init__.py — package exports for the OpenRouter client.
-- rag-app/backend/app/llm/clients/openrouter.py — full client with retries, streaming, embeddings.
-- rag-app/backend/app/tests/unit/test_llm_envsafe.py — unit tests for env/header helpers.
-- rag-app/backend/app/tests/unit/test_openrouter_client.py — unit tests for retry/backoff, streaming, and offline guards.
+- rag-app/backend/app/llm/clients/openrouter.py — sync client with retries, streaming, embeddings.
+- rag-app/backend/app/tests/unit/test_llm_envsafe.py — env/header helper coverage.
+- rag-app/backend/app/tests/unit/test_openrouter_client.py — retry/backoff, streaming, offline guards.
 
-Rationale: This list covers the entire OpenRouter integration vertical slice defined for Phase 2, including utilities, client implementation, configuration, documentation, and regression tests, while leaving later pipeline services untouched.
+Rationale: This set covers the full OpenRouter integration vertical slice described in Phase 2, including configuration, docs, 
+client implementation, exports, and deterministic tests, while keeping upstream/downstream services untouched.

--- a/app_finalstubs/finalstubs_latest.json
+++ b/app_finalstubs/finalstubs_latest.json
@@ -4625,5 +4625,393 @@
     "test_functions": [
       "test_get_logger_emits_json"
     ]
+  },
+  {
+    "file_path": "PHASE_2_NOTES.md",
+    "language": "markdown",
+    "imported_types": [],
+    "imports": [],
+    "declared_types": [],
+    "spec_entry": true
+  },
+  {
+    "file_path": "rag-app/backend/app/llm/__init__.py",
+    "language": "python",
+    "imported_types": [],
+    "imports": [],
+    "declared_types": []
+  },
+  {
+    "file_path": "rag-app/backend/app/llm/clients/__init__.py",
+    "language": "python",
+    "imported_types": [],
+    "imports": [],
+    "declared_types": []
+  },
+  {
+    "file_path": "rag-app/backend/app/tests/unit/test_llm_envsafe.py",
+    "language": "python",
+    "imported_types": [],
+    "imports": [],
+    "declared_types": [
+      {
+        "name": "_clear_env",
+        "type": "function",
+        "line": 1,
+        "docstring": "",
+        "modifiers": [],
+        "decorators": [],
+        "extends": [],
+        "args": [
+          {
+            "name": "monkeypatch",
+            "type": "pytest.MonkeyPatch"
+          }
+        ],
+        "returns": {
+          "type": "None",
+          "description": ""
+        },
+        "members": []
+      },
+      {
+        "name": "test_mask_bearer_masks_middle",
+        "type": "function",
+        "line": 1,
+        "docstring": "",
+        "modifiers": [],
+        "decorators": [],
+        "extends": [],
+        "args": [],
+        "returns": {
+          "type": "None",
+          "description": ""
+        },
+        "members": []
+      },
+      {
+        "name": "test_mask_bearer_handles_short_values",
+        "type": "function",
+        "line": 1,
+        "docstring": "",
+        "modifiers": [],
+        "decorators": [],
+        "extends": [],
+        "args": [],
+        "returns": {
+          "type": "None",
+          "description": ""
+        },
+        "members": []
+      },
+      {
+        "name": "test_openrouter_headers_requires_key",
+        "type": "function",
+        "line": 1,
+        "docstring": "",
+        "modifiers": [],
+        "decorators": [],
+        "extends": [],
+        "args": [
+          {
+            "name": "monkeypatch",
+            "type": "pytest.MonkeyPatch"
+          }
+        ],
+        "returns": {
+          "type": "None",
+          "description": ""
+        },
+        "members": []
+      },
+      {
+        "name": "test_masked_headers_masks_authorization",
+        "type": "function",
+        "line": 1,
+        "docstring": "",
+        "modifiers": [],
+        "decorators": [],
+        "extends": [],
+        "args": [
+          {
+            "name": "monkeypatch",
+            "type": "pytest.MonkeyPatch"
+          }
+        ],
+        "returns": {
+          "type": "None",
+          "description": ""
+        },
+        "members": []
+      }
+    ],
+    "spec_entry": true,
+    "test_functions": [
+      "test_mask_bearer_masks_middle",
+      "test_mask_bearer_handles_short_values",
+      "test_openrouter_headers_requires_key",
+      "test_masked_headers_masks_authorization"
+    ]
+  },
+  {
+    "file_path": "rag-app/backend/app/tests/unit/test_openrouter_client.py",
+    "language": "python",
+    "imported_types": [],
+    "imports": [],
+    "declared_types": [
+      {
+        "name": "DummyResponse",
+        "type": "class",
+        "line": 1,
+        "docstring": "",
+        "modifiers": [],
+        "decorators": [],
+        "extends": [],
+        "args": [],
+        "members": []
+      },
+      {
+        "name": "MockClient",
+        "type": "class",
+        "line": 1,
+        "docstring": "",
+        "modifiers": [],
+        "decorators": [],
+        "extends": [],
+        "args": [],
+        "members": []
+      },
+      {
+        "name": "DummyStreamResponse",
+        "type": "class",
+        "line": 1,
+        "docstring": "",
+        "modifiers": [],
+        "decorators": [],
+        "extends": [],
+        "args": [],
+        "members": []
+      },
+      {
+        "name": "MockAsyncClient",
+        "type": "class",
+        "line": 1,
+        "docstring": "",
+        "modifiers": [],
+        "decorators": [],
+        "extends": [],
+        "args": [],
+        "members": []
+      },
+      {
+        "name": "_reset_settings",
+        "type": "function",
+        "line": 1,
+        "docstring": "",
+        "modifiers": [],
+        "decorators": [],
+        "extends": [],
+        "args": [
+          {
+            "name": "monkeypatch",
+            "type": "pytest.MonkeyPatch"
+          }
+        ],
+        "returns": {
+          "type": "None",
+          "description": ""
+        },
+        "members": []
+      },
+      {
+        "name": "_patch_sleep",
+        "type": "function",
+        "line": 1,
+        "docstring": "",
+        "modifiers": [],
+        "decorators": [],
+        "extends": [],
+        "args": [
+          {
+            "name": "monkeypatch",
+            "type": "pytest.MonkeyPatch"
+          }
+        ],
+        "returns": {
+          "type": "None",
+          "description": ""
+        },
+        "members": []
+      },
+      {
+        "name": "online_env",
+        "type": "function",
+        "line": 1,
+        "docstring": "",
+        "modifiers": [],
+        "decorators": [],
+        "extends": [],
+        "args": [
+          {
+            "name": "monkeypatch",
+            "type": "pytest.MonkeyPatch"
+          }
+        ],
+        "returns": {
+          "type": "None",
+          "description": ""
+        },
+        "members": []
+      },
+      {
+        "name": "test_chat_sync_offline_guard",
+        "type": "function",
+        "line": 1,
+        "docstring": "",
+        "modifiers": [],
+        "decorators": [],
+        "extends": [],
+        "args": [
+          {
+            "name": "monkeypatch",
+            "type": "pytest.MonkeyPatch"
+          }
+        ],
+        "returns": {
+          "type": "None",
+          "description": ""
+        },
+        "members": []
+      },
+      {
+        "name": "test_chat_sync_retries_then_succeeds",
+        "type": "function",
+        "line": 1,
+        "docstring": "",
+        "modifiers": [],
+        "decorators": [],
+        "extends": [],
+        "args": [
+          {
+            "name": "monkeypatch",
+            "type": "pytest.MonkeyPatch"
+          },
+          {
+            "name": "online_env",
+            "type": "Any"
+          }
+        ],
+        "returns": {
+          "type": "None",
+          "description": ""
+        },
+        "members": []
+      },
+      {
+        "name": "test_chat_stream_async_yields_events",
+        "type": "function",
+        "line": 1,
+        "docstring": "",
+        "modifiers": [],
+        "decorators": [],
+        "extends": [],
+        "args": [
+          {
+            "name": "monkeypatch",
+            "type": "pytest.MonkeyPatch"
+          },
+          {
+            "name": "online_env",
+            "type": "Any"
+          }
+        ],
+        "returns": {
+          "type": "None",
+          "description": ""
+        },
+        "members": []
+      },
+      {
+        "name": "test_chat_stream_idle_timeout",
+        "type": "function",
+        "line": 1,
+        "docstring": "",
+        "modifiers": [],
+        "decorators": [],
+        "extends": [],
+        "args": [
+          {
+            "name": "monkeypatch",
+            "type": "pytest.MonkeyPatch"
+          },
+          {
+            "name": "online_env",
+            "type": "Any"
+          }
+        ],
+        "returns": {
+          "type": "None",
+          "description": ""
+        },
+        "members": []
+      },
+      {
+        "name": "test_embed_sync_parses_vectors",
+        "type": "function",
+        "line": 1,
+        "docstring": "",
+        "modifiers": [],
+        "decorators": [],
+        "extends": [],
+        "args": [
+          {
+            "name": "monkeypatch",
+            "type": "pytest.MonkeyPatch"
+          },
+          {
+            "name": "online_env",
+            "type": "Any"
+          }
+        ],
+        "returns": {
+          "type": "None",
+          "description": ""
+        },
+        "members": []
+      },
+      {
+        "name": "test_chat_sync_propagates_auth_error",
+        "type": "function",
+        "line": 1,
+        "docstring": "",
+        "modifiers": [],
+        "decorators": [],
+        "extends": [],
+        "args": [
+          {
+            "name": "monkeypatch",
+            "type": "pytest.MonkeyPatch"
+          },
+          {
+            "name": "online_env",
+            "type": "Any"
+          }
+        ],
+        "returns": {
+          "type": "None",
+          "description": ""
+        },
+        "members": []
+      }
+    ],
+    "spec_entry": true,
+    "test_functions": [
+      "test_chat_sync_offline_guard",
+      "test_chat_sync_retries_then_succeeds",
+      "test_chat_stream_async_yields_events",
+      "test_chat_stream_idle_timeout",
+      "test_embed_sync_parses_vectors",
+      "test_chat_sync_propagates_auth_error"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- refresh `PHASE_2_SCOPE.lock` to document the full OpenRouter vertical slice owned by Phase 2
- add Phase-2 notes, package exports, and unit-test specs to `app_finalstubs/finalstubs_latest.json`

## Testing
- ruff check --fix
- ruff check
- BLACK_CACHE_DIR=/tmp/black-cache black .
- black --check .
- FLUIDRAG_OFFLINE=true pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d982889bc0832495dd9aacb5b4b03f