### PR TITLE
chore(phase-7): add verification report

### DIFF
--- a/rag-app/CHANGELOG.md
+++ b/rag-app/CHANGELOG.md
@@ -11,3 +11,6 @@
 
 ### Documentation
 - README instructions for triggering the orchestrator endpoints and retrieving streamed artifacts.
+
+### Verification
+- Confirmed orchestrator endpoints, artifact streaming guards, and associated tests align with Phase 7 plans during audit (see reports/phase_7_verification.md).

--- a/rag-app/reports/phase_7_verification.md
+++ b/rag-app/reports/phase_7_verification.md
@@ -1,0 +1,33 @@
+# Phase 7 Verification
+
+## Phase 7 Checklist
+| Item | Plan Reference | Implementation Evidence | Tests | Status | Notes |
+| --- | --- | --- | --- | --- | --- |
+| Orchestrator endpoints (`/run`, `/status/{doc_id}`, `/results/{doc_id}`) orchestrate services and emit audit trail | app_plan/07_Routes_Orchestrator.md §Goals–Deliverables【F:app_plan/07_Routes_Orchestrator.md†L3-L13】 | FastAPI handlers call upload→parse→chunk→header→pass services, persist manifests, and write `pipeline.audit.json`.【F:rag-app/backend/app/routes/orchestrator.py†L60-L205】 | Unit test exercises happy path and validates audit + manifest payloads.【F:rag-app/backend/app/tests/unit/test_orchestrator_routes.py†L73-L172】 | ✅ | No remediation required. |
+| Pass manifest/result validation keeps contracts tidy | app_plan/07_Routes_Orchestrator.md §Scope【F:app_plan/07_Routes_Orchestrator.md†L7-L9】 | Routes load `PassManifest`/`PassResult` models and guard decoding errors before returning data.【F:rag-app/backend/app/routes/orchestrator.py†L125-L205】 | Unit test asserts manifest persistence and validated pass payloads.【F:rag-app/backend/app/tests/unit/test_orchestrator_routes.py†L120-L170】 | ✅ | No remediation required. |
+| Artifact streaming protects root and streams chunks | app_plan/07_Routes_Orchestrator.md §Scope–Deliverables【F:app_plan/07_Routes_Orchestrator.md†L7-L13】 | Streaming route constrains resolved paths to `ARTIFACT_ROOT` and returns async iterator from storage adapter.【F:rag-app/backend/app/routes/orchestrator.py†L208-L229】【F:rag-app/backend/app/adapters/storage.py†L1-L63】 | Unit test enforces 403 on escapes and 404 on missing files while confirming payload bytes.【F:rag-app/backend/app/tests/unit/test_orchestrator_routes.py†L226-L237】 | ✅ | No remediation required. |
+| Documentation and tooling updates for Phase 7 surface orchestrator usage | app_plan/07_Routes_Orchestrator.md §Goals【F:app_plan/07_Routes_Orchestrator.md†L3-L6】 | README documents orchestrator routes; dev requirements list lint/type/coverage tooling; changelog now includes verification summary.【F:rag-app/README.md†L1-L76】【F:rag-app/requirements-dev.txt†L1-L3】【F:rag-app/CHANGELOG.md†L1-L17】 | Covered implicitly via README instructions; no executable tests required. | ✅ | Added verification note during audit. |
+
+## Traceability Matrix
+| Plan Item | Implementation | Tests |
+| --- | --- | --- |
+| Wire orchestrator API with service `main.py` entries and return artifacts【F:app_plan/07_Routes_Orchestrator.md†L3-L12】 | Orchestrator route module dispatches to upload/parser/chunk/header/pass services and emits audit metadata.【F:rag-app/backend/app/routes/orchestrator.py†L60-L205】 | Happy-path unit test seeds service responses and asserts aggregated response fields and persisted audit file.【F:rag-app/backend/app/tests/unit/test_orchestrator_routes.py†L73-L172】 |
+| Validate manifests/results using contracts (tidy models)【F:app_plan/07_Routes_Orchestrator.md†L7-L9】 | `status` and `results` handlers parse `PassManifest`/`PassResult` models with guarded error logging.【F:rag-app/backend/app/routes/orchestrator.py†L125-L205】 | Unit tests assert validated manifests and error handling for missing manifests.【F:rag-app/backend/app/tests/unit/test_orchestrator_routes.py†L120-L223】 |
+| Provide artifact streaming endpoint with path security and chunked transfer【F:app_plan/07_Routes_Orchestrator.md†L7-L13】 | Route resolves requested paths against `ARTIFACT_ROOT` and streams via adapter-level async iterator.【F:rag-app/backend/app/routes/orchestrator.py†L208-L229】【F:rag-app/backend/app/adapters/storage.py†L37-L63】 | Unit test covers forbidden escape paths and missing artifacts, plus verifies streamed bytes.【F:rag-app/backend/app/tests/unit/test_orchestrator_routes.py†L226-L237】 |
+| Surface API usage in docs and changelog【F:app_plan/07_Routes_Orchestrator.md†L3-L6】 | README pipeline orchestrator section; changelog verification entry; dev tooling requirements file.【F:rag-app/README.md†L48-L76】【F:rag-app/CHANGELOG.md†L1-L17】【F:rag-app/requirements-dev.txt†L1-L3】 | N/A (documentation item) |
+
+## Static Checks
+- `mypy backend` (baseline issues in legacy modules: packages `__all__`, `llm.utils` spec guard, generator return hints, and controller typing).【db680e†L1-L8】【00f3bf†L1-L8】 No Phase 7 regressions detected.
+- `ruff check backend` passed with no findings.【d97dd3†L1-L2】
+- `ruff format backend` left files unchanged.【e539ae†L1-L2】
+
+## Test Summary
+- `pytest -q --maxfail=1 --disable-warnings` → 46 passed.【7aed6f†L1-L2】
+- `pytest --cov=backend/app --cov-report=term-missing` → 46 passed; coverage 87% (consistent with prior baseline).【2c30cc†L1-L101】
+
+## Cross-Phase Changes
+- Added Phase 7 verification note to the changelog to document audit completion.【F:rag-app/CHANGELOG.md†L1-L17】
+- Created this verification report for traceability.【F:rag-app/reports/phase_7_verification.md†L1-L39】
+
+## Open Issues
+- None.


### PR DESCRIPTION
## Summary
- add a Phase 7 verification report with checklist, traceability matrix, and quality summaries
- document the audit completion in the changelog verification section

## Testing
- pytest -q --maxfail=1 --disable-warnings
- pytest --cov=backend/app --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68d9d640482483248a986387d7408b39