### PR TITLE
chore: finalize phase 9 verification

### DIFF
--- a/rag-app/CHANGELOG.md
+++ b/rag-app/CHANGELOG.md
@@ -18,6 +18,12 @@
 - Existing unit tests were refactored to rely on reusable fixtures, improving determinism and
   asserting richer invariants across the pipeline stages.
 
+### Fixed
+- Route packages now explicitly re-export their service helpers to satisfy strict mypy checks and
+  clarify the functions exercised by the new route error tests.
+- Vector adapter persistence tests compare floats via `math.isclose` so type checking remains
+  strict without losing numerical robustness.
+
 ### Documentation
 - README updated with guidance for running the full pipeline using the curated fixture, refreshed
   test/coverage commands, and a description of the new data assets.
@@ -25,8 +31,9 @@
 
 ### Verification
 - Backend pytest suite expanded to 96 passing tests covering phases 1–9 with 91% line coverage
-  across `backend/app`.
-- Ruff, mypy, and pytest coverage reports executed to satisfy repo quality bars.
+  across `backend/app`, run with `-W error`.
+- Ruff, mypy (`--strict`), and pytest coverage reports executed to satisfy repo quality bars during
+  the audit.
 
 ## [Phase 8] - 2025-09-30
 ### Added

--- a/rag-app/backend/app/routes/__init__.py
+++ b/rag-app/backend/app/routes/__init__.py
@@ -1,5 +1,6 @@
 """Backend API routes for FluidRAG."""
 
+from . import chunk, headers, parser, upload
 from .chunk import router as chunk_router
 from .headers import router as headers_router
 from .orchestrator import router as orchestrator_router
