### PR TITLE
feat: add chunk service and hybrid retrieval utilities

### DIFF
--- a/PHASE_4_NOTES.md
+++ b/PHASE_4_NOTES.md
@@ -1,0 +1,30 @@
+# Phase 4 Notes — Chunk Service & Vector Indexes
+
+## Overview
+- Added chunk service package with sentence segmentation, typography features, UF chunk heuristics, and offline-friendly sparse+dense index builders.
+- Introduced `/chunk/uf` FastAPI route returning persisted `uf_chunks.jsonl` artifacts and optional index manifest.
+- Implemented vector adapter abstractions (BM25, Faiss-style cosine store, Qdrant stub) plus hybrid retrieval helper for future passes.
+- Extended settings/ENV to control `CHUNK_TARGET_TOKENS` and `CHUNK_TOKEN_OVERLAP`, updated docs and configuration samples accordingly.
+
+## Running the Chunk Pipeline
+1. Normalize and parse content as in earlier phases.
+2. Invoke the chunk endpoint:
+   ```bash
+   curl -s -X POST http://127.0.0.1:8000/chunk/uf \
+     -H 'Content-Type: application/json' \
+     -d '{"doc_id": "<doc_id>", "normalize_artifact": "<parse_enriched_path>"}'
+   ```
+3. Inspect `${ARTIFACT_ROOT}/<doc_id>/uf_chunks.jsonl`, `index.manifest.json`, and `chunk.audit.json` for persisted artifacts.
+
+## Configuration
+- `CHUNK_TARGET_TOKENS` (default 90) — approximate token budget per UF chunk.
+- `CHUNK_TOKEN_OVERLAP` (default 12) — token overlap between adjacent chunks.
+
+## Tests & Quality Gates
+- Unit tests cover chunk controller + retrieval utilities: `pytest -q rag-app/backend/app/tests/unit/test_chunk.py`
+- Full offline suite: `FLUIDRAG_OFFLINE=true pytest -q -o cache_dir=/tmp/pytest_cache`
+- Lint & format: `ruff check rag-app`, `black --check rag-app`
+
+## Notes
+- Dense index builder uses deterministic hashing to remain offline-friendly while providing cosine similarity search.
+- Qdrant adapter stores vectors in-memory and logs when running offline; ready for future remote integration once allowed.

--- a/PHASE_4_SCOPE.lock
+++ b/PHASE_4_SCOPE.lock
@@ -1,0 +1,29 @@
+Phase 4 Scope Selection — Chunk Service & Vector Indexes
+=======================================================
+Scope rationale: implement the UF chunking pipeline, typography features, sparse+dense vector adapters, FastAPI route, settings, documentation, and unit tests required by the Phase 4 plan while preserving prior phase contracts and offline defaults.
+
+Files to add or modify:
+- PHASE_4_SCOPE.lock
+- PHASE_4_NOTES.md
+- rag-app/backend/app/config.py
+- rag-app/.env.example
+- rag-app/README.md
+- rag-app/backend/app/main.py
+- rag-app/backend/app/routes/__init__.py
+- rag-app/backend/app/routes/chunk.py
+- rag-app/backend/app/services/__init__.py
+- rag-app/backend/app/services/chunk_service/__init__.py
+- rag-app/backend/app/services/chunk_service/main.py
+- rag-app/backend/app/services/chunk_service/chunk_controller.py
+- rag-app/backend/app/services/chunk_service/packages/__init__.py
+- rag-app/backend/app/services/chunk_service/packages/segment/__init__.py
+- rag-app/backend/app/services/chunk_service/packages/segment/sentences.py
+- rag-app/backend/app/services/chunk_service/packages/features/__init__.py
+- rag-app/backend/app/services/chunk_service/packages/features/typography.py
+- rag-app/backend/app/services/chunk_service/packages/index/__init__.py
+- rag-app/backend/app/services/chunk_service/packages/index/local_vss.py
+- rag-app/backend/app/adapters/__init__.py
+- rag-app/backend/app/adapters/vectors.py
+- rag-app/backend/app/contracts/__init__.py
+- rag-app/backend/app/contracts/chunking.py
+- rag-app/backend/app/tests/unit/test_chunk.py

--- a/rag-app/.env.example
+++ b/rag-app/.env.example
@@ -19,6 +19,10 @@ ARTIFACT_ROOT=rag-app/data/artifacts
 UPLOAD_OCR_THRESHOLD=0.85
 # Timeout in seconds for parser fan-out tasks
 PARSER_TIMEOUT_SECONDS=1.0
+# Target average token count per UF chunk
+CHUNK_TARGET_TOKENS=90
+# Token overlap between consecutive UF chunks
+CHUNK_TOKEN_OVERLAP=12
 
 # OpenRouter configuration
 OPENROUTER_API_KEY=

--- a/rag-app/README.md
+++ b/rag-app/README.md
@@ -33,6 +33,18 @@ curl -s -X POST http://127.0.0.1:8000/parser/enrich \
 
 This triggers the asyncio fan-out (text/tables/images/links/language) and fan-in merge, producing `parse.enriched.json` under the artifact root.
 
