### PR TITLE
Fix Phase-4 docstring and typing gaps

### DIFF
--- a/rag-app/backend/app/adapters/vectors.py
+++ b/rag-app/backend/app/adapters/vectors.py
@@ -201,12 +201,12 @@ def hybrid_search(
     dense_scores: dict[int, float] = {}
     if dense is not None and query_vec is not None:
         if isinstance(dense, FaissIndex):
-            results = dense.search(query_vec, k=k)
-            for idx, score in results:
+            faiss_results = dense.search(query_vec, k=k)
+            for idx, score in faiss_results:
                 dense_scores[idx] = score
         else:
-            results = dense.search(query_vec, k=k)
-            for item in results:
+            qdrant_results = dense.search(query_vec, k=k)
+            for item in qdrant_results:
                 dense_scores[int(item.get("id", 0))] = float(item.get("score", 0.0))
 
     combined: dict[int, dict[str, float]] = {}

--- a/rag-app/backend/app/llm/utils.py
+++ b/rag-app/backend/app/llm/utils.py
@@ -4,14 +4,17 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 __path__ = [str(Path(__file__).with_name("utils"))]
 if __spec__ is not None:  # pragma: no cover - package wiring
     __spec__.submodule_search_locations = __path__
     __package__ = __spec__.parent  # type: ignore[assignment]
 
-from .envsafe import masked_headers
+if TYPE_CHECKING:
+    from backend.app.llm.utils.envsafe import masked_headers as masked_headers
+else:
+    from .envsafe import masked_headers
 
 
 def windows_curl(url: str, headers: dict[str, str], payload: dict[str, Any]) -> str:

--- a/rag-app/backend/app/services/parser_service/packages/__init__.py
+++ b/rag-app/backend/app/services/parser_service/packages/__init__.py
@@ -1,3 +1,5 @@
 """Parser helper package."""
 
-__all__ = []
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/rag-app/backend/app/services/parser_service/packages/detect/__init__.py
+++ b/rag-app/backend/app/services/parser_service/packages/detect/__init__.py
@@ -1,3 +1,5 @@
 """Parser helper package."""
 
-__all__ = []
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/rag-app/backend/app/services/parser_service/packages/enhance/__init__.py
+++ b/rag-app/backend/app/services/parser_service/packages/enhance/__init__.py
@@ -1,3 +1,5 @@
 """Parser helper package."""
 
-__all__ = []
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/rag-app/backend/app/services/parser_service/packages/extract/__init__.py
+++ b/rag-app/backend/app/services/parser_service/packages/extract/__init__.py
@@ -1,3 +1,5 @@
 """Parser helper package."""
 
-__all__ = []
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/rag-app/backend/app/services/parser_service/packages/merge/__init__.py
+++ b/rag-app/backend/app/services/parser_service/packages/merge/__init__.py
@@ -1,3 +1,5 @@
 """Parser helper package."""
 
-__all__ = []
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/rag-app/backend/app/services/parser_service/packages/ocr/__init__.py
+++ b/rag-app/backend/app/services/parser_service/packages/ocr/__init__.py
@@ -1,3 +1,5 @@
 """Parser helper package."""
 
-__all__ = []
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/rag-app/backend/app/services/upload_service/packages/__init__.py
+++ b/rag-app/backend/app/services/upload_service/packages/__init__.py
@@ -1,3 +1,5 @@
 """Upload service packages."""
 
-__all__ = []
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/rag-app/backend/app/services/upload_service/packages/emit/__init__.py
+++ b/rag-app/backend/app/services/upload_service/packages/emit/__init__.py
@@ -1,3 +1,5 @@
 """Emit helpers."""
 
-__all__ = []
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/rag-app/backend/app/services/upload_service/packages/guards/__init__.py
+++ b/rag-app/backend/app/services/upload_service/packages/guards/__init__.py
@@ -1,3 +1,5 @@
 """Upload guards package."""
 
-__all__ = []
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/rag-app/backend/app/services/upload_service/packages/normalize/__init__.py
+++ b/rag-app/backend/app/services/upload_service/packages/normalize/__init__.py
@@ -1,3 +1,5 @@
 """Normalization helpers."""
 
-__all__ = []
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/rag-app/backend/app/tests/unit/test_chunk.py
+++ b/rag-app/backend/app/tests/unit/test_chunk.py
@@ -33,6 +33,7 @@ def _build_pipeline(tmp_path: Path, text: str) -> tuple[str, str]:
 
 
 def test_run_uf_chunking_creates_chunks_and_indexes(tmp_path: Path) -> None:
+    """Unit test placeholder."""
     doc_id, enriched_path = _build_pipeline(
         tmp_path,
         (
@@ -68,6 +69,7 @@ def test_run_uf_chunking_creates_chunks_and_indexes(tmp_path: Path) -> None:
 
 
 def test_run_uf_chunking_missing_artifact_raises_not_found(tmp_path: Path) -> None:
+    """Validate chunk boundaries respect sentence and header edges."""
     with pytest.raises(NotFoundError):
         run_uf_chunking("doc-123", str(tmp_path / "missing.json"))
 

--- a/rag-app/backend/app/tests/unit/test_openrouter_client.py
+++ b/rag-app/backend/app/tests/unit/test_openrouter_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from collections.abc import AsyncGenerator, Iterator
 from typing import Any
 
 import pytest
@@ -73,8 +74,8 @@ class DummyStreamResponse:
     ) -> None:  # pragma: no cover - context stub
         return None
 
-    def aiter_lines(self):
-        async def _gen():
+    def aiter_lines(self) -> AsyncGenerator[str, None]:
+        async def _gen() -> AsyncGenerator[str, None]:
             for item in self._lines:
                 if isinstance(item, float):
                     await asyncio.sleep(item)
@@ -116,7 +117,7 @@ class MockAsyncClient:
 
 
 @pytest.fixture(autouse=True)
-def _reset_settings(monkeypatch: pytest.MonkeyPatch) -> None:
+def _reset_settings(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()

--- a/rag-app/backend/app/util/logging.py
+++ b/rag-app/backend/app/util/logging.py
@@ -72,7 +72,7 @@ def _configure_root_logger(level: str) -> None:
     _LOGGER_INITIALIZED = True
 
 
-def get_logger(name: str = None) -> logging.Logger:
+def get_logger(name: str | None = None) -> logging.Logger:
     """Return configured JSON logger."""
     try:
         from ..config import get_settings  # Local import to avoid circular dependency.


### PR DESCRIPTION
## Summary
- add the stub-mandated docstrings to the chunk service unit tests and tighten OpenRouter fixtures for typing
- annotate package `__all__` exports and adjust hybrid search bookkeeping so mypy accepts the vector adapters
- ensure the LLM utils import remains type-checkable while preserving the runtime shim

## Testing
- FLUIDRAG_OFFLINE=true pytest -q -o cache_dir=/tmp/pytest_cache -k "phase4"
- FLUIDRAG_OFFLINE=true pytest -q -o cache_dir=/tmp/pytest_cache
- mypy .
- ruff check .
- black --check .

------
https://chatgpt.com/codex/tasks/task_e_68d9913d9f34832488a18b5a90c4043f