### PR TITLE
Add manual stage controls to dashboard

### DIFF
--- a/rag-app/frontend/index.html
+++ b/rag-app/frontend/index.html
@@ -63,6 +63,94 @@
             <div class="pipeline-pass-results" data-pass-results></div>
           </section>
         </div>
+        <section class="stage-runner" data-stage-runner-root>
+          <header class="stage-runner-header">
+            <h3>Manual Stage Controls</h3>
+            <p>Trigger individual ingestion stages when you need to inspect intermediates.</p>
+          </header>
+          <div class="stage-runner-doc">
+            <span class="stage-label">Active document</span>
+            <span class="stage-value" data-stage-doc>—</span>
+          </div>
+          <div class="stage-runner-grid">
+            <article class="stage-card">
+              <header>
+                <h4>1. Upload</h4>
+                <p>Normalize the source file and emit <code>normalize.json</code>.</p>
+              </header>
+              <button type="button" data-stage-upload-run>Run Upload</button>
+              <p class="status" data-stage-upload-status>Idle</p>
+              <dl class="stage-details" data-stage-upload-details hidden>
+                <div class="detail-row">
+                  <dt>Doc ID</dt>
+                  <dd data-stage-upload-doc>—</dd>
+                </div>
+                <div class="detail-row">
+                  <dt>Normalized</dt>
+                  <dd data-stage-upload-path>—</dd>
+                </div>
+                <div class="detail-row">
+                  <dt>Manifest</dt>
+                  <dd data-stage-upload-manifest>—</dd>
+                </div>
+              </dl>
+            </article>
+            <article class="stage-card">
+              <header>
+                <h4>2. Preprocess</h4>
+                <p>Parse the document and generate universal file chunks.</p>
+              </header>
+              <button type="button" data-stage-preprocess-run>Run Preprocess</button>
+              <p class="status" data-stage-preprocess-status>Idle</p>
+              <dl class="stage-details" data-stage-preprocess-details hidden>
+                <div class="detail-row">
+                  <dt>Enriched parse</dt>
+                  <dd data-stage-preprocess-parse>—</dd>
+                </div>
+                <div class="detail-row">
+                  <dt>Chunk file</dt>
+                  <dd data-stage-preprocess-chunks>—</dd>
+                </div>
+              </dl>
+            </article>
+            <article class="stage-card">
+              <header>
+                <h4>3. Header search</h4>
+                <p>Detect headings, repair numbering, and re-chunk by section.</p>
+              </header>
+              <button type="button" data-stage-headers-run>Run Header Search</button>
+              <p class="status" data-stage-headers-status>Idle</p>
+              <dl class="stage-details" data-stage-headers-details hidden>
+                <div class="detail-row">
+                  <dt>Header chunks</dt>
+                  <dd data-stage-headers-path>—</dd>
+                </div>
+                <div class="detail-row">
+                  <dt>Headers found</dt>
+                  <dd data-stage-headers-count>—</dd>
+                </div>
+              </dl>
+            </article>
+            <article class="stage-card">
+              <header>
+                <h4>4. Structured passes</h4>
+                <p>Run the five retrieval passes over the header-aligned chunks.</p>
+              </header>
+              <button type="button" data-stage-passes-run>Run Passes</button>
+              <p class="status" data-stage-passes-status>Idle</p>
+              <dl class="stage-details" data-stage-passes-details hidden>
+                <div class="detail-row">
+                  <dt>Manifest</dt>
+                  <dd data-stage-passes-manifest>—</dd>
+                </div>
+                <div class="detail-row">
+                  <dt>Passes</dt>
+                  <dd data-stage-passes-count>—</dd>
+                </div>
+              </dl>
+            </article>
+          </div>
+        </section>
         <section class="card-footer">
           <button id="ping-backend" type="button">Ping Backend</button>
           <pre id="health-response" aria-live="polite"></pre>

--- a/rag-app/frontend/js/apiClient.js
+++ b/rag-app/frontend/js/apiClient.js
@@ -59,6 +59,46 @@ export class ApiClient {
     });
   }
 