+## Chunk Service & Vector Indexes
+
+After running the parser, invoke the chunk service to generate UF chunks and build local indexes:
+
+```bash
+curl -s -X POST http://127.0.0.1:8000/chunk/uf \
+  -H 'Content-Type: application/json' \
+  -d '{"doc_id": "<doc_id>", "normalize_artifact": "<parse_enriched_path>"}'
+```
+
+The response echoes the chunk artifact path (`uf_chunks.jsonl`) and, if enabled, the index manifest. The chunk controller writes a `chunk.audit.json` record alongside the JSONL file and persists sparse+dense index metadata when offline-safe hashing is enabled by default.
+
 ## Benchmark Harness
 
 To measure offline performance end-to-end:
@@ -62,6 +74,8 @@ Key variables for the ingestion pipeline:
 - `ARTIFACT_ROOT` — directory where `normalize.json` and `parse.enriched.json` are written (defaults to `rag-app/data/artifacts`).
 - `UPLOAD_OCR_THRESHOLD` — minimum average coverage (0–1) before the upload controller triggers OCR fallback.
 - `PARSER_TIMEOUT_SECONDS` — timeout applied to each parser fan-out task.
+- `CHUNK_TARGET_TOKENS` — target token count for each UF chunk (defaults to 90).
+- `CHUNK_TOKEN_OVERLAP` — token overlap budget between adjacent chunks (defaults to 12).
 
 Key variables for the OpenRouter integration:
 

--- a/rag-app/backend/app/adapters/__init__.py
+++ b/rag-app/backend/app/adapters/__init__.py
@@ -1,0 +1,17 @@
+"""Adapters for vector and embedding integrations."""
+
+from .vectors import (
+    BM25Index,
+    EmbeddingModel,
+    FaissIndex,
+    QdrantIndex,
+    hybrid_search,
+)
+
+__all__ = [
+    "EmbeddingModel",
+    "BM25Index",
+    "FaissIndex",
+    "QdrantIndex",
+    "hybrid_search",
+]