@@ -8,6 +9,10 @@ from .passes import router as passes_router
 from .upload import router as upload_router
 
 __all__ = [
+    "upload",
+    "parser",
+    "chunk",
+    "headers",
     "upload_router",
     "parser_router",
     "chunk_router",

--- a/rag-app/backend/app/tests/unit/test_route_error_mapping.py
+++ b/rag-app/backend/app/tests/unit/test_route_error_mapping.py
@@ -10,10 +10,10 @@ import pytest
 from fastapi import HTTPException
 
 from ...routes import chunk, headers, parser, upload
-from ...services.chunk_service import ChunkResult
-from ...services.header_service import HeaderJoinResult
-from ...services.parser_service import ParseResult
-from ...services.upload_service import NormalizedDoc
+from ...services.chunk_service import ChunkResult, run_uf_chunking
+from ...services.header_service import HeaderJoinResult, join_and_rechunk
+from ...services.parser_service import ParseResult, parse_and_enrich
+from ...services.upload_service import NormalizedDoc, ensure_normalized
 from ...util.errors import AppError, NotFoundError, ValidationError
 
 
@@ -51,7 +51,7 @@ def _make_header_result() -> HeaderJoinResult:
 
 def test_upload_route_success(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_run_in_threadpool(func: Callable[..., Any], *args: Any) -> Any:
-        assert func is upload.ensure_normalized
+        assert func is ensure_normalized
         return _make_normalized_doc()
 
     monkeypatch.setattr(upload, "run_in_threadpool", fake_run_in_threadpool)
@@ -86,7 +86,7 @@ def test_upload_route_error_mapping(
 
 def test_chunk_route_success(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_run_in_threadpool(func: Callable[..., Any], *args: Any) -> Any:
-        assert func is chunk.run_uf_chunking
+        assert func is run_uf_chunking
         return _make_chunk_result()
 
     monkeypatch.setattr(chunk, "run_in_threadpool", fake_run_in_threadpool)
@@ -120,7 +120,7 @@ def test_chunk_route_error_mapping(
 
 def test_parser_route_success(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_run_in_threadpool(func: Callable[..., Any], *args: Any) -> Any:
-        assert func is parser.parse_and_enrich
+        assert func is parse_and_enrich
         return _make_parse_result()
 
     monkeypatch.setattr(parser, "run_in_threadpool", fake_run_in_threadpool)
@@ -158,7 +158,7 @@ def test_parser_route_error_mapping(
 
 def test_header_route_success(monkeypatch: pytest.MonkeyPatch) -> None:
     async def fake_run_in_threadpool(func: Callable[..., Any], *args: Any) -> Any:
-        assert func is headers.join_and_rechunk
+        assert func is join_and_rechunk
         return _make_header_result()
 
     monkeypatch.setattr(headers, "run_in_threadpool", fake_run_in_threadpool)

--- a/rag-app/backend/app/tests/unit/test_vectors.py
+++ b/rag-app/backend/app/tests/unit/test_vectors.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from pathlib import Path
 
 import pytest
@@ -40,7 +41,10 @@ def test_faiss_index_add_search_and_persist(tmp_path: Path) -> None:
     # Reload and ensure vectors persisted
     reloaded = FaissIndex(dim=3, index_path=str(index_path))
     results = reloaded.search([1.0, 0.0, 0.0], k=1)
-    assert results == [(0, pytest.approx(1.0))]
+    assert results, "search should return persisted vector"
+    index_id, similarity = results[0]
+    assert index_id == 0
+    assert math.isclose(similarity, 1.0, rel_tol=1e-6)
 
 
 def test_faiss_index_validates_dimensions() -> None:

--- a/rag-app/reports/phase_9_verification.md
+++ b/rag-app/reports/phase_9_verification.md
@@ -1,0 +1,61 @@
+# Phase 9 Verification Report
+
+## Phase 9 Checklist
+| Deliverable | Status | Notes |
+| --- | --- | --- |
+| Shared pytest fixtures in `backend/app/tests/conftest.py` | ✅ | Provides `sample_pdf_path`, `expected_sections`, and offline environment reset consumed across unit and e2e suites. |
+| Curated document fixture `backend/app/tests/data/documents/engineering_overview.txt` | ✅ | Serves as canonical source for normalization, parser, chunk, header, pass, and e2e pipeline tests. |
+| Expected sections payload `backend/app/tests/data/json/expected_sections.json` | ✅ | Drives header/pass assertions in upload, header, pass, and orchestrator tests. |
+| Updated upload tests (`backend/app/tests/unit/test_upload.py`) | ✅ | Validate manifest emission, stats, and header presence using curated fixture. |
+| Updated parser tests (`backend/app/tests/unit/test_parser.py`) | ✅ | Exercise enrichment paths, OCR triggering, and error handling. |
+| Updated chunk tests (`backend/app/tests/unit/test_chunk.py`) | ✅ | Assert UF chunking artifacts, hybrid search, and error handling. |
+| Updated header tests (`backend/app/tests/unit/test_headers.py`) | ✅ | Cover header detection, section mapping, sequence repair, and precision/recall benchmarks. |
+| Updated pass tests (`backend/app/tests/unit/test_passes.py`) | ✅ | Validate retrieval ranking, pass manifest generation, schema checks, and context composer. |
+| Updated pipeline e2e test (`backend/app/tests/e2e/test_pipeline_e2e.py`) | ✅ | Runs full FastAPI stack against curated fixture verifying pipeline run/status/results/artifact streaming. |
+| New storage tests (`backend/app/tests/unit/test_storage.py`) | ✅ | Cover JSON/JSONL persistence, invalid rows, streaming IO, and missing-file errors. |
+| New vector tests (`backend/app/tests/unit/test_vectors.py`) | ✅ | Exercise BM25, FAISS, hybrid search, and online/offline Qdrant paths. |
+| New pass route tests (`backend/app/tests/unit/test_pass_routes.py`) | ✅ | Validate pass manifest/list/get behaviors, error logging, and payload schema. |
+| New route error mapping tests (`backend/app/tests/unit/test_route_error_mapping.py`) | ✅ | Assert upload/parser/chunk/header routes convert service errors to HTTP status codes. |
+| New identifier tests (`backend/app/tests/unit/test_ids.py`) | ✅ | Confirm doc ID normalization and pass artifact naming. |
+| New LLM client tests (`backend/app/tests/unit/test_llm_client.py`) | ✅ | Verify offline synthesis, deterministic embeddings, and online guard rails. |
+| Pytest marker registration for Phase 9 | ✅ | `pyproject.toml` includes `phase9` marker ensuring selection parity with prior phases. |
+| Documentation/reporting updates | ✅ | `CHANGELOG.md`, `README.md`, and `reports/phase_9_outcome.md` describe fixtures, suites, and workflows; this verification adds follow-up notes. |
+
+## Traceability Matrix
+| Plan Item | Implementation | Tests & Evidence |
+| --- | --- | --- |
+| Shared fixtures (`conftest.py`) | `backend/app/tests/conftest.py` | Consumed by unit suites (upload, parser, chunk, headers, passes, storage, vectors, pass routes, route error mapping) and e2e pipeline test. |
+| Curated engineering document | `backend/app/tests/data/documents/engineering_overview.txt` | Materialized by `sample_pdf_path` fixture; referenced in upload/parser/chunk/header/pass/e2e tests. |
+| Expected headers/passes JSON | `backend/app/tests/data/json/expected_sections.json` | Used by `expected_sections` fixture for header/pass/e2e assertions. |
+| Upload normalization coverage | `backend/app/tests/unit/test_upload.py` | Asserts manifest stats, header presence, and idempotence. |
+| Parser enrichment coverage | `backend/app/tests/unit/test_parser.py` | Validates language detection, reading order, OCR branch, and error handling. |
+| Chunking & vector coverage | `backend/app/tests/unit/test_chunk.py`, `backend/app/tests/unit/test_vectors.py` | Ensures UF chunk artifacts, hybrid search behavior, FAISS persistence, Qdrant offline path. |
+| Header join/rechunk coverage | `backend/app/tests/unit/test_headers.py` | Asserts header detection, section mapping, sequence repair, and benchmarking helpers. |
+| Pass orchestration coverage | `backend/app/tests/unit/test_passes.py` | Exercises retrieval scoring, manifest writing, schema validation, and context window composer. |
+| Pipeline orchestration coverage | `backend/app/tests/e2e/test_pipeline_e2e.py`, `backend/app/tests/unit/test_pass_routes.py` | End-to-end `/pipeline/run` flow plus pass manifest/list/get routes. |
+| Storage adapter coverage | `backend/app/tests/unit/test_storage.py` | Validates JSON/JSONL IO, streaming paths, and error handling branches. |
+| Route error mapping coverage | `backend/app/tests/unit/test_route_error_mapping.py` | Confirms threadpool invocations and HTTP status translation for upload/parser/chunk/header routes. |
+| Identifier helpers | `backend/app/tests/unit/test_ids.py` | Ensures normalization and artifact naming invariants. |
+| LLM adapters | `backend/app/tests/unit/test_llm_client.py` | Verifies offline/online chat behavior and deterministic embeddings. |
+| Pytest marker | `pyproject.toml` | `phase9` marker registered to avoid deselection warnings. |
+| Documentation & reporting | `CHANGELOG.md`, `README.md`, `reports/phase_9_outcome.md`, `reports/phase_9_verification.md` | Phase 9 scope, fixture workflow, and verification outcomes recorded. |
+
+_No gaps observed: every Phase 9 plan item is implemented and exercised by deterministic tests. Final stubs omit explicit entries for new tests but runtime code matches plan specifications._
+
+## Static Checks
+- `ruff check backend/app --fix` (clean)【528741†L1-L2】
+- `ruff format backend/app` (no changes required)【2f7859†L1-L2】
+- `mypy backend/app --pretty --show-error-codes --strict` (clean)【d847ec†L1-L2】
+
+## Test Summary
+- `pytest -q --maxfail=1 --disable-warnings -W error` → 96 passed【ad0a29†L1-L3】
+- `pytest --cov=backend/app --cov-report=term-missing -W error` → 96 passed, 91% line coverage across `backend/app`【d3687d†L1-L60】
+
+## Cross-Phase Adjustments
+- Re-exported route modules in `backend/app/routes/__init__.py` so strict mypy recognizes service helpers referenced by route error tests, without altering public router APIs.【F:backend/app/routes/__init__.py†L1-L22】
+- Updated vector persistence test to use `math.isclose` and route error mapping test to compare against service functions, preserving behavior while satisfying strict typing expectations.【F:backend/app/tests/unit/test_vectors.py†L1-L47】【F:backend/app/tests/unit/test_route_error_mapping.py†L1-L194】
+
+## Residual Issues
+- Runtime warnings: None (tests executed with `-W error`).
+- Type-checking errors: None (strict mypy clean).
+- Lint/style violations: None (ruff clean).


### PR DESCRIPTION
## Summary
- re-exported route modules so strict mypy recognises the service helpers exercised by the new error mapping tests
- hardened vector persistence and route error tests to satisfy strict typing without changing runtime behaviour
- added the Phase 9 verification report capturing checklist, traceability, and tooling outcomes

## Testing
- pytest -q --maxfail=1 --disable-warnings -W error
- pytest --cov=backend/app --cov-report=term-missing -W error
- mypy backend/app --pretty --show-error-codes --strict
- ruff check backend/app --fix

------
https://chatgpt.com/codex/tasks/task_e_68da7871d9548324a1288ca3f35343e3