### PR TITLE
fix: align chunk service implementation with final stubs

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+python_version = 3.10
+files = rag-app/backend/app
+ignore_missing_imports = True

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 testpaths = rag-app/backend/app/tests
 pythonpath = rag-app
+markers =
+    phase4: Phase 4 acceptance coverage

--- a/rag-app/backend/app/adapters/vectors.py
+++ b/rag-app/backend/app/adapters/vectors.py
@@ -191,7 +191,7 @@ def hybrid_search(
     alpha: float = 0.5,
     k: int = 20,
 ) -> list[dict[str, Any]]:
-    """Fuse sparse+dense scores."""
+    """Fuse sparse+dense scores"""
     sparse_scores: dict[int, float] = {}
     if bm25 is not None:
         for idx, score in bm25.search(query, k=k):

--- a/rag-app/backend/app/config.py
+++ b/rag-app/backend/app/config.py
@@ -70,7 +70,7 @@ class Settings(BaseSettings):
     )
 
     def __init__(self, **data: Any) -> None:
-        """Pydantic settings init."""
+        """Pydantic settings init"""
         super().__init__(**data)
 
     @property

--- a/rag-app/backend/app/services/chunk_service/chunk_controller.py
+++ b/rag-app/backend/app/services/chunk_service/chunk_controller.py
@@ -29,18 +29,17 @@ class ChunkInternal(BaseModel):
     index_manifest_path: str | None = None
 
 
-def _validate_inputs(
-    doc_id: str | None, normalize_artifact: str | None
-) -> tuple[str, str]:
-    if not doc_id or not doc_id.strip():
+def _validate_inputs(doc_id: str, normalize_artifact: str) -> tuple[str, str]:
+    if not doc_id.strip():
         raise ValidationError("doc_id is required for chunking")
-    if not normalize_artifact or not normalize_artifact.strip():
+    if not normalize_artifact.strip():
         raise ValidationError("normalize_artifact is required for chunking")
     return doc_id.strip(), normalize_artifact.strip()
 
 
 def run_uf_chunking(
-    doc_id: str | None = None, normalize_artifact: str | None = None
+    doc_id: str,
+    normalize_artifact: str,
 ) -> ChunkInternal:
     """Controller for chunking & local index building."""
     doc_id, normalize_artifact = _validate_inputs(doc_id, normalize_artifact)

--- a/rag-app/backend/app/services/chunk_service/main.py
+++ b/rag-app/backend/app/services/chunk_service/main.py
@@ -17,9 +17,7 @@ class ChunkResult(BaseModel):
     index_manifest_path: str | None = None
 
 
-def run_uf_chunking(
-    doc_id: str | None = None, normalize_artifact: str | None = None
-) -> ChunkResult:
+def run_uf_chunking(doc_id: str, normalize_artifact: str) -> ChunkResult:
     """Create UF chunks from enriched parse."""
     internal: ChunkInternal = controller_run_uf_chunking(
         doc_id=doc_id, normalize_artifact=normalize_artifact


### PR DESCRIPTION
## Summary
- align chunk controller/service signatures and docstrings with the final stub contracts
- update chunk unit tests to use the stubbed function names, add a phase4 marker, and consolidate hybrid search coverage
- register the new pytest marker and add a mypy configuration so `mypy` runs cleanly without arguments

## Testing
- FLUIDRAG_OFFLINE=true pytest -q -o cache_dir=/tmp/pytest_cache -k "phase4"
- FLUIDRAG_OFFLINE=true pytest -q -o cache_dir=/tmp/pytest_cache
- ruff check .
- black --check .
- mypy


------
https://chatgpt.com/codex/tasks/task_e_68d99a73f2b48324b22b5c116cff52aa