--- a/rag-app/backend/app/adapters/vectors.py
+++ b/rag-app/backend/app/adapters/vectors.py
@@ -1,0 +1,236 @@
+"""Vector adapters and lightweight retrieval utilities."""
+
+from __future__ import annotations
+
+import json
+import math
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+from ..config import get_settings
+from ..util.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def _tokenize(text: str) -> list[str]:
+    """Lowercase whitespace tokenizer used for sparse retrieval."""
+    return [token for token in text.lower().split() if token]
+
+
+class EmbeddingModel(ABC):
+    """Abstraction for embedding backends."""
+
+    @abstractmethod
+    def embed_texts(self, texts: list[str]) -> list[list[float]]:
+        """Batch embed texts."""
+
+    @property
+    @abstractmethod
+    def dimension(self) -> int:
+        """Return embedding dimensionality."""
+
+
+class BM25Index:
+    """Sparse BM25 index over chunks."""
+
+    def __init__(self) -> None:
+        """Init BM25 index."""
+        self._doc_freqs: dict[str, int] = {}
+        self._documents: list[list[str]] = []
+        self._doc_lengths: list[int] = []
+        self._avgdl: float = 0.0
+        self._k1 = 1.5
+        self._b = 0.75
+
+    def add(self, docs: list[str]) -> None:
+        """Add docs."""
+        for doc in docs:
+            tokens = _tokenize(doc)
+            self._documents.append(tokens)
+            self._doc_lengths.append(len(tokens))
+            for token in set(tokens):
+                self._doc_freqs[token] = self._doc_freqs.get(token, 0) + 1
+        total_len = sum(self._doc_lengths) or 1
+        self._avgdl = total_len / max(len(self._documents), 1)
+        logger.debug(
+            "bm25.add", extra={"docs": len(docs), "total_docs": len(self._documents)}
+        )
+
+    def _idf(self, term: str) -> float:
+        df = self._doc_freqs.get(term, 0)
+        if df == 0:
+            return 0.0
+        n = len(self._documents)
+        return math.log(1 + (n - df + 0.5) / (df + 0.5))
+
+    def search(self, query: str, k: int = 20) -> list[tuple[int, float]]:
+        """Search top-k."""
+        if not self._documents:
+            return []
+        query_tokens = _tokenize(query)
+        scores: list[tuple[int, float]] = []
+        for idx, doc_tokens in enumerate(self._documents):
+            score = 0.0
+            freq: dict[str, int] = {}
+            for token in doc_tokens:
+                freq[token] = freq.get(token, 0) + 1
+            for token in query_tokens:
+                if token not in freq:
+                    continue
+                tf = freq[token]
+                numerator = tf * (self._k1 + 1)
+                denominator = tf + self._k1 * (
+                    1
+                    - self._b
+                    + self._b * (self._doc_lengths[idx] / (self._avgdl or 1))
+                )
+                score += self._idf(token) * (numerator / (denominator or 1))
+            scores.append((idx, score))
+        scores.sort(key=lambda item: item[1], reverse=True)
+        return scores[:k]
+
+
+class FaissIndex:
+    """Local FAISS dense vector index."""
+
+    def __init__(self, dim: int, index_path: str | None = None) -> None:
+        """Create or load index."""
+        self._dim = dim
+        self._vectors: list[list[float]] = []
+        self._path = Path(index_path) if index_path else None
+        if self._path and self._path.exists():
+            try:
+                payload = json.loads(self._path.read_text(encoding="utf-8"))
+                self._vectors = [
+                    [float(value) for value in vector]
+                    for vector in payload.get("vectors", [])
+                ]
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("faiss.load_failed", extra={"error": str(exc)})
+                self._vectors = []
+
+    def _validate(self, vector: Sequence[float]) -> None:
+        if len(vector) != self._dim:
+            raise ValueError(f"vector dimensionality {len(vector)} != {self._dim}")
+
+    def add(self, vectors: list[list[float]]) -> None:
+        """Add vectors."""
+        for vector in vectors:
+            self._validate(vector)
+            self._vectors.append([float(v) for v in vector])
+        logger.debug(
+            "faiss.add", extra={"count": len(vectors), "total": len(self._vectors)}
+        )
+
+    def _cosine(self, a: Sequence[float], b: Sequence[float]) -> float:
+        dot = sum(x * y for x, y in zip(a, b, strict=False))
+        norm_a = math.sqrt(sum(x * x for x in a)) or 1.0
+        norm_b = math.sqrt(sum(y * y for y in b)) or 1.0
+        return dot / (norm_a * norm_b)
+
+    def search(self, query_vec: list[float], k: int = 20) -> list[tuple[int, float]]:
+        """Search top-k."""
+        self._validate(query_vec)
+        scored = [
+            (idx, self._cosine(query_vec, vector))
+            for idx, vector in enumerate(self._vectors)
+        ]
+        scored.sort(key=lambda item: item[1], reverse=True)
+        return scored[:k]
+
+    def save(self) -> None:
+        """Persist index."""
+        if not self._path:
+            return
+        data = {"vectors": self._vectors, "dim": self._dim}
+        self._path.write_text(json.dumps(data), encoding="utf-8")
+
+
+class QdrantIndex:
+    """Qdrant remote dense vector index."""
+
+    def __init__(self, collection: str) -> None:
+        """Init client/collection."""
+        self._collection = collection
+        self._vectors: list[list[float]] = []
+        self._payloads: list[dict[str, Any]] = []
+        if get_settings().offline is False:
+            logger.warning(
+                "qdrant.offline_stub",
+                extra={"collection": collection, "mode": "offline"},
+            )
+
+    def add(self, vectors: list[list[float]], payloads: list[dict] | None) -> None:
+        """Add vectors."""
+        self._vectors.extend([list(map(float, vector)) for vector in vectors])
+        payloads = payloads or [{} for _ in vectors]
+        if len(payloads) != len(vectors):
+            raise ValueError("payload count must match vectors")
+        self._payloads.extend(payloads)
+
+    def search(self, query_vec: list[float], k: int = 20) -> list[dict]:
+        """Search."""
+        faiss = FaissIndex(len(query_vec))
+        faiss.add(self._vectors)
+        results = faiss.search(query_vec, k=k)
+        response: list[dict[str, Any]] = []
+        for idx, score in results:
+            payload = self._payloads[idx] if idx < len(self._payloads) else {}
+            response.append({"id": idx, "score": score, "payload": payload})
+        return response
+
+
+def hybrid_search(
+    bm25: BM25Index | None,
+    dense: FaissIndex | QdrantIndex | None,
+    query: str,
+    query_vec: list[float] | None,
+    alpha: float = 0.5,
+    k: int = 20,
+) -> list[dict[str, Any]]:
+    """Fuse sparse+dense scores."""
+    sparse_scores: dict[int, float] = {}
+    if bm25 is not None:
+        for idx, score in bm25.search(query, k=k):
+            if score > 0:
+                sparse_scores[idx] = score
+
+    dense_scores: dict[int, float] = {}
+    if dense is not None and query_vec is not None:
+        if isinstance(dense, FaissIndex):
+            results = dense.search(query_vec, k=k)
+            for idx, score in results:
+                dense_scores[idx] = score
+        else:
+            results = dense.search(query_vec, k=k)
+            for item in results:
+                dense_scores[int(item.get("id", 0))] = float(item.get("score", 0.0))
+
+    combined: dict[int, dict[str, float]] = {}
+    for idx in set(sparse_scores) | set(dense_scores):
+        combined[idx] = {
+            "sparse": sparse_scores.get(idx, 0.0),
+            "dense": dense_scores.get(idx, 0.0),
+        }
+    fused: list[tuple[int, float, dict[str, float]]] = []
+    for idx, parts in combined.items():
+        score = alpha * parts["dense"] + (1 - alpha) * parts["sparse"]
+        fused.append((idx, score, parts))
+    fused.sort(key=lambda item: item[1], reverse=True)
+    top = fused[:k]
+    return [
+        {"id": idx, "score": score, "dense": parts["dense"], "sparse": parts["sparse"]}
+        for idx, score, parts in top
+    ]
+
+
+__all__ = [
+    "EmbeddingModel",
+    "BM25Index",
+    "FaissIndex",
+    "QdrantIndex",
+    "hybrid_search",
+]

