### PR TITLE
chore: add rag pass package init modules

### DIFF
--- a/rag-app/backend/app/services/rag_pass_service/packages/compose/__init__.py
+++ b/rag-app/backend/app/services/rag_pass_service/packages/compose/__init__.py
@@ -1,0 +1,5 @@
+"""Context composition helpers for RAG passes."""
+
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/rag-app/backend/app/services/rag_pass_service/packages/emit/__init__.py
+++ b/rag-app/backend/app/services/rag_pass_service/packages/emit/__init__.py
@@ -1,0 +1,5 @@
+"""Emit helpers for RAG passes."""
+
+from __future__ import annotations
+
+__all__: list[str] = []


### PR DESCRIPTION
## Summary
- add missing package __init__ modules for the rag pass compose and emit packages to satisfy stub expectations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9ccd8369c83248cd2067068c529fc