+  /** POST upload normalization. */
+  async normalizeUpload({ fileId, fileName } = {}) {
+    return this._request("/upload/normalize", {
+      method: "POST",
+      body: JSON.stringify({ file_id: fileId, file_name: fileName }),
+    });
+  }
+
+  /** POST parser enrichment. */
+  async parseDocument({ docId, normalizeArtifact }) {
+    return this._request("/parser/enrich", {
+      method: "POST",
+      body: JSON.stringify({ doc_id: docId, normalize_artifact: normalizeArtifact }),
+    });
+  }
+
+  /** POST chunk generation. */
+  async chunkDocument({ docId, normalizeArtifact }) {
+    return this._request("/chunk/uf", {
+      method: "POST",
+      body: JSON.stringify({ doc_id: docId, normalize_artifact: normalizeArtifact }),
+    });
+  }
+
+  /** POST header detection and rechunking. */
+  async joinHeaders({ docId, chunksArtifact }) {
+    return this._request("/headers/join", {
+      method: "POST",
+      body: JSON.stringify({ doc_id: docId, chunks_artifact: chunksArtifact }),
+    });
+  }
+
+  /** POST pass execution. */
+  async runPasses({ docId, rechunkArtifact }) {
+    return this._request("/passes/run", {
+      method: "POST",
+      body: JSON.stringify({ doc_id: docId, rechunk_artifact: rechunkArtifact }),
+    });
+  }
+
   /** GET status. */
   async status(docId) {
     return this._request(`/pipeline/status/${encodeURIComponent(docId)}`);

--- a/rag-app/frontend/js/main.js
+++ b/rag-app/frontend/js/main.js
@@ -1,8 +1,10 @@
 import ApiClient from "./apiClient.js";
 import UploadVM from "./viewmodels/UploadVM.js";
 import PipelineVM from "./viewmodels/PipelineVM.js";
+import StageRunnerVM from "./viewmodels/StageRunnerVM.js";
 import UploadView from "./views/UploadView.js";
 import PipelineView from "./views/PipelineView.js";
+import StageRunnerView from "./views/StageRunnerView.js";
 
 const button = document.getElementById("ping-backend");
 const output = document.getElementById("health-response");
@@ -67,7 +69,9 @@ function restoreLastDocId() {
 
 const pipelineRoot = document.querySelector("[data-pipeline-root]");
 const uploadRoot = document.querySelector("[data-upload-root]");
+const stageRunnerRoot = document.querySelector("[data-stage-runner-root]");
 let pipelineView = null;
+let uploadView = null;
 if (pipelineRoot) {
   const pipelineVM = new PipelineVM(apiClient);
   pipelineView = new PipelineView(pipelineVM, pipelineRoot);
@@ -75,7 +79,7 @@ if (pipelineRoot) {
 
 if (uploadRoot && pipelineView) {
   const uploadVM = new UploadVM(apiClient);
-  new UploadView(uploadVM, uploadRoot, {
+  uploadView = new UploadView(uploadVM, uploadRoot, {
     pipelineView,
     onRun: (docId) => {
       if (!offline && docId) {
@@ -84,6 +88,21 @@ if (uploadRoot && pipelineView) {
         });
       }
     },
+  });
+}
+
+if (stageRunnerRoot) {
+  const stageRunnerVM = new StageRunnerVM(apiClient);
+  const resolveInput = () => {
+    if (uploadView?.input) {
+      return uploadView.input.value || "";
+    }
+    const input = document.querySelector("[data-upload-input]");
+    return input ? input.value : "";
+  };
+  new StageRunnerView(stageRunnerVM, stageRunnerRoot, {
+    pipelineView,
+    getInputValue: resolveInput,
   });
 }
 

--- a/rag-app/frontend/js/viewmodels/StageRunnerVM.js
+++ b/rag-app/frontend/js/viewmodels/StageRunnerVM.js
@@ -1,0 +1,186 @@
+/** Manual stage runner view-model. */
+
+export class StageRunnerVM {
+  constructor(apiClient) {
+    this.api = apiClient;
+    this.docId = "";
+    this.normalizedArtifact = "";
+    this.enrichedArtifact = "";
+    this.chunkArtifact = "";
+    this.headerChunksArtifact = "";
+    this.upload = this._defaultStageState();
+    this.preprocess = this._defaultStageState();
+    this.headers = this._defaultStageState();
+    this.passes = this._defaultStageState();
+  }
+
+  _defaultStageState() {
+    return {
+      status: "idle",
+      error: null,
+      payload: null,
+      lastUpdated: null,
+    };
+  }
+
+  _resetDownstreamStages() {
+    this.preprocess = this._defaultStageState();
+    this.headers = this._defaultStageState();
+    this.passes = this._defaultStageState();
+    this.enrichedArtifact = "";
+    this.chunkArtifact = "";
+    this.headerChunksArtifact = "";
+  }
+
+  _markStage(stage, updates) {
+    const current = this[stage] || this._defaultStageState();
+    this[stage] = {
+      ...current,
+      ...updates,
+      lastUpdated: new Date(),
+    };
+  }
+
+  _snapshot(stage) {
+    const source = this[stage] || this._defaultStageState();
+    return {
+      status: source.status,
+      error: source.error,
+      payload: source.payload,
+      lastUpdated: source.lastUpdated,
+    };
+  }
+
+  get state() {
+    return {
+      docId: this.docId,
+      normalizedArtifact: this.normalizedArtifact,
+      enrichedArtifact: this.enrichedArtifact,
+      chunkArtifact: this.chunkArtifact,
+      headerChunksArtifact: this.headerChunksArtifact,
+      upload: this._snapshot("upload"),
+      preprocess: this._snapshot("preprocess"),
+      headers: this._snapshot("headers"),
+      passes: this._snapshot("passes"),
+    };
+  }
+
+  async runUpload({ fileId = null, fileName = "" } = {}) {
+    this._markStage("upload", { status: "running", error: null });
+    try {
+      const response = await this.api.normalizeUpload({ fileId, fileName });
+      if (response && response.offline) {
+        this._markStage("upload", { status: "offline", payload: response });
+        return response;
+      }
+      this.docId = response?.doc_id || "";
+      this.normalizedArtifact = response?.normalized_path || "";
+      this._resetDownstreamStages();
+      this._markStage("upload", { status: "completed", payload: response });
+      return response;
+    } catch (err) {
+      this._markStage("upload", { status: "error", error: err });
+      throw err;
+    }
+  }
+
+  async runPreprocess() {
+    if (!this.docId || !this.normalizedArtifact) {
+      const error = new Error("Run the upload stage first.");
+      this._markStage("preprocess", { status: "error", error });
+      throw error;
+    }
+    this._markStage("preprocess", { status: "running", error: null });
+    let parseResult = null;
+    let chunkResult = null;
+    try {
+      parseResult = await this.api.parseDocument({
+        docId: this.docId,
+        normalizeArtifact: this.normalizedArtifact,
+      });
+      if (parseResult && parseResult.offline) {
+        this._markStage("preprocess", {
+          status: "offline",
+          payload: { parse: parseResult, chunk: null },
+        });
+        return { parse: parseResult, chunk: null };
+      }
+      this.enrichedArtifact = parseResult?.enriched_path || "";
+      chunkResult = await this.api.chunkDocument({
+        docId: this.docId,
+        normalizeArtifact: this.enrichedArtifact,
+      });
+      if (chunkResult && chunkResult.offline) {
+        this._markStage("preprocess", {
+          status: "offline",
+          payload: { parse: parseResult, chunk: chunkResult },
+        });
+        return { parse: parseResult, chunk: chunkResult };
+      }
+      this.chunkArtifact = chunkResult?.chunks_path || "";
+      this._markStage("preprocess", {
+        status: "completed",
+        payload: { parse: parseResult, chunk: chunkResult },
+      });
+      return { parse: parseResult, chunk: chunkResult };
+    } catch (err) {
+      this._markStage("preprocess", {
+        status: "error",
+        error: err,
+        payload: { parse: parseResult, chunk: chunkResult },
+      });
+      throw err;
+    }
+  }
+
+  async runHeaders() {
+    if (!this.docId || !this.chunkArtifact) {
+      const error = new Error("Run preprocess to generate chunks first.");
+      this._markStage("headers", { status: "error", error });
+      throw error;
+    }
+    this._markStage("headers", { status: "running", error: null });
+    try {
+      const response = await this.api.joinHeaders({
+        docId: this.docId,
+        chunksArtifact: this.chunkArtifact,
+      });
+      if (response && response.offline) {
+        this._markStage("headers", { status: "offline", payload: response });
+        return response;
+      }
+      this.headerChunksArtifact = response?.header_chunks_path || "";
+      this._markStage("headers", { status: "completed", payload: response });
+      return response;
+    } catch (err) {
+      this._markStage("headers", { status: "error", error: err });
+      throw err;
+    }
+  }
+
+  async runPasses() {
+    if (!this.docId || !this.headerChunksArtifact) {
+      const error = new Error("Run header search before executing passes.");
+      this._markStage("passes", { status: "error", error });
+      throw error;
+    }
+    this._markStage("passes", { status: "running", error: null });
+    try {
+      const response = await this.api.runPasses({
+        docId: this.docId,
+        rechunkArtifact: this.headerChunksArtifact,
+      });
+      if (response && response.offline) {
+        this._markStage("passes", { status: "offline", payload: response });
+        return response;
+      }
+      this._markStage("passes", { status: "completed", payload: response });
+      return response;
+    } catch (err) {
+      this._markStage("passes", { status: "error", error: err });
+      throw err;
+    }
+  }
+}
+
+export default StageRunnerVM;

--- a/rag-app/frontend/js/views/StageRunnerView.js
+++ b/rag-app/frontend/js/views/StageRunnerView.js
@@ -1,0 +1,292 @@
+/** Manual stage controls view. */
+
+export class StageRunnerView {
+  constructor(vm, root, { pipelineView = null, getInputValue = null } = {}) {
+    this.vm = vm;
+    this.root = root;
+    this.pipelineView = pipelineView;
+    this.getInputValue = typeof getInputValue === "function" ? getInputValue : () => "";
+
+    this.docDisplay = root ? root.querySelector("[data-stage-doc]") : null;
+
+    this.uploadButton = root ? root.querySelector("[data-stage-upload-run]") : null;
+    this.uploadStatus = root ? root.querySelector("[data-stage-upload-status]") : null;
+    this.uploadDetails = root ? root.querySelector("[data-stage-upload-details]") : null;
+    this.uploadDoc = root ? root.querySelector("[data-stage-upload-doc]") : null;
+    this.uploadPath = root ? root.querySelector("[data-stage-upload-path]") : null;
+    this.uploadManifest = root
+      ? root.querySelector("[data-stage-upload-manifest]")
+      : null;
+
+    this.preprocessButton = root
+      ? root.querySelector("[data-stage-preprocess-run]")
+      : null;
+    this.preprocessStatus = root
+      ? root.querySelector("[data-stage-preprocess-status]")
+      : null;
+    this.preprocessDetails = root
+      ? root.querySelector("[data-stage-preprocess-details]")
+      : null;
+    this.preprocessParse = root
+      ? root.querySelector("[data-stage-preprocess-parse]")
+      : null;
+    this.preprocessChunks = root
+      ? root.querySelector("[data-stage-preprocess-chunks]")
+      : null;
+
+    this.headersButton = root ? root.querySelector("[data-stage-headers-run]") : null;
+    this.headersStatus = root ? root.querySelector("[data-stage-headers-status]") : null;
+    this.headersDetails = root
+      ? root.querySelector("[data-stage-headers-details]")
+      : null;
+    this.headersPath = root ? root.querySelector("[data-stage-headers-path]") : null;
+    this.headersCount = root
+      ? root.querySelector("[data-stage-headers-count]")
+      : null;
+
+    this.passesButton = root ? root.querySelector("[data-stage-passes-run]") : null;
+    this.passesStatus = root ? root.querySelector("[data-stage-passes-status]") : null;
+    this.passesDetails = root
+      ? root.querySelector("[data-stage-passes-details]")
+      : null;
+    this.passesManifest = root
+      ? root.querySelector("[data-stage-passes-manifest]")
+      : null;
+    this.passesCount = root
+      ? root.querySelector("[data-stage-passes-count]")
+      : null;
+
+    this._bindEvents();
+    this.render();
+  }
+
+  _bindEvents() {
+    if (this.uploadButton) {
+      this.uploadButton.addEventListener("click", () => {
+        void this._handleUpload();
+      });
+    }
+    if (this.preprocessButton) {
+      this.preprocessButton.addEventListener("click", () => {
+        void this._handlePreprocess();
+      });
+    }
+    if (this.headersButton) {
+      this.headersButton.addEventListener("click", () => {
+        void this._handleHeaders();
+      });
+    }
+    if (this.passesButton) {
+      this.passesButton.addEventListener("click", () => {
+        void this._handlePasses();
+      });
+    }
+  }
+
+  _setText(node, value) {
+    if (node) {
+      node.textContent = value;
+    }
+  }
+
+  _toggle(node, shouldShow) {
+    if (node) {
+      node.hidden = !shouldShow;
+    }
+  }
+
+  _formatStatus(stageState) {
+    if (!stageState) {
+      return "Idle";
+    }
+    if (stageState.status === "error" && stageState.error) {
+      return `Error: ${stageState.error.message || String(stageState.error)}`;
+    }
+    switch (stageState.status) {
+      case "running":
+        return "Running...";
+      case "completed":
+        return "Completed";
+      case "offline":
+        return "Offline mode";
+      case "idle":
+      default:
+        return "Idle";
+    }
+  }
+
+  _persistDocId(docId) {
+    if (!docId) {
+      return;
+    }
+    try {
+      window.localStorage.setItem("fluidrag:lastDocId", docId);
+    } catch (err) {
+      console.warn("Unable to persist doc id", err);
+    }
+  }
+
+  async _handleUpload() {
+    if (!this.uploadButton) {
+      return;
+    }
+    const source = this.getInputValue() || "";
+    if (!source.trim()) {
+      this._setText(this.uploadStatus, "Enter a document path or ID.");
+      return;
+    }
+    this.uploadButton.disabled = true;
+    const promise = this.vm.runUpload({ fileName: source.trim(), fileId: null });
+    this.render();
+    try {
+      const response = await promise;
+      if (!response?.offline && this.vm.docId) {
+        this._persistDocId(this.vm.docId);
+      }
+    } catch (err) {
+      console.warn("Upload stage failed", err);
+    } finally {
+      this.uploadButton.disabled = false;
+      this.render();
+    }
+  }
+
+  async _handlePreprocess() {
+    if (!this.preprocessButton) {
+      return;
+    }
+    this.preprocessButton.disabled = true;
+    const promise = this.vm.runPreprocess();
+    this.render();
+    try {
+      await promise;
+    } catch (err) {
+      console.warn("Preprocess stage failed", err);
+    } finally {
+      this.preprocessButton.disabled = false;
+      this.render();
+    }
+  }
+
+  async _handleHeaders() {
+    if (!this.headersButton) {
+      return;
+    }
+    this.headersButton.disabled = true;
+    const promise = this.vm.runHeaders();
+    this.render();
+    try {
+      await promise;
+    } catch (err) {
+      console.warn("Header stage failed", err);
+    } finally {
+      this.headersButton.disabled = false;
+      this.render();
+    }
+  }
+
+  async _handlePasses() {
+    if (!this.passesButton) {
+      return;
+    }
+    this.passesButton.disabled = true;
+    const promise = this.vm.runPasses();
+    this.render();
+    try {
+      const payload = await promise;
+      if (!payload?.offline && this.pipelineView && this.vm.docId) {
+        void this.pipelineView.refresh(this.vm.docId);
+      }
+    } catch (err) {
+      console.warn("Pass stage failed", err);
+    } finally {
+      this.passesButton.disabled = false;
+      this.render();
+    }
+  }
+
+  render() {
+    if (!this.root) {
+      return;
+    }
+    const state = this.vm.state;
+    this._setText(this.docDisplay, state.docId || "—");
+
+    this._setText(this.uploadStatus, this._formatStatus(state.upload));
+    const hasUploadPayload = Boolean(
+      state.upload?.payload && !state.upload.payload?.offline
+    );
+    this._toggle(this.uploadDetails, hasUploadPayload);
+    if (hasUploadPayload) {
+      this._setText(this.uploadDoc, state.docId || "—");
+      this._setText(this.uploadPath, state.normalizedArtifact || "—");
+      this._setText(
+        this.uploadManifest,
+        state.upload?.payload?.manifest_path || "—"
+      );
+    }
+
+    this._setText(this.preprocessStatus, this._formatStatus(state.preprocess));
+    const preprocessPayload = state.preprocess?.payload || {};
+    const hasPreprocessPayload = Boolean(
+      preprocessPayload.parse && !preprocessPayload.parse?.offline
+    );
+    this._toggle(this.preprocessDetails, hasPreprocessPayload);
+    if (hasPreprocessPayload) {
+      this._setText(
+        this.preprocessParse,
+        preprocessPayload.parse?.enriched_path || state.enrichedArtifact || "—"
+      );
+      this._setText(
+        this.preprocessChunks,
+        preprocessPayload.chunk?.chunks_path || state.chunkArtifact || "—"
+      );
+    }
+
+    this._setText(this.headersStatus, this._formatStatus(state.headers));
+    const hasHeadersPayload = Boolean(
+      state.headers?.payload && !state.headers.payload?.offline
+    );
+    this._toggle(this.headersDetails, hasHeadersPayload);
+    if (hasHeadersPayload) {
+      this._setText(
+        this.headersPath,
+        state.headers.payload?.header_chunks_path || state.headerChunksArtifact || "—"
+      );
+      this._setText(
+        this.headersCount,
+        String(state.headers.payload?.header_count ?? "—")
+      );
+    }
+
+    this._setText(this.passesStatus, this._formatStatus(state.passes));
+    const hasPassesPayload = Boolean(
+      state.passes?.payload && !state.passes.payload?.offline
+    );
+    this._toggle(this.passesDetails, hasPassesPayload);
+    if (hasPassesPayload) {
+      const passNames = Object.keys(state.passes.payload?.passes || {});
+      this._setText(this.passesManifest, state.passes.payload?.manifest_path || "—");
+      this._setText(this.passesCount, String(passNames.length));
+    }
+
+    if (this.uploadButton) {
+      this.uploadButton.disabled = state.upload.status === "running";
+    }
+    if (this.preprocessButton) {
+      const canRun = Boolean(state.normalizedArtifact);
+      this.preprocessButton.disabled =
+        !canRun || state.preprocess.status === "running";
+    }
+    if (this.headersButton) {
+      const canRun = Boolean(state.chunkArtifact);
+      this.headersButton.disabled = !canRun || state.headers.status === "running";
+    }
+    if (this.passesButton) {
+      const canRun = Boolean(state.headerChunksArtifact);
+      this.passesButton.disabled = !canRun || state.passes.status === "running";
+    }
+  }
+}
+
+export default StageRunnerView;

--- a/rag-app/frontend/styles/app.css
+++ b/rag-app/frontend/styles/app.css
@@ -210,6 +210,101 @@ body {
   gap: 1rem;
 }
 
+.stage-runner {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  background: rgba(6, 16, 28, 0.55);
+  border-radius: 1rem;
+  padding: 1.5rem;
+}
+
+.stage-runner-header h3 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.stage-runner-header p {
+  margin: 0.25rem 0 0;
+  opacity: 0.8;
+}
+
+.stage-runner-doc {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+}
+
+.stage-label {
+  opacity: 0.7;
+  font-weight: 600;
+}
+
+.stage-value {
+  font-weight: 700;
+}
+
+.stage-runner-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
+  gap: 1.25rem;
+}
+
+.stage-card {
+  background: rgba(8, 20, 32, 0.75);
+  border-radius: 1rem;
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-height: 14rem;
+}
+
+.stage-card header h4 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.stage-card header p {
+  margin: 0.25rem 0 0;
+  font-size: 0.9rem;
+  opacity: 0.75;
+}
+
+.stage-card button {
+  align-self: flex-start;
+}
+
+.stage-details {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.stage-details .detail-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  font-size: 0.85rem;
+}
+
+.stage-details dt {
+  margin: 0;
+  opacity: 0.7;
+}
+
+.stage-details dd {
+  margin: 0;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  text-align: right;
+  word-break: break-all;
+}
+
 button {
   margin: 0;
   padding: 0.75rem 1.5rem;
@@ -254,6 +349,10 @@ button:disabled {
 
   .card {
     padding: 1.5rem;
+  }
+
+  .stage-runner-grid {
+    grid-template-columns: 1fr;
   }
 
   .field-row {


### PR DESCRIPTION
## Summary
- add a passes/run endpoint so the structured passes can be triggered independently
- expose stage-specific client helpers and render manual stage controls in the dashboard
- style the new controls and ensure the pipeline monitor refreshes after passes complete

## Testing
- pytest backend/app/tests/unit/test_pass_routes.py


------
https://chatgpt.com/codex/tasks/task_e_68db028664848324a2fc83b62911763b