--- a/rag-app/backend/app/config.py
+++ b/rag-app/backend/app/config.py
@@ -52,6 +52,16 @@ class Settings(BaseSettings):
         default=0.85,
         validation_alias=AliasChoices("UPLOAD_OCR_THRESHOLD", "upload_ocr_threshold"),
     )
+    chunk_target_tokens: int = Field(
+        default=90,
+        ge=10,
+        validation_alias=AliasChoices("CHUNK_TARGET_TOKENS", "chunk_target_tokens"),
+    )
+    chunk_token_overlap: int = Field(
+        default=12,
+        ge=0,
+        validation_alias=AliasChoices("CHUNK_TOKEN_OVERLAP", "chunk_token_overlap"),
+    )
     parser_timeout_seconds: float = Field(
         default=1.0,
         validation_alias=AliasChoices(

--- a/rag-app/backend/app/contracts/__init__.py
+++ b/rag-app/backend/app/contracts/__init__.py
@@ -1,0 +1,5 @@
+"""Pydantic contracts shared across services."""
+
+from .chunking import HybridSearchResult, UFChunk
+
+__all__ = ["UFChunk", "HybridSearchResult"]

--- a/rag-app/backend/app/contracts/chunking.py
+++ b/rag-app/backend/app/contracts/chunking.py
@@ -1,0 +1,31 @@
+"""Contracts for chunking and retrieval."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class UFChunk(BaseModel):
+    """Universal format chunk representation."""
+
+    chunk_id: str
+    doc_id: str
+    text: str
+    sentence_start: int = Field(ge=0)
+    sentence_end: int = Field(ge=0)
+    token_count: int = Field(ge=0)
+    typography: dict[str, Any] = Field(default_factory=dict)
+
+
+class HybridSearchResult(BaseModel):
+    """Result row from hybrid search fusion."""
+
+    chunk_index: int = Field(ge=0)
+    score: float
+    dense_score: float
+    sparse_score: float
+
+
+__all__ = ["UFChunk", "HybridSearchResult"]

--- a/rag-app/backend/app/main.py
+++ b/rag-app/backend/app/main.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from .config import get_settings
-from .routes import parser_router, upload_router
+from .routes import chunk_router, parser_router, upload_router
 from .util.logging import get_logger
 
 logger = get_logger(__name__)
@@ -27,6 +27,7 @@ def create_app() -> FastAPI:
 
     app.include_router(upload_router)
     app.include_router(parser_router)
+    app.include_router(chunk_router)
 
     @app.get("/health", tags=["system"])
     async def healthcheck() -> dict[str, str]:

--- a/rag-app/backend/app/routes/__init__.py
+++ b/rag-app/backend/app/routes/__init__.py
@@ -1,6 +1,7 @@
 """Backend API routes for FluidRAG."""
 
+from .chunk import router as chunk_router
 from .parser import router as parser_router
 from .upload import router as upload_router
 
-__all__ = ["parser_router", "upload_router"]
+__all__ = ["upload_router", "parser_router", "chunk_router"]

--- a/rag-app/backend/app/routes/chunk.py
+++ b/rag-app/backend/app/routes/chunk.py
@@ -1,0 +1,34 @@
+"""Chunk routes."""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+from fastapi.concurrency import run_in_threadpool
+from pydantic import BaseModel
+
+from ..services.chunk_service import ChunkResult, run_uf_chunking
+from ..util.errors import AppError, NotFoundError, ValidationError
+
+router = APIRouter(prefix="/chunk", tags=["chunk"])
+
+
+class ChunkRequest(BaseModel):
+    """Request body for chunk generation."""
+
+    doc_id: str
+    normalize_artifact: str
+
+
+@router.post("/uf", response_model=ChunkResult)
+async def chunk_document(request: ChunkRequest) -> ChunkResult:
+    """Generate UF chunks and build local indexes."""
+    try:
+        return await run_in_threadpool(
+            run_uf_chunking, request.doc_id, request.normalize_artifact
+        )
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except NotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except AppError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/rag-app/backend/app/services/__init__.py
+++ b/rag-app/backend/app/services/__init__.py
@@ -1,3 +1,5 @@
 """Domain services for the FluidRAG backend."""
 
-__all__ = []
+from .chunk_service import run_uf_chunking as run_chunking
+
+__all__ = ["run_chunking"]

--- a/rag-app/backend/app/services/chunk_service/__init__.py
+++ b/rag-app/backend/app/services/chunk_service/__init__.py
@@ -1,0 +1,5 @@
+"""Chunk service package."""
+
+from .main import ChunkResult, run_uf_chunking
+
+__all__ = ["ChunkResult", "run_uf_chunking"]

--- a/rag-app/backend/app/services/chunk_service/chunk_controller.py
+++ b/rag-app/backend/app/services/chunk_service/chunk_controller.py
@@ -1,0 +1,126 @@
+"""Chunk controller orchestrating segmentation and indexing."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from pydantic import BaseModel
+
+from ...config import get_settings
+from ...contracts.chunking import UFChunk
+from ...util.audit import stage_record
+from ...util.errors import AppError, NotFoundError, ValidationError
+from ...util.logging import get_logger
+from .packages.features.typography import extract_typography
+from .packages.index.local_vss import build_local_index
+from .packages.segment.sentences import split_sentences
+from .packages.segment.uf_chunker import uf_chunk
+
+logger = get_logger(__name__)
+
+
+class ChunkInternal(BaseModel):
+    """Internal chunk descriptor."""
+
+    doc_id: str
+    chunks_path: str
+    chunk_count: int
+    index_manifest_path: str | None = None
+
+
+def _validate_inputs(
+    doc_id: str | None, normalize_artifact: str | None
+) -> tuple[str, str]:
+    if not doc_id or not doc_id.strip():
+        raise ValidationError("doc_id is required for chunking")
+    if not normalize_artifact or not normalize_artifact.strip():
+        raise ValidationError("normalize_artifact is required for chunking")
+    return doc_id.strip(), normalize_artifact.strip()
+
+
+def run_uf_chunking(
+    doc_id: str | None = None, normalize_artifact: str | None = None
+) -> ChunkInternal:
+    """Controller for chunking & local index building."""
+    doc_id, normalize_artifact = _validate_inputs(doc_id, normalize_artifact)
+    settings = get_settings()
+    artifact_root = Path(settings.artifact_root_path) / doc_id
+    artifact_root.mkdir(parents=True, exist_ok=True)
+    target_tokens = int(getattr(settings, "chunk_target_tokens", 90))
+    overlap = int(getattr(settings, "chunk_token_overlap", 12))
+    try:
+        sentences = split_sentences(normalize_artifact)
+        if not sentences:
+            raise ValidationError("no sentences available for chunking")
+        typography = extract_typography(normalize_artifact)
+        chunk_dicts = uf_chunk(
+            sentences=sentences,
+            typography=typography,
+            target_tokens=target_tokens,
+            overlap=overlap,
+        )
+        if not chunk_dicts:
+            raise AppError("failed to create chunks")
+        chunks_path = artifact_root / "uf_chunks.jsonl"
+        with chunks_path.open("w", encoding="utf-8") as handle:
+            for index, chunk in enumerate(chunk_dicts, start=1):
+                payload = UFChunk(
+                    chunk_id=f"{doc_id}:c{index}",
+                    doc_id=doc_id,
+                    text=chunk["text"],
+                    sentence_start=chunk["sentence_start"],
+                    sentence_end=chunk["sentence_end"],
+                    token_count=chunk["token_count"],
+                    typography=chunk.get("typography", {}),
+                ).model_dump()
+                handle.write(json.dumps(payload, ensure_ascii=False) + "\n")
+        build_local_index(doc_id=doc_id, chunks_path=str(chunks_path))
+        manifest_path = artifact_root / "index.manifest.json"
+        audit_path = artifact_root / "chunk.audit.json"
+        audit_payload = stage_record(
+            stage="chunk.build",
+            status="ok",
+            doc_id=doc_id,
+            chunks=len(chunk_dicts),
+            target_tokens=target_tokens,
+            overlap=overlap,
+        )
+        audit_path.write_text(json.dumps(audit_payload, indent=2), encoding="utf-8")
+        logger.info(
+            "chunk.run.success",
+            extra={
+                "doc_id": doc_id,
+                "chunks": len(chunk_dicts),
+                "chunks_path": str(chunks_path),
+            },
+        )
+        return ChunkInternal(
+            doc_id=doc_id,
+            chunks_path=str(chunks_path),
+            chunk_count=len(chunk_dicts),
+            index_manifest_path=str(manifest_path) if manifest_path.exists() else None,
+        )
+    except FileNotFoundError as exc:
+        handle_chunk_errors(exc)
+        raise
+    except Exception as exc:  # noqa: BLE001
+        handle_chunk_errors(exc)
+        raise
+
+
+def handle_chunk_errors(e: Exception) -> None:
+    """Normalize and raise chunk errors."""
+    if isinstance(e, ValidationError):
+        logger.warning("chunk.validation_failed", extra={"error": str(e)})
+        raise
+    if isinstance(e, FileNotFoundError):
+        logger.error("chunk.artifact_missing", extra={"error": str(e)})
+        raise NotFoundError(str(e)) from e
+    if isinstance(e, AppError):
+        raise
+    logger.error("chunk.unexpected", extra={"error": str(e), "type": type(e).__name__})
+    raise AppError("chunking failed") from e
+
+
+__all__ = ["run_uf_chunking", "handle_chunk_errors", "ChunkInternal"]

--- a/rag-app/backend/app/services/chunk_service/main.py
+++ b/rag-app/backend/app/services/chunk_service/main.py
@@ -1,0 +1,30 @@
+"""Chunk service facade."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from .chunk_controller import ChunkInternal
+from .chunk_controller import run_uf_chunking as controller_run_uf_chunking
+
+
+class ChunkResult(BaseModel):
+    """UF chunking result."""
+
+    doc_id: str
+    chunks_path: str
+    chunk_count: int
+    index_manifest_path: str | None = None
+
+
+def run_uf_chunking(
+    doc_id: str | None = None, normalize_artifact: str | None = None
+) -> ChunkResult:
+    """Create UF chunks from enriched parse."""
+    internal: ChunkInternal = controller_run_uf_chunking(
+        doc_id=doc_id, normalize_artifact=normalize_artifact
+    )
+    return ChunkResult(**internal.model_dump())
+
+
+__all__ = ["ChunkResult", "run_uf_chunking"]

--- a/rag-app/backend/app/services/chunk_service/packages/__init__.py
+++ b/rag-app/backend/app/services/chunk_service/packages/__init__.py
@@ -1,0 +1,1 @@
+"""Chunk service utilities."""

--- a/rag-app/backend/app/services/chunk_service/packages/features/__init__.py
+++ b/rag-app/backend/app/services/chunk_service/packages/features/__init__.py
@@ -1,0 +1,1 @@
+"""Chunk service utilities."""

--- a/rag-app/backend/app/services/chunk_service/packages/features/typography.py
+++ b/rag-app/backend/app/services/chunk_service/packages/features/typography.py
@@ -1,0 +1,83 @@
+"""Typography feature extraction for chunking."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .....util.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def _extract_font(block: dict[str, Any]) -> dict[str, Any]:
+    font = block.get("font")
+    if isinstance(font, dict):
+        return font
+    style = block.get("style")
+    if isinstance(style, dict):
+        candidate = style.get("font")
+        if isinstance(candidate, dict):
+            return candidate
+    return {}
+
+
+def _is_heading(text: str, font: dict[str, Any]) -> bool:
+    if not text:
+        return False
+    upper_ratio = sum(1 for c in text if c.isupper()) / max(len(text), 1)
+    size = float(font.get("size", 0) or 0)
+    weight = str(font.get("weight", "")).lower()
+    return size >= 16 or (upper_ratio > 0.55 and weight in {"bold", "700"})
+
+
+def extract_typography(normalize_artifact_path: str | None = None) -> dict[str, Any]:
+    """Compute typography features."""
+    if not normalize_artifact_path:
+        return {}
+    path = Path(normalize_artifact_path)
+    if not path.exists():
+        logger.warning(
+            "chunk.typography.missing_artifact", extra={"path": normalize_artifact_path}
+        )
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        logger.error(
+            "chunk.typography.invalid_json",
+            extra={"path": normalize_artifact_path, "error": str(exc)},
+        )
+        return {}
+
+    features: dict[str, Any] = {"pages": {}, "headings": []}
+    total_size = 0.0
+    total_weight = 0.0
+    block_count = 0
+    for page in payload.get("pages", []):
+        page_number = page.get("page_number")
+        sizes: list[float] = []
+        for block in page.get("blocks", []):
+            font = _extract_font(block)
+            size = float(font.get("size", 0) or 0)
+            weight = font.get("weight", "normal")
+            sizes.append(size)
+            total_size += size
+            total_weight += 700.0 if str(weight).lower() in {"bold", "700"} else 400.0
+            block_count += 1
+            if _is_heading(block.get("text", ""), font):
+                features.setdefault("headings", []).append(block.get("id"))
+        if sizes:
+            features["pages"][str(page_number or len(features["pages"]) + 1)] = {
+                "avg_size": sum(sizes) / len(sizes),
+                "max_size": max(sizes),
+                "min_size": min(sizes),
+            }
+    if block_count:
+        features["avg_size"] = total_size / block_count
+        features["avg_weight"] = total_weight / block_count
+    else:
+        features["avg_size"] = 0.0
+        features["avg_weight"] = 0.0
+    return features

--- a/rag-app/backend/app/services/chunk_service/packages/index/__init__.py
+++ b/rag-app/backend/app/services/chunk_service/packages/index/__init__.py
@@ -1,0 +1,1 @@
+"""Chunk service utilities."""

--- a/rag-app/backend/app/services/chunk_service/packages/index/local_vss.py
+++ b/rag-app/backend/app/services/chunk_service/packages/index/local_vss.py
@@ -1,0 +1,84 @@
+"""Local vector store builder for UF chunks."""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+from pathlib import Path
+from typing import Any
+
+from .....adapters.vectors import BM25Index, FaissIndex
+from .....util.logging import get_logger
+
+logger = get_logger(__name__)
+
+_HASH_DIMENSION = 16
+_TOKEN_PATTERN = re.compile(r"\w+")
+
+
+def _hash_embed(text: str, dim: int = _HASH_DIMENSION) -> list[float]:
+    vector = [0.0] * dim
+    tokens = _TOKEN_PATTERN.findall(text.lower())
+    if not tokens:
+        return vector
+    for token in tokens:
+        index = hash(token) % dim
+        vector[index] += 1.0
+    norm = math.sqrt(sum(value * value for value in vector)) or 1.0
+    return [value / norm for value in vector]
+
+
+def build_local_index(
+    doc_id: str | None = None, chunks_path: str | None = None
+) -> None:
+    """Optionally build per-doc vector index."""
+    if not chunks_path:
+        return
+    path = Path(chunks_path)
+    if not path.exists():
+        logger.warning("chunk.index.missing_chunks", extra={"path": chunks_path})
+        return
+
+    chunk_texts: list[str] = []
+    chunk_vectors: list[list[float]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            if not line.strip():
+                continue
+            record = json.loads(line)
+            text = record.get("text", "")
+            chunk_texts.append(text)
+            chunk_vectors.append(_hash_embed(text))
+
+    bm25 = BM25Index()
+    if chunk_texts:
+        bm25.add(chunk_texts)
+    index_dir = path.parent
+    index_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest: dict[str, Any] = {
+        "doc_id": doc_id,
+        "chunk_count": len(chunk_texts),
+        "bm25_docs": len(chunk_texts),
+        "dense_index_path": None,
+    }
+
+    if chunk_vectors:
+        dense_path = index_dir / "vectors.faiss.json"
+        faiss = FaissIndex(len(chunk_vectors[0]), str(dense_path))
+        faiss.add(chunk_vectors)
+        faiss.save()
+        manifest["dense_index_path"] = str(dense_path)
+
+    manifest_path = index_dir / "index.manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+    logger.info(
+        "chunk.index.built",
+        extra={
+            "doc_id": doc_id,
+            "chunks": len(chunk_texts),
+            "dense": bool(chunk_vectors),
+            "path": str(manifest_path),
+        },
+    )

--- a/rag-app/backend/app/services/chunk_service/packages/segment/__init__.py
+++ b/rag-app/backend/app/services/chunk_service/packages/segment/__init__.py
@@ -1,0 +1,1 @@
+"""Chunk service utilities."""

--- a/rag-app/backend/app/services/chunk_service/packages/segment/sentences.py
+++ b/rag-app/backend/app/services/chunk_service/packages/segment/sentences.py
@@ -1,0 +1,59 @@
+"""Sentence segmentation utilities for UF chunking."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Iterable
+from pathlib import Path
+
+from .....util.logging import get_logger
+
+logger = get_logger(__name__)
+
+_SENTENCE_SPLIT = re.compile(r"(?<=[.!?])\s+|\n+")
+
+
+def _iter_block_text(payload: dict) -> Iterable[str]:
+    blocks = payload.get("blocks")
+    if isinstance(blocks, list):
+        for block in blocks:
+            text = block.get("text", "") if isinstance(block, dict) else ""
+            if text:
+                yield text
+    pages = payload.get("pages")
+    if isinstance(pages, list):
+        for page in pages:
+            for block in page.get("blocks", []):
+                text = block.get("text", "") if isinstance(block, dict) else ""
+                if text:
+                    yield text
+
+
+def split_sentences(normalize_artifact_path: str | None = None) -> list[str]:
+    """Segment text into sentences using punctuation and layout."""
+    if not normalize_artifact_path:
+        return []
+    path = Path(normalize_artifact_path)
+    if not path.exists():
+        logger.warning(
+            "chunk.sentences.missing_artifact", extra={"path": normalize_artifact_path}
+        )
+        raise FileNotFoundError(normalize_artifact_path)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        logger.error(
+            "chunk.sentences.invalid_json",
+            extra={"path": normalize_artifact_path, "error": str(exc)},
+        )
+        raise
+
+    sentences: list[str] = []
+    for block_text in _iter_block_text(payload):
+        candidates = _SENTENCE_SPLIT.split(block_text.strip())
+        for candidate in candidates:
+            cleaned = candidate.strip()
+            if cleaned:
+                sentences.append(cleaned)
+    return sentences

--- a/rag-app/backend/app/services/chunk_service/packages/segment/uf_chunker.py
+++ b/rag-app/backend/app/services/chunk_service/packages/segment/uf_chunker.py
@@ -1,0 +1,82 @@
+"""Universal format chunking heuristics."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .....util.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def _sentence_token_count(sentence: str) -> int:
+    return len(sentence.split())
+
+
+def _is_heading_sentence(sentence: str) -> bool:
+    text = sentence.strip()
+    if not text:
+        return False
+    words = text.split()
+    if len(words) <= 6 and text.isupper():
+        return True
+    upper_ratio = sum(1 for c in text if c.isupper()) / max(len(text), 1)
+    return upper_ratio > 0.55 and len(words) <= 12
+
+
+def uf_chunk(
+    sentences: list[str] | None = None,
+    typography: dict[str, Any] | None = None,
+    target_tokens: int | None = None,
+    overlap: int | None = None,
+) -> list[dict[str, Any]]:
+    """Produce UF micro-chunks with metadata."""
+    sentences = sentences or []
+    if not sentences:
+        return []
+    target_tokens = max(target_tokens or 90, 10)
+    overlap_tokens = max(overlap or 12, 0)
+    avg_tokens = sum(_sentence_token_count(s) for s in sentences) / max(
+        len(sentences), 1
+    )
+    overlap_sentences = int(round(overlap_tokens / max(avg_tokens or 1, 1)))
+    overlap_sentences = max(0, min(overlap_sentences, len(sentences) - 1))
+    chunks: list[dict[str, Any]] = []
+    start = 0
+    while start < len(sentences):
+        end = start
+        token_total = 0
+        while end < len(sentences) and token_total < target_tokens:
+            token_total += _sentence_token_count(sentences[end])
+            end += 1
+            if end < len(sentences) and _is_heading_sentence(sentences[end]):
+                break
+        chunk_sentences = sentences[start:end]
+        if not chunk_sentences:
+            break
+        chunk = {
+            "text": " ".join(chunk_sentences),
+            "sentence_start": start,
+            "sentence_end": end - 1,
+            "token_count": sum(_sentence_token_count(s) for s in chunk_sentences),
+            "typography": {
+                "avg_size": (typography or {}).get("avg_size", 0.0),
+                "avg_weight": (typography or {}).get("avg_weight", 0.0),
+            },
+        }
+        chunks.append(chunk)
+        if end >= len(sentences):
+            break
+        next_start = max(end - overlap_sentences, start + 1)
+        if next_start <= start:
+            next_start = start + 1
+        start = next_start
+    logger.debug(
+        "chunk.uf_chunk",
+        extra={
+            "chunks": len(chunks),
+            "sentences": len(sentences),
+            "target": target_tokens,
+        },
+    )
+    return chunks

--- a/rag-app/backend/app/tests/unit/test_chunk.py
+++ b/rag-app/backend/app/tests/unit/test_chunk.py
@@ -1,0 +1,88 @@
+"""Unit tests for chunk service and retrieval helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ...adapters.vectors import BM25Index, FaissIndex, hybrid_search
+from ...config import get_settings
+from ...services.chunk_service import ChunkResult, run_uf_chunking
+from ...services.parser_service import parse_and_enrich
+from ...services.upload_service import ensure_normalized
+from ...util.errors import NotFoundError
+
+
+@pytest.fixture(autouse=True)
+def _reset_settings(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("FLUIDRAG_OFFLINE", "true")
+    monkeypatch.setenv("ARTIFACT_ROOT", str(tmp_path / "artifacts"))
+    monkeypatch.setenv("CHUNK_TARGET_TOKENS", "18")
+    monkeypatch.setenv("CHUNK_TOKEN_OVERLAP", "10")
+    get_settings.cache_clear()
+
+
+def _build_pipeline(tmp_path: Path, text: str) -> tuple[str, str]:
+    source = tmp_path / "doc.txt"
+    source.write_text(text, encoding="utf-8")
+    normalized = ensure_normalized(file_name=str(source))
+    parsed = parse_and_enrich(normalized.doc_id, normalized.normalized_path)
+    return parsed.doc_id, parsed.enriched_path
+
+
+def test_run_uf_chunking_creates_chunks_and_indexes(tmp_path: Path) -> None:
+    doc_id, enriched_path = _build_pipeline(
+        tmp_path,
+        (
+            "Executive Summary introduces the strategy. This section highlights key metrics with figures and ratios. "
+            "Detailed analysis follows with multiple insights and supporting evidence. "
+            "Mid-course adjustments are enumerated alongside risks. "
+            "Appendix covers supplemental materials and citations. "
+            "Final thoughts reinforce the narrative and call to action."
+        ),
+    )
+
+    result: ChunkResult = run_uf_chunking(doc_id, enriched_path)
+    chunks_path = Path(result.chunks_path)
+    manifest_path = Path(result.index_manifest_path or "")
+    audit_path = chunks_path.with_name("chunk.audit.json")
+
+    assert chunks_path.exists(), "uf_chunks.jsonl should be written"
+    assert manifest_path.exists(), "index manifest should exist"
+    assert audit_path.exists(), "chunk audit record should exist"
+
+    rows = [
+        json.loads(line)
+        for line in chunks_path.read_text(encoding="utf-8").splitlines()
+        if line
+    ]
+    assert len(rows) >= 2, "chunking should produce multiple segments for long text"
+    assert rows[0]["sentence_start"] == 0
+    assert rows[0]["sentence_end"] >= rows[0]["sentence_start"]
+    assert (
+        rows[1]["sentence_start"] <= rows[0]["sentence_end"]
+    ), "overlap should reuse context"
+    assert rows[0]["token_count"] <= 40
+
+
+def test_run_uf_chunking_missing_artifact_raises_not_found(tmp_path: Path) -> None:
+    with pytest.raises(NotFoundError):
+        run_uf_chunking("doc-123", str(tmp_path / "missing.json"))
+
+
+def test_hybrid_search_fuses_sparse_and_dense() -> None:
+    bm25 = BM25Index()
+    bm25.add(["alpha beta", "beta gamma", "delta epsilon"])
+
+    faiss = FaissIndex(2)
+    faiss.add([[0.9, 0.1], [0.6, 0.4], [0.0, 1.0]])
+
+    results = hybrid_search(
+        bm25, faiss, query="beta", query_vec=[0.8, 0.2], alpha=0.6, k=2
+    )
+    assert results, "hybrid search should return matches"
+    top = results[0]
+    assert top["id"] == 0, "first document should win due to combined score"
+    assert top["dense"] >= top["sparse"], "dense score should influence ranking"


### PR DESCRIPTION
## Summary
- add chunk service pipeline with typography features, UF chunking, and FastAPI `/chunk/uf` route
- implement offline-friendly BM25 and dense vector adapters with hybrid retrieval helper
- extend configuration/docs/env samples and add targeted unit coverage for chunking and hybrid search

## Testing
- `ruff check rag-app`
- `black --check rag-app`
- `FLUIDRAG_OFFLINE=true pytest -q -o cache_dir=/tmp/pytest_cache rag-app/backend/app/tests/unit/test_chunk.py`
- `FLUIDRAG_OFFLINE=true pytest -q -o cache_dir=/tmp/pytest_cache`


------
https://chatgpt.com/codex/tasks/task_e_68d98bdb23988324b1a72503cd16ad51