### PR TITLE
Register pytest markers for phase tests

### DIFF
--- a/rag-app/pyproject.toml
+++ b/rag-app/pyproject.toml
@@ -26,3 +26,7 @@ indent-style = "space"
 [tool.pytest.ini_options]
 testpaths = ["backend/app/tests"]
 pythonpath = ["rag-app"]
+markers = [
+    "phase4: marks tests that exercise Phase 4 functionality",
+    "phase5: marks tests that exercise Phase 5 functionality",
+]


### PR DESCRIPTION
## Summary
- register the phase4 and phase5 pytest markers so phase-specific unit tests are recognized

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9c03a60648324bca7d44eb2cb9e71