### PR TITLE
docs: document container host bindings for dev server

### DIFF
--- a/rag-app/PHASE_1_NOTES.md
+++ b/rag-app/PHASE_1_NOTES.md
@@ -16,6 +16,14 @@ cp .env.example .env
 python run.py  # backend on :8000, frontend on :3000
 ```
 
+When running inside a container or remote workspace where the preview needs to
+be accessed from another process (for example, Playwright-driven screenshots),
+export the host bindings first:
+
+```bash
+FRONTEND_HOST=0.0.0.0 BACKEND_HOST=0.0.0.0 python run.py
+```
+
 ## Testing
 ```bash
 pytest -q


### PR DESCRIPTION
## Summary
- note how to expose the development backend and frontend when running in a container
- add example command exporting FRONTEND_HOST and BACKEND_HOST

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dac9eb50588324b2b345460bb0fb55