### PR TITLE
Align Phase 3 docstrings with catalog spec

### DIFF
--- a/rag-app/backend/app/services/upload_service/main.py
+++ b/rag-app/backend/app/services/upload_service/main.py
@@ -22,7 +22,7 @@ class NormalizedDoc(BaseModel):
 def ensure_normalized(
     file_id: str | None = None, file_name: str | None = None
 ) -> NormalizedDoc:
-    """Validate/normalize upload and emit normalize.json."""
+    """Validate/normalize upload and emit normalize.json"""
     internal: NormalizedDocInternal = controller_ensure_normalized(
         file_id=file_id, file_name=file_name
     )

--- a/rag-app/backend/app/util/retry.py
+++ b/rag-app/backend/app/util/retry.py
@@ -112,7 +112,7 @@ def with_retries(
     *args: Any,
     **kwargs: Any,
 ) -> Any:
-    """Execute with retries/backoff and optional circuit breaker."""
+    """Execute with retries/backoff and optional circuit breaker"""
     if policy is None:
         policy = RetryPolicy()
     attempts = 0


### PR DESCRIPTION
## Summary
- update Phase 3 upload and retry docstrings to match catalog wording
- keep implementation unchanged while honoring spec punctuation requirements

## Testing
- FLUIDRAG_OFFLINE=true pytest -q -o cache_dir=/tmp/pytest_cache


------
https://chatgpt.com/codex/tasks/task_e_68d989efd9288324a85fb09a2a0ed2d0