### PR TITLE
feat: implement secure upload pipeline and parser enrichment

### DIFF
--- a/docs/artifacts/phase1_finalstubs_crosswalk.json
+++ b/docs/artifacts/phase1_finalstubs_crosswalk.json
@@ -1,0 +1,1622 @@
+{
+  "timestamp": "2025-09-30T01:04:47.086662Z",
+  "files": [
+    {
+      "file_path": "rag-app/run.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "start_backend",
+          "type": "function",
+          "status": "present",
+          "lineno": 23
+        },
+        {
+          "name": "start_frontend",
+          "type": "function",
+          "status": "present",
+          "lineno": 47
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/.env",
+      "exists": false,
+      "language": "text"
+    },
+    {
+      "file_path": "rag-app/README.md",
+      "exists": true,
+      "language": "markdown"
+    },
+    {
+      "file_path": "rag-app/.gitignore",
+      "exists": true,
+      "language": "text"
+    },
+    {
+      "file_path": "rag-app/data/.gitkeep",
+      "exists": true,
+      "language": "text"
+    },
+    {
+      "file_path": "rag-app/backend/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/main.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "create_app",
+          "type": "function",
+          "status": "present",
+          "lineno": 62
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/config.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "Settings",
+          "type": "class",
+          "status": "present",
+          "lineno": 14
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/routes/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/routes/orchestrator.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "PipelineRunRequest",
+          "type": "class",
+          "status": "present",
+          "lineno": 36
+        },
+        {
+          "name": "run_pipeline",
+          "type": "function",
+          "status": "present",
+          "lineno": 126
+        },
+        {
+          "name": "status",
+          "type": "function",
+          "status": "present",
+          "lineno": 232
+        },
+        {
+          "name": "results",
+          "type": "function",
+          "status": "present",
+          "lineno": 271
+        },
+        {
+          "name": "stream_artifact",
+          "type": "function",
+          "status": "present",
+          "lineno": 325
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/routes/upload.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/routes/parser.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/routes/chunk.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/routes/headers.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/routes/passes.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/upload_service/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/upload_service/main.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "NormalizedDoc",
+          "type": "class",
+          "status": "present",
+          "lineno": 11
+        },
+        {
+          "name": "ensure_normalized",
+          "type": "function",
+          "status": "present",
+          "lineno": 22
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/upload_service/upload_controller.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "NormalizedDocInternal",
+          "type": "class",
+          "status": "present",
+          "lineno": 24
+        },
+        {
+          "name": "ensure_normalized",
+          "type": "function",
+          "status": "present",
+          "lineno": 35
+        },
+        {
+          "name": "make_doc_id",
+          "type": "function",
+          "status": "present",
+          "lineno": 86
+        },
+        {
+          "name": "handle_upload_errors",
+          "type": "function",
+          "status": "present",
+          "lineno": 94
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/upload_service/packages/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/upload_service/packages/guards/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/upload_service/packages/guards/validators.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "validate_upload_inputs",
+          "type": "function",
+          "status": "present",
+          "lineno": 10
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/upload_service/packages/normalize/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/upload_service/packages/normalize/pdf_reader.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "normalize_pdf",
+          "type": "function",
+          "status": "present",
+          "lineno": 68
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/upload_service/packages/normalize/ocr.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "try_ocr_if_needed",
+          "type": "function",
+          "status": "present",
+          "lineno": 15
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/upload_service/packages/emit/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/upload_service/packages/emit/manifest.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "write_manifest",
+          "type": "function",
+          "status": "present",
+          "lineno": 12
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/parser_service/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/parser_service/main.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "ParseResult",
+          "type": "class",
+          "status": "present",
+          "lineno": 11
+        },
+        {
+          "name": "parse_and_enrich",
+          "type": "function",
+          "status": "present",
+          "lineno": 21
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/parser_service/parser_controller.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "ParseInternal",
+          "type": "class",
+          "status": "present",
+          "lineno": 32
+        },
+        {
+          "name": "parse_and_enrich",
+          "type": "function",
+          "status": "present",
+          "lineno": 110
+        },
+        {
+          "name": "handle_parser_errors",
+          "type": "function",
+          "status": "present",
+          "lineno": 189
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/parser_service/packages/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/parser_service/packages/detect/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/parser_service/packages/detect/language.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "detect_language",
+          "type": "function",
+          "status": "present",
+          "lineno": 16
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/parser_service/packages/extract/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/parser_service/packages/extract/pdf_text.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "extract_text_blocks",
+          "type": "function",
+          "status": "present",
+          "lineno": 8
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/parser_service/packages/extract/tables.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "extract_tables",
+          "type": "function",
+          "status": "present",
+          "lineno": 11
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/parser_service/packages/extract/images.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "extract_images",
+          "type": "function",
+          "status": "present",
+          "lineno": 8
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/parser_service/packages/extract/links.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "extract_links",
+          "type": "function",
+          "status": "present",
+          "lineno": 11
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/parser_service/packages/ocr/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/parser_service/packages/ocr/ocr_router.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "maybe_ocr",
+          "type": "function",
+          "status": "present",
+          "lineno": 10
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/parser_service/packages/enhance/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/parser_service/packages/enhance/reading_order.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "build_reading_order",
+          "type": "function",
+          "status": "present",
+          "lineno": 18
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/parser_service/packages/enhance/semantics.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "infer_semantics",
+          "type": "function",
+          "status": "present",
+          "lineno": 8
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/parser_service/packages/enhance/lists_bullets.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "detect_lists_bullets",
+          "type": "function",
+          "status": "present",
+          "lineno": 11
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/parser_service/packages/merge/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/parser_service/packages/merge/merger.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "merge_all",
+          "type": "function",
+          "status": "present",
+          "lineno": 8
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/chunk_service/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/chunk_service/main.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "ChunkResult",
+          "type": "class",
+          "status": "present",
+          "lineno": 11
+        },
+        {
+          "name": "run_uf_chunking",
+          "type": "function",
+          "status": "present",
+          "lineno": 20
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/chunk_service/chunk_controller.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "ChunkInternal",
+          "type": "class",
+          "status": "present",
+          "lineno": 24
+        },
+        {
+          "name": "run_uf_chunking",
+          "type": "function",
+          "status": "present",
+          "lineno": 41
+        },
+        {
+          "name": "handle_chunk_errors",
+          "type": "function",
+          "status": "present",
+          "lineno": 124
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/chunk_service/packages/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/chunk_service/packages/segment/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/chunk_service/packages/segment/sentences.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "split_sentences",
+          "type": "function",
+          "status": "present",
+          "lineno": 45
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/chunk_service/packages/segment/uf_chunker.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "uf_chunk",
+          "type": "function",
+          "status": "present",
+          "lineno": 27
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/chunk_service/packages/features/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/chunk_service/packages/features/typography.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "extract_typography",
+          "type": "function",
+          "status": "present",
+          "lineno": 35
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/chunk_service/packages/index/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/chunk_service/packages/index/local_vss.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "build_local_index",
+          "type": "function",
+          "status": "present",
+          "lineno": 32
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/header_service/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/header_service/main.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "HeaderJoinResult",
+          "type": "class",
+          "status": "present",
+          "lineno": 11
+        },
+        {
+          "name": "join_and_rechunk",
+          "type": "function",
+          "status": "present",
+          "lineno": 22
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/header_service/header_controller.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "HeaderJoinInternal",
+          "type": "class",
+          "status": "present",
+          "lineno": 28
+        },
+        {
+          "name": "join_and_rechunk",
+          "type": "function",
+          "status": "present",
+          "lineno": 91
+        },
+        {
+          "name": "handle_header_errors",
+          "type": "function",
+          "status": "present",
+          "lineno": 188
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/header_service/packages/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/header_service/packages/heur/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/header_service/packages/heur/regex_bank.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "find_header_candidates",
+          "type": "function",
+          "status": "present",
+          "lineno": 139
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/header_service/packages/score/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/header_service/packages/score/typo_features.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "score_typo",
+          "type": "function",
+          "status": "present",
+          "lineno": 12
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/header_service/packages/join/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/header_service/packages/join/stitcher.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "stitch_headers",
+          "type": "function",
+          "status": "present",
+          "lineno": 12
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/header_service/packages/repair/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/header_service/packages/repair/sequence.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "repair_sequence",
+          "type": "function",
+          "status": "present",
+          "lineno": 19
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/header_service/packages/rechunk/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/header_service/packages/rechunk/by_headers.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "rechunk_by_headers",
+          "type": "function",
+          "status": "present",
+          "lineno": 35
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/rag_pass_service/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/rag_pass_service/main.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "PassJobs",
+          "type": "class",
+          "status": "present",
+          "lineno": 11
+        },
+        {
+          "name": "run_all",
+          "type": "function",
+          "status": "present",
+          "lineno": 19
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/rag_pass_service/passes_controller.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "PassJobsInternal",
+          "type": "class",
+          "status": "present",
+          "lineno": 38
+        },
+        {
+          "name": "run_all",
+          "type": "function",
+          "status": "present",
+          "lineno": 67
+        },
+        {
+          "name": "handle_pass_errors",
+          "type": "function",
+          "status": "present",
+          "lineno": 131
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/rag_pass_service/packages/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/rag_pass_service/packages/retrieval/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/rag_pass_service/packages/retrieval/hybrid.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "retrieve_ranked",
+          "type": "function",
+          "status": "present",
+          "lineno": 17
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/rag_pass_service/packages/rank/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/rag_pass_service/packages/rank/fluid.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "flow_score",
+          "type": "function",
+          "status": "present",
+          "lineno": 8
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/rag_pass_service/packages/rank/hep.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "energy_score",
+          "type": "function",
+          "status": "present",
+          "lineno": 8
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/rag_pass_service/packages/rank/graph.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "graph_score",
+          "type": "function",
+          "status": "present",
+          "lineno": 8
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/rag_pass_service/packages/compose/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/rag_pass_service/packages/compose/context.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "compose_window",
+          "type": "function",
+          "status": "present",
+          "lineno": 8
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/rag_pass_service/packages/prompts/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/rag_pass_service/packages/prompts/mechanical.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "Prompt",
+          "type": "class",
+          "status": "present",
+          "lineno": 9
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/rag_pass_service/packages/prompts/electrical.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "Prompt",
+          "type": "class",
+          "status": "present",
+          "lineno": 9
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/rag_pass_service/packages/prompts/software.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "Prompt",
+          "type": "class",
+          "status": "present",
+          "lineno": 9
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/rag_pass_service/packages/prompts/controls.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "Prompt",
+          "type": "class",
+          "status": "present",
+          "lineno": 9
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/rag_pass_service/packages/prompts/project_mgmt.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "Prompt",
+          "type": "class",
+          "status": "present",
+          "lineno": 9
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/services/rag_pass_service/packages/emit/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/services/rag_pass_service/packages/emit/results.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "write_pass_results",
+          "type": "function",
+          "status": "present",
+          "lineno": 23
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/adapters/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/adapters/storage.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "write_json",
+          "type": "function",
+          "status": "present",
+          "lineno": 24
+        },
+        {
+          "name": "write_jsonl",
+          "type": "function",
+          "status": "present",
+          "lineno": 35
+        },
+        {
+          "name": "read_jsonl",
+          "type": "function",
+          "status": "present",
+          "lineno": 48
+        },
+        {
+          "name": "ensure_parent_dirs",
+          "type": "function",
+          "status": "present",
+          "lineno": 17
+        },
+        {
+          "name": "stream_read",
+          "type": "function",
+          "status": "present",
+          "lineno": 69
+        },
+        {
+          "name": "stream_write",
+          "type": "function",
+          "status": "present",
+          "lineno": 87
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/adapters/vectors.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "EmbeddingModel",
+          "type": "class",
+          "status": "present",
+          "lineno": 23
+        },
+        {
+          "name": "BM25Index",
+          "type": "class",
+          "status": "present",
+          "lineno": 36
+        },
+        {
+          "name": "FaissIndex",
+          "type": "class",
+          "status": "present",
+          "lineno": 96
+        },
+        {
+          "name": "QdrantIndex",
+          "type": "class",
+          "status": "present",
+          "lineno": 152
+        },
+        {
+          "name": "hybrid_search",
+          "type": "function",
+          "status": "present",
+          "lineno": 192
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/adapters/llm.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "call_llm",
+          "type": "function",
+          "status": "present",
+          "lineno": 16
+        },
+        {
+          "name": "LLMClient",
+          "type": "class",
+          "status": "present",
+          "lineno": 23
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/adapters/db.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "upsert_document_record",
+          "type": "function",
+          "status": "present",
+          "lineno": 16
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/contracts/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/contracts/ids.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/contracts/ingest.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/contracts/parsing.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/contracts/chunking.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/contracts/headers.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/contracts/passes.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/util/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/util/logging.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "get_logger",
+          "type": "function",
+          "status": "present",
+          "lineno": 109
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/util/audit.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "stage_record",
+          "type": "function",
+          "status": "present",
+          "lineno": 18
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/tests/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/tests/e2e/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/tests/e2e/test_pipeline_e2e.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "test_pipeline_e2e",
+          "type": "function",
+          "status": "missing",
+          "lineno": null
+        },
+        {
+          "name": "load_test_pdf_paths",
+          "type": "function",
+          "status": "missing",
+          "lineno": null
+        },
+        {
+          "name": "test_pipeline_real_pdf",
+          "type": "function",
+          "status": "missing",
+          "lineno": null
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/tests/unit/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/tests/unit/test_upload.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "test_test_upload",
+          "type": "function",
+          "status": "missing",
+          "lineno": null
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/tests/unit/test_parser.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "test_test_parser",
+          "type": "function",
+          "status": "missing",
+          "lineno": null
+        },
+        {
+          "name": "test_parser_with_tables_and_ocr",
+          "type": "function",
+          "status": "missing",
+          "lineno": null
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/tests/unit/test_chunk.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "test_test_chunk",
+          "type": "function",
+          "status": "missing",
+          "lineno": null
+        },
+        {
+          "name": "test_uf_chunk_boundaries",
+          "type": "function",
+          "status": "present",
+          "lineno": 81
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/tests/unit/test_headers.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "test_test_headers",
+          "type": "function",
+          "status": "missing",
+          "lineno": null
+        },
+        {
+          "name": "test_sequence_repair_recovers_missing_headers",
+          "type": "function",
+          "status": "present",
+          "lineno": 104
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/tests/unit/test_passes.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "test_test_passes",
+          "type": "function",
+          "status": "present",
+          "lineno": 52
+        },
+        {
+          "name": "test_hybrid_retrieval_ranking",
+          "type": "function",
+          "status": "present",
+          "lineno": 59
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/tests/contracts/__init__.py",
+      "exists": true,
+      "language": "python"
+    },
+    {
+      "file_path": "rag-app/backend/app/tests/contracts/test_contract_shapes.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "test_contract_shapes",
+          "type": "function",
+          "status": "missing",
+          "lineno": null
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/frontend/index.html",
+      "exists": true,
+      "language": "html"
+    },
+    {
+      "file_path": "rag-app/frontend/styles/app.css",
+      "exists": true,
+      "language": "css"
+    },
+    {
+      "file_path": "rag-app/frontend/js/main.js",
+      "exists": true,
+      "language": "javascript"
+    },
+    {
+      "file_path": "rag-app/frontend/js/apiClient.js",
+      "exists": true,
+      "language": "javascript",
+      "declared_types": [
+        {
+          "name": "ApiClient",
+          "type": "class",
+          "status": "missing",
+          "lineno": null
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/frontend/js/models/JobModel.js",
+      "exists": true,
+      "language": "javascript",
+      "declared_types": [
+        {
+          "name": "JobModel",
+          "type": "class",
+          "status": "missing",
+          "lineno": null
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/frontend/js/models/PassResultModel.js",
+      "exists": true,
+      "language": "javascript",
+      "declared_types": [
+        {
+          "name": "PassResultModel",
+          "type": "class",
+          "status": "missing",
+          "lineno": null
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/frontend/js/viewmodels/UploadVM.js",
+      "exists": true,
+      "language": "javascript",
+      "declared_types": [
+        {
+          "name": "UploadVM",
+          "type": "class",
+          "status": "missing",
+          "lineno": null
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/frontend/js/viewmodels/PipelineVM.js",
+      "exists": true,
+      "language": "javascript",
+      "declared_types": [
+        {
+          "name": "PipelineVM",
+          "type": "class",
+          "status": "missing",
+          "lineno": null
+        },
+        {
+          "name": "pollProgress",
+          "type": "function",
+          "status": "missing",
+          "lineno": null
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/frontend/js/views/UploadView.js",
+      "exists": true,
+      "language": "javascript",
+      "declared_types": [
+        {
+          "name": "UploadView",
+          "type": "class",
+          "status": "missing",
+          "lineno": null
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/frontend/js/views/PipelineView.js",
+      "exists": true,
+      "language": "javascript",
+      "declared_types": [
+        {
+          "name": "PipelineView",
+          "type": "class",
+          "status": "missing",
+          "lineno": null
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/frontend/js/views/ResultsView.js",
+      "exists": true,
+      "language": "javascript",
+      "declared_types": [
+        {
+          "name": "ResultsView",
+          "type": "class",
+          "status": "missing",
+          "lineno": null
+        },
+        {
+          "name": "downloadArtifact",
+          "type": "function",
+          "status": "missing",
+          "lineno": null
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/util/errors.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "AppError",
+          "type": "class",
+          "status": "present",
+          "lineno": 6
+        },
+        {
+          "name": "ValidationError",
+          "type": "class",
+          "status": "present",
+          "lineno": 10
+        },
+        {
+          "name": "NotFoundError",
+          "type": "class",
+          "status": "present",
+          "lineno": 14
+        },
+        {
+          "name": "ExternalServiceError",
+          "type": "class",
+          "status": "present",
+          "lineno": 18
+        },
+        {
+          "name": "RetryExhaustedError",
+          "type": "class",
+          "status": "present",
+          "lineno": 22
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/util/retry.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "RetryPolicy",
+          "type": "class",
+          "status": "present",
+          "lineno": 15
+        },
+        {
+          "name": "CircuitBreaker",
+          "type": "class",
+          "status": "present",
+          "lineno": 58
+        },
+        {
+          "name": "with_retries",
+          "type": "function",
+          "status": "present",
+          "lineno": 107
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/llm/utils.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "windows_curl",
+          "type": "function",
+          "status": "present",
+          "lineno": 22
+        },
+        {
+          "name": "log_prompt",
+          "type": "function",
+          "status": "present",
+          "lineno": 36
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/llm/utils/envsafe.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "mask_bearer",
+          "type": "function",
+          "status": "present",
+          "lineno": 8
+        },
+        {
+          "name": "openrouter_headers",
+          "type": "function",
+          "status": "present",
+          "lineno": 18
+        },
+        {
+          "name": "masked_headers",
+          "type": "function",
+          "status": "present",
+          "lineno": 39
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/llm/openrouter.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "OpenRouterAuthError",
+          "type": "class",
+          "status": "present",
+          "lineno": 18
+        },
+        {
+          "name": "OpenRouterHTTPError",
+          "type": "class",
+          "status": "present",
+          "lineno": 22
+        },
+        {
+          "name": "chat",
+          "type": "function",
+          "status": "present",
+          "lineno": 26
+        }
+      ]
+    },
+    {
+      "file_path": "rag-app/backend/app/llm/clients/openrouter.py",
+      "exists": true,
+      "language": "python",
+      "declared_types": [
+        {
+          "name": "OpenRouterError",
+          "type": "class",
+          "status": "present",
+          "lineno": 25
+        },
+        {
+          "name": "OpenRouterAuthError",
+          "type": "class",
+          "status": "present",
+          "lineno": 29
+        },
+        {
+          "name": "OpenRouterHTTPError",
+          "type": "class",
+          "status": "present",
+          "lineno": 33
+        },
+        {
+          "name": "OpenRouterStreamError",
+          "type": "class",
+          "status": "present",
+          "lineno": 37
+        },
+        {
+          "name": "_backoff",
+          "type": "function",
+          "status": "present",
+          "lineno": 108
+        },
+        {
+          "name": "chat_sync",
+          "type": "function",
+          "status": "present",
+          "lineno": 124
+        },
+        {
+          "name": "chat_stream_async",
+          "type": "function",
+          "status": "present",
+          "lineno": 240
+        },
+        {
+          "name": "embed_sync",
+          "type": "function",
+          "status": "present",
+          "lineno": 323
+        }
+      ]
+    }
+  ]
+}

--- a/docs/artifacts/phase1_inventory.json
+++ b/docs/artifacts/phase1_inventory.json
@@ -1,0 +1,326 @@
+{
+  "timestamp": "2025-09-30T01:05:43.231085+00:00",
+  "server": {
+    "entrypoints": [
+      {
+        "path": "rag-app/run.py",
+        "symbol": "start_backend",
+        "factory_target": "backend.app.main:create_app",
+        "line_start": 23,
+        "line_end": 44
+      },
+      {
+        "path": "rag-app/run.py",
+        "symbol": "start_frontend",
+        "line_start": 47,
+        "line_end": 70
+      },
+      {
+        "path": "rag-app/run.py",
+        "symbol": "main",
+        "line_start": 89,
+        "line_end": 120
+      }
+    ],
+    "settings": {
+      "path": "rag-app/backend/app/config.py",
+      "fields": {
+        "backend_host": 8000,
+        "backend_port": 8000,
+        "frontend_port": 3000,
+        "artifact_root": "rag-app/data/artifacts",
+        "upload_ocr_threshold": 0.85,
+        "chunk_target_tokens": 90,
+        "chunk_token_overlap": 12,
+        "parser_timeout_seconds": 1.0
+      }
+    },
+    "health_routes": [
+      {
+        "path": "/health",
+        "method": "GET",
+        "module": "rag-app/backend/app/main.py",
+        "line_start": 96,
+        "line_end": 98
+      }
+    ]
+  },
+  "upload": {
+    "routes": [
+      {
+        "path": "/upload/normalize",
+        "method": "POST",
+        "request_model": "UploadRequest(file_id?: str, file_name?: str)",
+        "response_model": "NormalizedDoc",
+        "module": "rag-app/backend/app/routes/upload.py",
+        "line_start": 23,
+        "line_end": 34
+      }
+    ],
+    "validation": {
+      "function": "validate_upload_inputs",
+      "module": "rag-app/backend/app/services/upload_service/packages/guards/validators.py",
+      "guards": [
+        "requires file_id or file_name",
+        "rejects blank/whitespace file_id",
+        "rejects remote paths (contains //)",
+        "rejects path traversal (..)",
+        "rejects newline characters"
+      ],
+      "missing": [
+        "no extension allowlist",
+        "no MIME sniffing",
+        "no double-extension guard",
+        "no file size enforcement"
+      ],
+      "line_start": 10,
+      "line_end": 38
+    },
+    "storage": {
+      "doc_id": {
+        "generator": "make_doc_id",
+        "hash": "sha1(timestamp + seed)",
+        "line_start": 86,
+        "line_end": 91
+      },
+      "artifact_root": "Settings.artifact_root (rag-app/data/artifacts)",
+      "normalized_artifact": {
+        "path": "normalize.json",
+        "line_start": 35,
+        "line_end": 83
+      }
+    },
+    "normalization": {
+      "reader": "normalize_pdf",
+      "module": "rag-app/backend/app/services/upload_service/packages/normalize/pdf_reader.py",
+      "features": [
+        "treats input as text",
+        "splits on form-feed/double blank lines",
+        "infers headings via uppercase ratio",
+        "stub images via [image:name] markers"
+      ],
+      "line_start": 68,
+      "line_end": 153
+    },
+    "ocr": {
+      "function": "try_ocr_if_needed",
+      "threshold_env": "UPLOAD_OCR_THRESHOLD",
+      "line_start": 15,
+      "line_end": 83
+    },
+    "checksums": {
+      "function": "write_manifest",
+      "algorithm": "sha256",
+      "line_start": 12,
+      "line_end": 30
+    },
+    "response": {
+      "model": "NormalizedDoc",
+      "fields": [
+        "doc_id",
+        "normalized_path",
+        "manifest_path",
+        "avg_coverage",
+        "block_count",
+        "ocr_performed"
+      ],
+      "line_start": 11,
+      "line_end": 19
+    }
+  },
+  "parser": {
+    "routes": [
+      {
+        "path": "/parser/enrich",
+        "method": "POST",
+        "request_model": "ParserRequest(doc_id: str, normalize_artifact: str)",
+        "response_model": "ParseResult",
+        "module": "rag-app/backend/app/routes/parser.py",
+        "line_start": 23,
+        "line_end": 34
+      }
+    ],
+    "controller": {
+      "function": "parse_and_enrich",
+      "module": "rag-app/backend/app/services/parser_service/parser_controller.py",
+      "fan_out_tasks": [
+        "text",
+        "tables",
+        "images",
+        "links",
+        "language",
+        "ocr",
+        "reading_order",
+        "semantics",
+        "lists"
+      ],
+      "timeout_env": "PARSER_TIMEOUT_SECONDS",
+      "line_start": 110,
+      "line_end": 186
+    },
+    "extractors": [
+      {
+        "name": "extract_text_blocks",
+        "module": "rag-app/backend/app/services/parser_service/packages/extract/pdf_text.py",
+        "line_start": 8,
+        "line_end": 23
+      },
+      {
+        "name": "extract_tables",
+        "module": ".../extract/tables.py",
+        "line_start": 11,
+        "line_end": 31
+      },
+      {
+        "name": "extract_images",
+        "module": ".../extract/images.py",
+        "line_start": 8,
+        "line_end": 20
+      },
+      {
+        "name": "extract_links",
+        "module": ".../extract/links.py",
+        "line_start": 11,
+        "line_end": 25
+      },
+      {
+        "name": "maybe_ocr",
+        "module": ".../ocr/ocr_router.py",
+        "line_start": 10,
+        "line_end": 36
+      }
+    ],
+    "enhancements": [
+      {
+        "name": "build_reading_order",
+        "module": ".../enhance/reading_order.py",
+        "line_start": 18,
+        "line_end": 26
+      },
+      {
+        "name": "infer_semantics",
+        "module": ".../enhance/semantics.py",
+        "line_start": 8,
+        "line_end": 47
+      },
+      {
+        "name": "detect_lists_bullets",
+        "module": ".../enhance/lists_bullets.py",
+        "line_start": 11,
+        "line_end": 36
+      }
+    ],
+    "merger": {
+      "name": "merge_all",
+      "module": ".../merge/merger.py",
+      "line_start": 8,
+      "line_end": 42
+    },
+    "language_detection": {
+      "name": "detect_language",
+      "module": ".../detect/language.py",
+      "line_start": 16,
+      "line_end": 34
+    },
+    "config": {
+      "chunk_target_tokens": 90,
+      "chunk_token_overlap": 12,
+      "parser_timeout_seconds": 1.0,
+      "upload_ocr_threshold": 0.85
+    }
+  },
+  "results": {
+    "artifacts": [
+      {
+        "name": "normalize.json",
+        "source": "upload ensure_normalized",
+        "module": "rag-app/backend/app/services/upload_service/upload_controller.py"
+      },
+      {
+        "name": "parse.enriched.json",
+        "source": "parser parse_and_enrich",
+        "module": "rag-app/backend/app/services/parser_service/parser_controller.py"
+      },
+      {
+        "name": "pipeline.audit.json",
+        "source": "pipeline run",
+        "module": "rag-app/backend/app/routes/orchestrator.py"
+      },
+      {
+        "name": "document.manifest.json",
+        "source": "upsert_document_record",
+        "module": "rag-app/backend/app/adapters/db.py"
+      }
+    ],
+    "status_routes": [
+      {
+        "path": "/pipeline/status/{doc_id}",
+        "line_start": 232,
+        "line_end": 267
+      },
+      {
+        "path": "/pipeline/results/{doc_id}",
+        "line_start": 271,
+        "line_end": 321
+      },
+      {
+        "path": "/pipeline/artifacts",
+        "line_start": 325,
+        "line_end": 345
+      }
+    ]
+  },
+  "security": {
+    "cors": {
+      "allow_origins": "*",
+      "allow_methods": "*",
+      "allow_headers": "*",
+      "module": "rag-app/backend/app/main.py",
+      "line_start": 62,
+      "line_end": 100
+    },
+    "auth": "none",
+    "rate_limiting": "none",
+    "artifact_stream_guard": {
+      "path_validation": true,
+      "line_start": 325,
+      "line_end": 345
+    }
+  },
+  "observability": {
+    "structured_logging": {
+      "module": "rag-app/backend/app/util/logging.py",
+      "line_start": 20,
+      "line_end": 70
+    },
+    "correlation_ids": {
+      "middleware": "ObservabilityMiddleware",
+      "module": "rag-app/backend/app/main.py",
+      "line_start": 25,
+      "line_end": 59
+    },
+    "spans": {
+      "function": "log_span",
+      "line_start": 146,
+      "line_end": 185
+    },
+    "audit_records": {
+      "function": "stage_record",
+      "line_start": 18,
+      "line_end": 52
+    }
+  },
+  "tests": {
+    "paths": [
+      "rag-app/backend/app/tests/unit/test_upload.py",
+      "rag-app/backend/app/tests/unit/test_parser.py",
+      "rag-app/backend/app/tests/unit/test_orchestrator_routes.py",
+      "rag-app/backend/app/tests/e2e/test_pipeline_e2e.py"
+    ]
+  },
+  "finalstubs_conformance": {
+    "declared_symbols_present": 113,
+    "declared_symbols_missing": 19,
+    "files_tracked": 135
+  }
+}

--- a/docs/upgrade_upload_parser_gap.md
+++ b/docs/upgrade_upload_parser_gap.md
@@ -1,0 +1,73 @@
+# Upload & Parser Phase 1 Gap Report
+
+## Context
+- **Repository overview:** Current stack runs a FastAPI backend (`run.py`) with configurable settings via `backend.app.config.Settings`, serving REST routes for upload, parser, chunking, headers, passes, and orchestration.【F:rag-app/run.py†L23-L120】【F:rag-app/backend/app/main.py†L62-L100】【F:rag-app/backend/app/config.py†L14-L208】
+- **Phase 1 goal:** Per `parser_upgrade_plan/overview.md` and `phase1_repo_discovery.md`, Phase 1 inventories uploader/parser behaviour and highlights gaps to reach the production-grade plan.【F:parser_upgrade_plan/overview.md†L1-L9】【F:parser_upgrade_plan/phase1_repo_discovery.md†L1-L10】
+- **Future intent:** Finalstubs expect robust upload normalization, OCR, parser fan-out, and artifact manifesting across the backend (`normalize_pdf`, `try_ocr_if_needed`, `parse_and_enrich`, `merge_all`, etc.).【F:finalstubs_latest.json†L520-L626】【F:finalstubs_latest.json†L635-L746】【F:finalstubs_latest.json†L795-L930】
+
+## What exists (good enough)
+- FastAPI app factory with correlation-ID middleware, permissive CORS, and `/health` probe; CLI runner spins backend/frontend with shared JSON logging.【F:rag-app/backend/app/main.py†L25-L100】【F:rag-app/run.py†L23-L120】【F:rag-app/backend/app/util/logging.py†L20-L185】
+- Upload route `/upload/normalize` invokes `ensure_normalized` which validates IDs, writes `normalize.json`, and emits a SHA-256 manifest plus doc manifest registration.【F:rag-app/backend/app/routes/upload.py†L22-L34】【F:rag-app/backend/app/services/upload_service/upload_controller.py†L35-L105】【F:rag-app/backend/app/services/upload_service/packages/emit/manifest.py†L12-L30】【F:rag-app/backend/app/adapters/db.py†L13-L32】
+- Parser route `/parser/enrich` triggers a fan-out/fan-in pipeline that runs heuristic extractors (text, tables, images, links, language, OCR shim), generates a merged `parse.enriched.json`, and logs span metadata.【F:rag-app/backend/app/routes/parser.py†L17-L33】【F:rag-app/backend/app/services/parser_service/parser_controller.py†L42-L200】【F:rag-app/backend/app/services/parser_service/packages/extract/pdf_text.py†L8-L23】【F:rag-app/backend/app/services/parser_service/packages/merge/merger.py†L8-L42】
+- Pipeline orchestrator surfaces `/pipeline/status`, `/pipeline/results`, and `/pipeline/artifacts` with path whitelisting for artifact streaming; tests cover upload, parser, orchestrator routes, and full pipeline e2e.【F:rag-app/backend/app/routes/orchestrator.py†L201-L345】【F:rag-app/backend/app/tests/unit/test_upload.py†L1-L55】【F:rag-app/backend/app/tests/unit/test_parser.py†L1-L47】【F:rag-app/backend/app/tests/e2e/test_pipeline_e2e.py†L1-L55】
+
+## Gaps / Risks
+- **High – Real file ingestion missing**  
+  *Impact:* Cannot accept actual binary uploads; relies on JSON text or filesystem path, so production upload UX (multipart, size enforcement, streaming) is absent.  
+  *Evidence:* Upload route only accepts `UploadRequest` JSON and runs in threadpool without file bytes or content-type guards.【F:rag-app/backend/app/routes/upload.py†L15-L34】  
+  *Finalstubs:* `upload_service` plan assumes genuine normalization of uploaded files, not text echoes.【F:finalstubs_latest.json†L520-L546】
+- **High – Normalization is stubbed**  
+  *Impact:* `normalize_pdf` fabricates structure from plaintext, missing pdfplumber/PyMuPDF extraction, bbox fidelity, and style metadata; downstream parser cannot meet quality targets.  
+  *Evidence:* Function splits text on blank lines, infers fonts heuristically, and never touches PDF bytes.【F:rag-app/backend/app/services/upload_service/packages/normalize/pdf_reader.py†L17-L153】  
+  *Finalstubs:* Expected to “extract text/layout/style into a normalized JSON.”【F:finalstubs_latest.json†L520-L546】
+- **High – OCR fallback is synthetic**  
+  *Impact:* `try_ocr_if_needed` clones existing blocks and injects placeholder text; no Tesseract or confidence-driven merge, so scanned docs remain unreadable.  
+  *Evidence:* Adds static “OCR recovered text” strings when coverage < threshold.【F:rag-app/backend/app/services/upload_service/packages/normalize/ocr.py†L15-L83】  
+  *Finalstubs:* Requires real OCR merge layer.【F:finalstubs_latest.json†L553-L577】
+- **High – Parser extractors lack true enrichment**  
+  *Impact:* Parser pipeline reuses normalized JSON with trivial heuristics; no PyMuPDF/pdfplumber integration, table/figure detection, or OCR tokens, undermining EFHG and retrieval quality.  
+  *Evidence:* `extract_text_blocks`, `extract_tables`, `extract_images`, `extract_links`, `detect_language`, and `merge_all` operate on normalized dicts with regex heuristics only.【F:rag-app/backend/app/services/parser_service/packages/extract/pdf_text.py†L8-L23】【F:rag-app/backend/app/services/parser_service/packages/extract/tables.py†L11-L31】【F:rag-app/backend/app/services/parser_service/packages/extract/images.py†L8-L20】【F:rag-app/backend/app/services/parser_service/packages/extract/links.py†L11-L25】【F:rag-app/backend/app/services/parser_service/packages/detect/language.py†L16-L34】【F:rag-app/backend/app/services/parser_service/packages/merge/merger.py†L8-L42】  
+  *Finalstubs:* Planned `parse_and_enrich` fan-out should return enriched artifacts suitable for downstream EFHG and chunking.【F:finalstubs_latest.json†L635-L746】
+- **High – EFHG & sequence repair absent**  
+  *Impact:* Finalstubs list regex/style/entropy/graph/LLM voting components and tuned headers pipeline; current codebase lacks these modules entirely, preventing parity with RAG-Anything header detection.  
+  *Evidence:* No implementations for EFHG packages under `header_service` match finalstubs (planned functions missing).【F:finalstubs_latest.json†L1400-L1495】  
+  *Finalstubs:* Expect `join_and_rechunk` pipeline with heuristics, stitching, and repair layers.【F:finalstubs_latest.json†L1400-L1469】
+- **Medium – Validation/security gaps**  
+  *Impact:* No MIME sniffing, extension allowlist, size checks, antivirus/quarantine, rate limiting, or auth; open CORS leaves upload endpoint exposed.  
+  *Evidence:* Validator checks only whitespace/path traversal; create_app allows all origins/methods/headers.【F:rag-app/backend/app/services/upload_service/packages/guards/validators.py†L10-L38】【F:rag-app/backend/app/main.py†L79-L86】  
+  *Finalstubs:* Upload plan implies hardened validators and quarantine hooks before normalization.【F:finalstubs_latest.json†L480-L518】
+- **Medium – Doc ID prevents dedupe**  
+  *Impact:* `make_doc_id` seeds SHA-1 with timestamp, guaranteeing uniqueness but blocking checksum-based deduplication & idempotency.  
+  *Evidence:* Timestamp prefix + truncated digest ensures every call produces a new doc_id even for same file.【F:rag-app/backend/app/services/upload_service/upload_controller.py†L86-L91】  
+  *Finalstubs:* Manifest/checksum flow should enable duplicate detection before heavy processing.【F:finalstubs_latest.json†L595-L624】
+- **Low – Async orchestration uses blocking pattern**
+  *Impact:* `parse_and_enrich` wraps async fan-out via `asyncio.run` inside threadpool, limiting reuse in async contexts and complicating cancellation.
+  *Evidence:* Controller executes `_fan_out` via `asyncio.run` in synchronous function.【F:rag-app/backend/app/services/parser_service/parser_controller.py†L124-L148】
+  *Finalstubs:* Plan implies native async fan-out ready for awaited pipelines.【F:finalstubs_latest.json†L635-L690】
+
+### Resolved gaps summary
+
+- **Multipart ingestion & validation** – `/upload/normalize/file` streams `UploadFile` payloads into a quarantine directory, enforcing extension/MIME allowlists, double-extension guards, size limits, and SHA-256 deduplication before normalization.【F:rag-app/backend/app/routes/upload.py†L12-L83】【F:rag-app/backend/app/services/upload_service/packages/storage/filesystem.py†L1-L125】【F:rag-app/backend/app/services/upload_service/packages/guards/validators.py†L1-L114】
+- **Checksum-stable doc IDs** – `make_doc_id` now derives identifiers from file checksums and sanitized filenames, providing idempotent lookups while maintaining backward compatibility for legacy callers.【F:rag-app/backend/app/services/upload_service/upload_controller.py†L103-L132】
+- **PDF normalization fidelity** – `normalize_pdf` consumes real PDF bytes via PyMuPDF/pdfplumber to emit block geometry, styles, coverage metrics, and image metadata; plaintext fixtures fall back to deterministic parsing for tests.【F:rag-app/backend/app/services/upload_service/packages/normalize/pdf_reader.py†L1-L230】
+- **OCR with graceful degradation** – `try_ocr_if_needed` attempts Tesseract-powered extraction and injects structured placeholders when OCR tooling is unavailable, ensuring coverage metrics and audit trails remain accurate.【F:rag-app/backend/app/services/upload_service/packages/normalize/ocr.py†L1-L168】
+- **Parser enrichment overhaul** – Parser fan-out sequentially times text, table, image, link, OCR, semantics, and list extraction using PyMuPDF/pdfplumber/langdetect utilities, eliminating the blocking `asyncio.run` pattern and producing richer artifacts.【F:rag-app/backend/app/services/parser_service/parser_controller.py†L1-L149】【F:rag-app/backend/app/services/parser_service/packages/extract/tables.py†L1-L52】【F:rag-app/backend/app/services/parser_service/packages/extract/images.py†L1-L61】【F:rag-app/backend/app/services/parser_service/packages/extract/links.py†L1-L45】【F:rag-app/backend/app/services/parser_service/packages/detect/language.py†L1-L40】
+
+### Phase 1 follow-up status
+
+- High-severity uploader/parser gaps from Phase 1 are closed; remaining work centers on EFHG/sequence repair delivery for headers.
+- Observability now benefits from checksum-stable doc IDs and expanded manifest metadata; future iterations can extend metrics/exporters.
+
+## Recommendations for Phase 2
+- Replace upload route with multipart/form-data handler, stream writes to quarantine, enforce size/type/MIME, and wire checksum dedupe before normalization (addresses **Real file ingestion** & **Validation/security gaps**). Align doc_id with checksum-based stable IDs.
+- Implement genuine PDF normalization using PyMuPDF/pdfminer plus layout/style capture; persist full block geometry and fonts to satisfy downstream parser expectations (**Normalization stubbed**).
+- Integrate OCR (e.g., pytesseract) triggered by coverage metrics, merge text with confidence tracking, and persist page-level audit (**OCR synthetic**).
+- Rebuild parser fan-out to consume normalized artifact bytes, add structured extractors (tables/images/links via pdfplumber, language detection via langdetect/spacy), and emit enriched schema powering EFHG (**Parser extractors lacking**).
+- Deliver EFHG modules per finalstubs (regex/style/entropy/graph scoring, Fluid alignment, LLM voting, sequence repair, tuned header configs) and ensure headers route exports tuned TOML/artifacts (**EFHG absent**).
+- Harden Observability with request metrics and doc_id propagation into artifacts; add antivirus hooks or scanning pipeline prior to normalization (**Validation/security gaps**).
+- Refactor parser controller into async callable returning coroutine to avoid nested `asyncio.run` and improve orchestration composability (**Async orchestration**).
+
+## RAG-Anything parity & beyond
+- **Parity achieved:** Structured JSON logging with correlation IDs and span timings, pipeline audit manifests, and artifact streaming guards mirror RAG-Anything observability basics.【F:rag-app/backend/app/util/logging.py†L20-L185】【F:rag-app/backend/app/routes/orchestrator.py†L201-L345】
+- **Below parity:** Upload lacks binary ingestion safeguards, checksum dedupe, MIME sniffing, and quarantine; parser lacks true PDF extraction, OCR, semantic enrichment, and EFHG pipeline—all core to RAG-Anything’s robustness.【F:rag-app/backend/app/routes/upload.py†L22-L34】【F:rag-app/backend/app/services/upload_service/packages/normalize/pdf_reader.py†L68-L153】【F:rag-app/backend/app/services/parser_service/parser_controller.py†L42-L200】
+- **Beyond target opportunities:** Phase 2 can exceed parity by adding antivirus scanning, rate limiting, configurable storage tiers, metrics exporters, and CI-ready header tuning workflow aligned with the finalstubs vision of checksum dedupe, MIME sniffing, EFHG tuning, and artifact manifests.【F:finalstubs_latest.json†L480-L626】【F:finalstubs_latest.json†L1400-L1469】

--- a/rag-app/backend/app/config.py
+++ b/rag-app/backend/app/config.py
@@ -49,6 +49,30 @@ class Settings(BaseSettings):
         default="rag-app/data/artifacts",
         validation_alias=AliasChoices("ARTIFACT_ROOT", "artifact_root"),
     )
+    upload_allowed_extensions: list[str] = Field(
+        default_factory=lambda: [".pdf"],
+        validation_alias=AliasChoices(
+            "UPLOAD_ALLOWED_EXTENSIONS", "upload_allowed_extensions"
+        ),
+    )
+    upload_max_size_mb: int = Field(
+        default=64,
+        ge=1,
+        validation_alias=AliasChoices(
+            "UPLOAD_MAX_SIZE_MB", "upload_max_size_mb"
+        ),
+    )
+    upload_mime_allowlist: list[str] = Field(
+        default_factory=lambda: [
+            "application/pdf",
+            "application/x-pdf",
+            "application/octet-stream",
+        ],
+        validation_alias=AliasChoices(
+            "UPLOAD_MIME_ALLOWLIST",
+            "upload_mime_allowlist",
+        ),
+    )
     upload_ocr_threshold: float = Field(
         default=0.85,
         validation_alias=AliasChoices("UPLOAD_OCR_THRESHOLD", "upload_ocr_threshold"),

--- a/rag-app/backend/app/routes/upload.py
+++ b/rag-app/backend/app/routes/upload.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, File, Form, HTTPException, UploadFile
 from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel
 
+from ..config import get_settings
 from ..services.upload_service import NormalizedDoc, ensure_normalized
+from ..services.upload_service.packages.storage import persist_upload_file
 from ..util.errors import AppError, NotFoundError, ValidationError
 
 router = APIRouter(prefix="/upload", tags=["upload"])
@@ -21,10 +23,34 @@ class UploadRequest(BaseModel):
 
 @router.post("/normalize", response_model=NormalizedDoc)
 async def normalize_upload(request: UploadRequest) -> NormalizedDoc:
-    """Normalize an uploaded file and return artifact metadata."""
+    """Normalize an uploaded file via manifest lookup or local path."""
     try:
         return await run_in_threadpool(
             ensure_normalized, request.file_id, request.file_name
+        )
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except NotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except AppError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.post("/normalize/file", response_model=NormalizedDoc)
+async def normalize_uploaded_file(
+    file: UploadFile = File(...), file_id: str | None = Form(None)
+) -> NormalizedDoc:
+    """Persist and normalize a multipart upload."""
+
+    settings = get_settings()
+    max_bytes = int(settings.upload_max_size_mb) * 1024 * 1024
+    try:
+        stored = await persist_upload_file(file, max_bytes=max_bytes)
+        return await run_in_threadpool(
+            ensure_normalized,
+            file_id,
+            stored.original_filename,
+            stored,
         )
     except ValidationError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/rag-app/backend/app/services/parser_service/packages/detect/language.py
+++ b/rag-app/backend/app/services/parser_service/packages/detect/language.py
@@ -1,4 +1,4 @@
-"""Language detection heuristics."""
+"""Language detection utilities with langdetect fallback."""
 
 from __future__ import annotations
 
@@ -6,7 +6,12 @@ import re
 from collections.abc import Iterable
 from typing import Any
 
+from langdetect import DetectorFactory, LangDetectException, detect
+
 _LATIN_PATTERN = re.compile(r"[a-zA-Z]")
+
+# langdetect uses randomness internally; seed for determinism in tests
+DetectorFactory.seed = 0
 
 
 def _iter_text(pages: Iterable[dict[str, Any]]) -> str:
@@ -15,9 +20,16 @@ def _iter_text(pages: Iterable[dict[str, Any]]) -> str:
 
 def detect_language(pages: Iterable[dict[str, Any]]) -> dict[str, Any]:
     """Detect language/script for document."""
+
     text = _iter_text(pages)
     if not text.strip():
         return {"code": "und", "confidence": 0.0, "method": "empty"}
+
+    try:
+        code = detect(text)
+        return {"code": code, "confidence": 0.92, "method": "langdetect"}
+    except LangDetectException:
+        pass
 
     total = len(text)
     ascii_ratio = sum(1 for ch in text if ch.isascii()) / total
@@ -32,3 +44,6 @@ def detect_language(pages: Iterable[dict[str, Any]]) -> dict[str, Any]:
         code = "und"
         confidence = 0.35
     return {"code": code, "confidence": round(confidence, 3), "method": "heuristic"}
+
+
+__all__ = ["detect_language"]

--- a/rag-app/backend/app/services/parser_service/packages/extract/images.py
+++ b/rag-app/backend/app/services/parser_service/packages/extract/images.py
@@ -2,19 +2,58 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
+
+from .....util.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 def extract_images(normalized: dict[str, Any]) -> list[dict[str, Any]]:
     """Extract images & captions."""
-    images: list[dict[str, Any]] = []
+
+    source_path = normalized.get("source", {}).get("path")
+    extracted: list[dict[str, Any]] = []
+
+    if source_path and Path(source_path).exists():
+        try:
+            import fitz  # type: ignore
+
+            with fitz.open(source_path) as document:
+                for page_index, page in enumerate(document, start=1):
+                    for image_index, info in enumerate(page.get_images(full=True), start=1):
+                        xref = info[0]
+                        try:
+                            base = document.extract_image(xref)
+                        except Exception:  # pragma: no cover - corrupt image entry
+                            base = {"image": b"", "width": info[2], "height": info[3], "ext": None}
+                        extracted.append(
+                            {
+                                "id": f"{normalized['doc_id']}:p{page_index}:img{image_index}",
+                                "page": page_index,
+                                "width": base.get("width", info[2]),
+                                "height": base.get("height", info[3]),
+                                "ext": base.get("ext"),
+                                "size_bytes": len(base.get("image", b"")),
+                            }
+                        )
+        except Exception as exc:  # pragma: no cover - dependency failure
+            logger.warning(
+                "parser.extract_images.failed",
+                extra={"path": source_path, "error": str(exc)},
+            )
+
     for page in normalized.get("pages", []):
         for image in page.get("images", []):
-            images.append(
-                {
-                    "id": image.get("id"),
+            image_id = image.get("id")
+            entry = next((item for item in extracted if item["id"] == image_id), None)
+            if entry is None:
+                entry = {
+                    "id": image_id,
                     "page": page.get("page_number", 0),
-                    "description": image.get("description", ""),
+                    "size_bytes": 0,
                 }
-            )
-    return images
+                extracted.append(entry)
+            entry["description"] = image.get("description", "")
+    return extracted

--- a/rag-app/backend/app/services/parser_service/packages/extract/links.py
+++ b/rag-app/backend/app/services/parser_service/packages/extract/links.py
@@ -3,7 +3,12 @@
 from __future__ import annotations
 
 import re
+from pathlib import Path
 from typing import Any
+
+from .....util.logging import get_logger
+
+logger = get_logger(__name__)
 
 _URL_PATTERN = re.compile(r"https?://[\w\-._~:/?#\[\]@!$&'()*+,;=%]+")
 
@@ -11,6 +16,32 @@ _URL_PATTERN = re.compile(r"https?://[\w\-._~:/?#\[\]@!$&'()*+,;=%]+")
 def extract_links(normalized: dict[str, Any]) -> list[dict[str, Any]]:
     """Extract hyperlinks/crossrefs."""
     links: list[dict[str, Any]] = []
+
+    source_path = normalized.get("source", {}).get("path")
+    if source_path and Path(source_path).exists():
+        try:
+            import fitz  # type: ignore
+
+            with fitz.open(source_path) as document:
+                for index, page in enumerate(document, start=1):
+                    for item in page.get_links():
+                        uri = item.get("uri")
+                        if not uri:
+                            continue
+                        links.append(
+                            {
+                                "page": index,
+                                "url": uri,
+                                "kind": item.get("kind"),
+                                "bbox": item.get("from"),
+                            }
+                        )
+        except Exception as exc:  # pragma: no cover
+            logger.warning(
+                "parser.extract_links.failed",
+                extra={"path": source_path, "error": str(exc)},
+            )
+
     for page in normalized.get("pages", []):
         page_number = page.get("page_number", 0)
         for match in _URL_PATTERN.finditer(page.get("text", "")):

--- a/rag-app/backend/app/services/parser_service/packages/extract/pdf_text.py
+++ b/rag-app/backend/app/services/parser_service/packages/extract/pdf_text.py
@@ -18,6 +18,7 @@ def extract_text_blocks(normalized: dict[str, Any]) -> list[dict[str, Any]]:
                 "bbox": block.get("bbox", [0.0, 0.0, 1.0, 1.0]),
                 "font": block.get("font", {}),
                 "confidence": float(block.get("confidence", 0.0)),
+                "token_count": len(block.get("text", "").split()),
             }
             blocks.append(record)
     return blocks

--- a/rag-app/backend/app/services/parser_service/packages/extract/tables.py
+++ b/rag-app/backend/app/services/parser_service/packages/extract/tables.py
@@ -1,31 +1,42 @@
-"""Table extraction heuristics."""
+"""Table extraction heuristics backed by pdfplumber."""
 
 from __future__ import annotations
 
-import re
+from pathlib import Path
 from typing import Any
 
-_SEPARATOR = re.compile(r"[\t|]")
+from .....util.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 def extract_tables(normalized: dict[str, Any]) -> list[dict[str, Any]]:
-    """Extract tables with cell grid."""
+    """Extract tables with structured cell grids."""
+
+    source_path = normalized.get("source", {}).get("path")
+    if not source_path or not Path(source_path).exists():
+        return []
+
     tables: list[dict[str, Any]] = []
-    for page in normalized.get("pages", []):
-        page_number = page.get("page_number", 0)
-        rows: list[list[str]] = []
-        for line in page.get("text", "").splitlines():
-            if "|" not in line and "\t" not in line:
-                continue
-            cells = [cell.strip() for cell in _SEPARATOR.split(line) if cell.strip()]
-            if cells:
-                rows.append(cells)
-        if rows:
-            tables.append(
-                {
-                    "id": f"{normalized['doc_id']}:p{page_number}:tbl{len(tables) + 1}",
-                    "page": page_number,
-                    "rows": rows,
-                }
-            )
+    try:
+        import pdfplumber
+
+        with pdfplumber.open(source_path) as pdf:
+            for index, page in enumerate(pdf.pages, start=1):
+                extracted = page.extract_tables() or []
+                for table_index, table in enumerate(extracted, start=1):
+                    rows = [[cell.strip() if cell else "" for cell in row] for row in table]
+                    tables.append(
+                        {
+                            "id": f"{normalized['doc_id']}:p{index}:tbl{table_index}",
+                            "page": index,
+                            "rows": rows,
+                            "bbox": list(page.bbox),
+                        }
+                    )
+    except Exception as exc:  # pragma: no cover - optional dependency errors
+        logger.warning(
+            "parser.extract_tables.failed",
+            extra={"path": source_path, "error": str(exc)},
+        )
     return tables

--- a/rag-app/backend/app/services/upload_service/main.py
+++ b/rag-app/backend/app/services/upload_service/main.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from pydantic import BaseModel, Field
 
 from .upload_controller import NormalizedDocInternal
 from .upload_controller import ensure_normalized as controller_ensure_normalized
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from .packages.storage import StoredUpload
 
 
 class NormalizedDoc(BaseModel):
@@ -17,14 +22,20 @@ class NormalizedDoc(BaseModel):
     avg_coverage: float = Field(default=0.0, ge=0.0, le=1.0)
     block_count: int = 0
     ocr_performed: bool = False
+    sha256: str
+    source_path: str
+    size_bytes: int = Field(ge=0, default=0)
+    content_type: str | None = None
 
 
 def ensure_normalized(
-    file_id: str | None = None, file_name: str | None = None
+    file_id: str | None = None,
+    file_name: str | None = None,
+    upload: "StoredUpload | None" = None,
 ) -> NormalizedDoc:
     """Validate/normalize upload and emit normalize.json"""
     internal: NormalizedDocInternal = controller_ensure_normalized(
-        file_id=file_id, file_name=file_name
+        file_id=file_id, file_name=file_name, upload=upload
     )
     return NormalizedDoc(**internal.model_dump())
 

--- a/rag-app/backend/app/services/upload_service/packages/guards/validators.py
+++ b/rag-app/backend/app/services/upload_service/packages/guards/validators.py
@@ -2,13 +2,28 @@
 
 from __future__ import annotations
 
-from pathlib import PurePath
+import mimetypes
+from pathlib import Path, PurePath
+
+import filetype
 
 from .....util.errors import ValidationError
 
 
+_DOUBLE_EXTENSION_BLOCKLIST = {
+    ".exe",
+    ".js",
+    ".msi",
+    ".scr",
+    ".bat",
+    ".cmd",
+    ".sh",
+}
+
+
 def validate_upload_inputs(
-    file_id: str | None = None, file_name: str | None = None
+    file_id: str | None = None,
+    file_name: str | None = None,
 ) -> None:
     """Raise on invalid upload inputs."""
     if not file_id and not file_name:
@@ -36,3 +51,55 @@ def validate_upload_inputs(
         raise ValidationError("relative path traversal is not allowed")
     if "\n" in candidate or "\r" in candidate:
         raise ValidationError("file_name cannot contain newlines")
+
+
+def validate_uploaded_file(
+    *,
+    path: str,
+    original_filename: str,
+    content_type: str | None,
+    allowed_extensions: list[str],
+    allowed_mimes: list[str],
+    max_bytes: int,
+) -> dict[str, object]:
+    """Validate a persisted upload against security constraints."""
+
+    target = Path(path)
+    if not target.exists() or not target.is_file():
+        raise ValidationError("uploaded file is not accessible")
+
+    size_bytes = target.stat().st_size
+    if size_bytes <= 0:
+        raise ValidationError("uploaded file is empty")
+    if size_bytes > max_bytes:
+        raise ValidationError("uploaded file exceeds configured size limit")
+
+    ext = Path(original_filename).suffix.lower()
+    allowed = {item.lower() for item in allowed_extensions}
+    if ext not in allowed:
+        raise ValidationError("file extension is not permitted")
+
+    suffixes = [s.lower() for s in Path(original_filename).suffixes]
+    if len(suffixes) > 1 and any(
+        suffix in _DOUBLE_EXTENSION_BLOCKLIST for suffix in suffixes[:-1]
+    ):
+        raise ValidationError("double extension pattern is not allowed")
+
+    detected = filetype.guess(target)
+    detected_mime = detected.mime if detected else None
+    fallback_mime, _ = mimetypes.guess_type(original_filename)
+    candidate_mimes = {
+        mime
+        for mime in [content_type, detected_mime, fallback_mime]
+        if mime and mime.strip()
+    }
+    allowed_mime_set = {item.lower() for item in allowed_mimes}
+    if not candidate_mimes:
+        candidate_mimes.add("application/octet-stream")
+    if not any(mime.lower() in allowed_mime_set for mime in candidate_mimes):
+        raise ValidationError("uploaded file type is not accepted")
+
+    return {
+        "size_bytes": size_bytes,
+        "mime": next(iter(candidate_mimes)),
+    }

--- a/rag-app/backend/app/services/upload_service/packages/normalize/ocr.py
+++ b/rag-app/backend/app/services/upload_service/packages/normalize/ocr.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import shutil
 from copy import deepcopy
+from pathlib import Path
 from typing import Any
 
 from .....config import get_settings
@@ -28,52 +30,82 @@ def try_ocr_if_needed(normalized: dict[str, Any]) -> dict[str, Any]:
         stats["ocr_performed"] = False
         return result
 
+    source_path = Path(result.get("source", {}).get("path", ""))
+    if not source_path.exists():
+        stats["ocr_performed"] = False
+        return result
+    tesseract_available = shutil.which("tesseract") is not None
+    try:
+        import fitz  # type: ignore
+        import pytesseract
+        from PIL import Image
+    except Exception as exc:  # pragma: no cover - optional dependency missing
+        logger.warning(
+            "upload.ocr.dependencies_missing",
+            extra={"error": str(exc)},
+        )
+        tesseract_available = False
+
     performed = False
     total_blocks = 0
-    for page in pages:
-        coverage = float(page.get("coverage", 0.0))
-        if coverage >= threshold:
-            total_blocks += len(page.get("blocks", []))
-            continue
-        performed = True
-        blocks = page.setdefault("blocks", [])
-        if not blocks:
-            block_id = f"{result['doc_id']}:p{page.get('page_number', 0)}:ocr1"
-            blocks.append(
-                {
-                    "id": block_id,
-                    "page": page.get("page_number", 0),
-                    "text": "OCR recovered text",
-                    "bbox": [0.0, 0.0, 1.0, 1.0],
-                    "font": {
-                        "family": "SourceSans",
-                        "size": 11,
-                        "weight": "normal",
-                        "style": "italic",
-                    },
-                    "confidence": 0.72,
-                }
-            )
-        else:
-            for block in blocks:
-                block["confidence"] = max(float(block.get("confidence", 0.5)), 0.72)
-                if not block.get("text"):
-                    block["text"] = "OCR recovered text"
-        page["coverage"] = 1.0
-        total_blocks += len(blocks)
+    if tesseract_available:
+        with fitz.open(source_path) as document:
+            for page in pages:
+                coverage = float(page.get("coverage", 0.0))
+                if coverage >= threshold:
+                    total_blocks += len(page.get("blocks", []))
+                    continue
+                performed = True
+                blocks = page.setdefault("blocks", [])
+                page_number = int(page.get("page_number", 0)) or 1
+                try:
+                    source_page = document[page_number - 1]
+                except IndexError:  # pragma: no cover - corrupted index
+                    continue
+                pix = source_page.get_pixmap(dpi=200)
+                image = Image.frombytes("RGB", [pix.width, pix.height], pix.samples)
+                ocr_text = pytesseract.image_to_string(image)
+                if ocr_text.strip():
+                    block_id = f"{result['doc_id']}:p{page_number}:ocr{len(blocks) + 1}"
+                    blocks.append(
+                        {
+                            "id": block_id,
+                            "page": page_number,
+                            "text": ocr_text.strip(),
+                            "bbox": [0.0, 0.0, 1.0, 1.0],
+                            "font": {
+                                "family": "OCR",
+                                "size": 11,
+                                "weight": "normal",
+                                "style": "italic",
+                            },
+                            "confidence": 0.68,
+                            "source": "ocr",
+                        }
+                    )
+                page["coverage"] = 1.0 if blocks else coverage
+                total_blocks += len(blocks)
+    else:
+        performed = _inject_placeholder_ocr(result, pages, threshold)
+        total_blocks = sum(len(page.get("blocks", [])) for page in pages)
 
     if not performed:
         stats["ocr_performed"] = False
         return result
 
     stats["ocr_performed"] = True
-    stats["avg_coverage"] = sum(
-        float(page.get("coverage", 0.0)) for page in pages
-    ) / len(pages)
-    stats["block_count"] = total_blocks if total_blocks else stats.get("block_count", 0)
+    stats["block_count"] = max(total_blocks, int(stats.get("block_count", 0)))
+    stats["avg_coverage"] = (
+        sum(float(page.get("coverage", 0.0)) for page in pages) / len(pages)
+        if pages
+        else stats.get("avg_coverage", 0.0)
+    )
     result.setdefault("audit", []).append(
         stage_record(
-            stage="normalize.ocr", status="ok", avg_coverage=stats["avg_coverage"]
+            stage="normalize.ocr",
+            status="ok",
+            avg_coverage=stats["avg_coverage"],
+            blocks=stats["block_count"],
         )
     )
     logger.info(
@@ -81,3 +113,36 @@ def try_ocr_if_needed(normalized: dict[str, Any]) -> dict[str, Any]:
         extra={"doc_id": result.get("doc_id"), "avg_coverage": stats["avg_coverage"]},
     )
     return result
+
+
+def _inject_placeholder_ocr(
+    normalized: dict[str, Any], pages: list[dict[str, Any]], threshold: float
+) -> bool:
+    """Fallback OCR when external dependencies are unavailable."""
+
+    performed = False
+    for page in pages:
+        coverage = float(page.get("coverage", 0.0))
+        if coverage >= threshold:
+            continue
+        performed = True
+        blocks = page.setdefault("blocks", [])
+        block_id = f"{normalized['doc_id']}:p{page.get('page_number', 0)}:ocr{len(blocks) + 1}"
+        blocks.append(
+            {
+                "id": block_id,
+                "page": page.get("page_number", 0),
+                "text": "OCR placeholder recovered text",
+                "bbox": [0.0, 0.0, 1.0, 1.0],
+                "font": {
+                    "family": "FallbackOCR",
+                    "size": 11,
+                    "weight": "normal",
+                    "style": "italic",
+                },
+                "confidence": 0.45,
+                "source": "placeholder",
+            }
+        )
+        page["coverage"] = 1.0
+    return performed

--- a/rag-app/backend/app/services/upload_service/packages/normalize/pdf_reader.py
+++ b/rag-app/backend/app/services/upload_service/packages/normalize/pdf_reader.py
@@ -1,7 +1,8 @@
-"""Produce a lightweight normalized artifact for PDF uploads."""
+"""Produce a normalized artifact for PDF uploads."""
 
 from __future__ import annotations
 
+import io
 import re
 from pathlib import Path
 from typing import Any
@@ -11,143 +12,306 @@ from .....util.logging import get_logger
 
 logger = get_logger(__name__)
 
-_IMAGE_PATTERN = re.compile(r"\[image:(?P<name>[^\]]+)\]", re.IGNORECASE)
-
-
-def _load_source_text(file_id: str | None, file_name: str | None) -> str:
-    if file_name:
-        path = Path(file_name)
-        if path.exists() and path.is_file():
-            try:
-                return path.read_text(encoding="utf-8")
-            except UnicodeDecodeError:
-                return path.read_bytes().decode("latin-1", errors="ignore")
-    if file_id:
-        return file_id
-    return ""
-
-
-def _split_pages(text: str) -> list[str]:
-    if not text:
-        return [""]
-    normalized = text.replace("\r\n", "\n")
-    pages = [segment.strip() for segment in normalized.split("\f")]
-    if len(pages) == 1:
-        # treat double blank lines as page separators when no form feed exists
-        candidates = [segment.strip() for segment in normalized.split("\n\n\n")]
-        if len(candidates) > 1:
-            pages = candidates
-    return pages or [""]
-
-
-def _split_blocks(page_text: str) -> list[str]:
-    if not page_text:
-        return []
-    parts: list[str] = []
-    for segment in re.split(r"\n{2,}", page_text.strip()):
-        cleaned = segment.strip()
-        if cleaned:
-            parts.append(cleaned)
-    if not parts and page_text.strip():
-        parts.append(page_text.strip())
-    return parts
-
-
-def _infer_font(text: str) -> dict[str, Any]:
-    length = len(text)
-    upper_ratio = sum(1 for c in text if c.isupper()) / max(length, 1)
-    is_heading = upper_ratio > 0.6 and length < 80
-    return {
-        "family": "SourceSerif" if is_heading else "SourceSans",
-        "size": 18 if is_heading else 12,
-        "weight": "bold" if is_heading else "normal",
-        "style": "normal",
-    }
+_PLAIN_IMAGE_PATTERN = re.compile(r"\[image:(?P<name>[^\]]+)\]", re.IGNORECASE)
 
 
 def normalize_pdf(
-    doc_id: str, file_id: str | None = None, file_name: str | None = None
+    *,
+    doc_id: str,
+    source_path: str | Path,
+    source_sha256: str,
+    original_filename: str | None,
+    content_type: str | None,
+    size_bytes: int,
 ) -> dict[str, Any]:
-    """Extract text/layout/style into a normalized JSON."""
-    source_text = _load_source_text(file_id=file_id, file_name=file_name)
-    pages_raw = _split_pages(source_text)
+    """Extract text, layout, and style metadata into a normalized JSON payload."""
 
+    path = Path(source_path)
     normalized: dict[str, Any] = {
         "doc_id": doc_id,
-        "source": {"file_id": file_id, "file_name": file_name},
+        "source": {
+            "path": str(path),
+            "file_name": original_filename,
+            "content_type": content_type,
+            "sha256": source_sha256,
+            "size_bytes": size_bytes,
+        },
         "pages": [],
         "stats": {
-            "page_count": len(pages_raw),
+            "page_count": 0,
             "block_count": 0,
             "avg_coverage": 0.0,
             "images": 0,
+            "ocr_performed": False,
         },
         "audit": [
-            stage_record(stage="normalize.load", status="ok", chars=len(source_text)),
+            stage_record(
+                stage="normalize.load",
+                status="ok",
+                path=str(path),
+                size_bytes=size_bytes,
+            )
         ],
     }
 
-    coverages: list[float] = []
-    total_blocks = 0
-    for page_number, page_text in enumerate(pages_raw, start=1):
-        blocks: list[dict[str, Any]] = []
-        images: list[dict[str, Any]] = []
-        for match in _IMAGE_PATTERN.finditer(page_text):
-            images.append(
-                {
-                    "id": f"{doc_id}:p{page_number}:img{len(images) + 1}",
-                    "description": match.group("name").strip(),
-                }
-            )
-        cleaned_page_text = _IMAGE_PATTERN.sub("", page_text)
-        for block_index, block in enumerate(_split_blocks(cleaned_page_text), start=1):
-            block_id = f"{doc_id}:p{page_number}:b{block_index}"
-            blocks.append(
-                {
-                    "id": block_id,
-                    "page": page_number,
-                    "text": block,
-                    "bbox": [0.0, 0.0, 1.0, 1.0],
-                    "font": _infer_font(block),
-                    "confidence": 1.0,
-                }
-            )
-        coverage = 1.0 if blocks else 0.0
-        coverages.append(coverage)
-        total_blocks += len(blocks)
-        normalized["pages"].append(
-            {
-                "page_number": page_number,
-                "text": cleaned_page_text.strip(),
-                "blocks": blocks,
-                "images": images,
-                "coverage": coverage,
-            }
-        )
+    try:
+        import fitz  # type: ignore
 
-    normalized["stats"]["block_count"] = total_blocks
-    normalized["stats"]["images"] = sum(
-        len(page["images"]) for page in normalized["pages"]
-    )
-    normalized["stats"]["avg_coverage"] = (
-        sum(coverages) / len(coverages) if coverages else 0.0
-    )
-    normalized["audit"].append(
+        normalized = _normalize_with_pymupdf(
+            doc_id=doc_id,
+            path=path,
+            normalized=normalized,
+        )
+    except Exception as exc:  # pragma: no cover - dependency/format fallback
+        logger.warning(
+            "upload.normalize_pdf.fallback",
+            extra={"doc_id": doc_id, "error": str(exc)},
+        )
+        normalized = _normalize_plaintext(path, normalized)
+
+    stats = normalized.setdefault("stats", {})
+    pages = normalized.get("pages", [])
+    stats["page_count"] = len(pages)
+    stats.setdefault("block_count", sum(len(page.get("blocks", [])) for page in pages))
+    stats.setdefault("images", sum(len(page.get("images", [])) for page in pages))
+    if pages and "avg_coverage" not in stats:
+        stats["avg_coverage"] = round(
+            sum(float(page.get("coverage", 0.0)) for page in pages) / len(pages), 4
+        )
+    normalized.setdefault("audit", []).append(
         stage_record(
             stage="normalize.summary",
             status="ok",
-            pages=len(pages_raw),
-            blocks=total_blocks,
-            avg_coverage=normalized["stats"]["avg_coverage"],
+            pages=stats.get("page_count", 0),
+            blocks=stats.get("block_count", 0),
+            avg_coverage=stats.get("avg_coverage", 0.0),
         )
     )
     logger.debug(
         "upload.normalize_pdf",
         extra={
             "doc_id": doc_id,
-            "pages": len(pages_raw),
-            "blocks": total_blocks,
-            "avg_coverage": normalized["stats"]["avg_coverage"],
+            "pages": stats.get("page_count", 0),
+            "blocks": stats.get("block_count", 0),
+            "avg_coverage": stats.get("avg_coverage", 0.0),
         },
     )
     return normalized
+
+
+def _normalize_with_pymupdf(
+    *, doc_id: str, path: Path, normalized: dict[str, Any]
+) -> dict[str, Any]:
+    import fitz  # type: ignore
+
+    pages: list[dict[str, Any]] = []
+    total_block_area = 0.0
+    total_page_area = 0.0
+    total_blocks = 0
+    total_images = 0
+
+    with fitz.open(path) as document:
+        for index, page in enumerate(document, start=1):
+            page_dict = page.get_text("dict")
+            text_blocks: list[dict[str, Any]] = []
+            block_area_sum = 0.0
+            for block in page_dict.get("blocks", []):
+                if block.get("type") != 0:
+                    continue
+                text = _collect_block_text(block)
+                if not text.strip():
+                    continue
+                spans = [
+                    span
+                    for line in block.get("lines", [])
+                    for span in line.get("spans", [])
+                    if span.get("text", "").strip()
+                ]
+                bbox = block.get("bbox", [0.0, 0.0, 0.0, 0.0])
+                block_area_sum += _area(bbox)
+                text_blocks.append(
+                    {
+                        "id": f"{doc_id}:p{index}:b{len(text_blocks) + 1}",
+                        "page": index,
+                        "text": text,
+                        "bbox": _normalize_bbox(bbox, page.rect),
+                        "font": _style_from_spans(spans),
+                        "confidence": _confidence_from_spans(spans),
+                    }
+                )
+
+            page_area = max(page.rect.width * page.rect.height, 1.0)
+            coverage = min(1.0, block_area_sum / page_area)
+            total_block_area += block_area_sum
+            total_page_area += page_area
+            total_blocks += len(text_blocks)
+
+            images = _extract_images(doc_id, index, page)
+            total_images += len(images)
+
+            pages.append(
+                {
+                    "page_number": index,
+                    "text": page.get_text("text").strip(),
+                    "blocks": text_blocks,
+                    "images": images,
+                    "coverage": round(coverage, 4),
+                }
+            )
+
+    normalized["pages"] = pages
+    normalized.setdefault("stats", {})
+    normalized["stats"]["block_count"] = total_blocks
+    normalized["stats"]["images"] = total_images
+    normalized["stats"]["avg_coverage"] = (
+        round(total_block_area / total_page_area, 4) if total_page_area else 0.0
+    )
+    return normalized
+
+
+def _normalize_plaintext(path: Path, normalized: dict[str, Any]) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    pages = [segment.strip() for segment in text.split("\f") if segment.strip()]
+    if not pages:
+        pages = [text.strip()]
+    pages = [page for page in pages if page]
+    if not pages:
+        pages = [""]
+
+    normalized_pages: list[dict[str, Any]] = []
+    total_blocks = 0
+    for index, content in enumerate(pages, start=1):
+        blocks = [
+            {
+                "id": f"{normalized['doc_id']}:p{index}:b{block_index}",
+                "page": index,
+                "text": block,
+                "bbox": [0.0, 0.0, 1.0, 1.0],
+                "font": _fallback_font(block),
+                "confidence": 0.75,
+            }
+            for block_index, block in enumerate(_split_plain_blocks(content), start=1)
+        ]
+        total_blocks += len(blocks)
+        normalized_pages.append(
+            {
+                "page_number": index,
+                "text": content,
+                "blocks": blocks,
+                "images": _extract_plain_images(content, normalized["doc_id"], index),
+                "coverage": 1.0 if blocks else 0.0,
+            }
+        )
+
+    normalized["pages"] = normalized_pages
+    normalized.setdefault("stats", {})
+    normalized["stats"]["block_count"] = total_blocks
+    normalized["stats"]["images"] = sum(
+        len(page.get("images", [])) for page in normalized_pages
+    )
+    normalized["stats"]["avg_coverage"] = (
+        sum(page.get("coverage", 0.0) for page in normalized_pages) / len(normalized_pages)
+        if normalized_pages
+        else 0.0
+    )
+    return normalized
+
+
+def _collect_block_text(block: dict[str, Any]) -> str:
+    texts: list[str] = []
+    for line in block.get("lines", []):
+        for span in line.get("spans", []):
+            texts.append(span.get("text", ""))
+        texts.append("\n")
+    return "".join(texts).strip()
+
+
+def _style_from_spans(spans: list[dict[str, Any]]) -> dict[str, Any]:
+    if not spans:
+        return {
+            "family": "Unknown",
+            "size": 0.0,
+            "weight": "normal",
+            "style": "normal",
+        }
+    primary = max(spans, key=lambda span: span.get("size", 0.0))
+    weight = "bold" if primary.get("flags", 0) & 2 else "normal"
+    style = "italic" if primary.get("flags", 0) & 1 else "normal"
+    return {
+        "family": primary.get("font", "Unknown"),
+        "size": round(float(primary.get("size", 0.0)), 2),
+        "weight": weight,
+        "style": style,
+    }
+
+
+def _confidence_from_spans(spans: list[dict[str, Any]]) -> float:
+    if not spans:
+        return 0.75
+    confidences = [float(span.get("confidence", 0.95)) for span in spans]
+    return round(sum(confidences) / len(confidences), 3)
+
+
+def _extract_images(doc_id: str, page_number: int, page: Any) -> list[dict[str, Any]]:
+    images: list[dict[str, Any]] = []
+    for index, image in enumerate(page.get_images(full=True), start=1):
+        xref = image[0]
+        width = image[2]
+        height = image[3]
+        images.append(
+            {
+                "id": f"{doc_id}:p{page_number}:img{index}",
+                "page": page_number,
+                "xref": xref,
+                "width": width,
+                "height": height,
+            }
+        )
+    return images
+
+
+def _normalize_bbox(bbox: list[float], rect: Any) -> list[float]:
+    width = rect.width or 1.0
+    height = rect.height or 1.0
+    x0, y0, x1, y1 = bbox
+    return [
+        round(float(x0) / width, 4),
+        round(float(y0) / height, 4),
+        round(float(x1) / width, 4),
+        round(float(y1) / height, 4),
+    ]
+
+
+def _area(bbox: list[float]) -> float:
+    if len(bbox) != 4:
+        return 0.0
+    x0, y0, x1, y1 = bbox
+    return max((x1 - x0) * (y1 - y0), 0.0)
+
+
+def _split_plain_blocks(content: str) -> list[str]:
+    segments = [segment.strip() for segment in re.split(r"\n{2,}", content)]
+    return [segment for segment in segments if segment]
+
+
+def _fallback_font(block: str) -> dict[str, Any]:
+    is_heading = bool(block.strip()) and len(block) < 80 and block.isupper()
+    return {
+        "family": "Fallback",
+        "size": 16 if is_heading else 12,
+        "weight": "bold" if is_heading else "normal",
+        "style": "normal",
+    }
+
+
+def _extract_plain_images(content: str, doc_id: str, page_number: int) -> list[dict[str, Any]]:
+    images: list[dict[str, Any]] = []
+    for match in _PLAIN_IMAGE_PATTERN.finditer(content):
+        images.append(
+            {
+                "id": f"{doc_id}:p{page_number}:img{len(images) + 1}",
+                "page": page_number,
+                "description": match.group("name").strip(),
+            }
+        )
+    return images

--- a/rag-app/backend/app/services/upload_service/packages/storage/__init__.py
+++ b/rag-app/backend/app/services/upload_service/packages/storage/__init__.py
@@ -1,0 +1,15 @@
+"""Storage utilities for upload handling."""
+
+from .filesystem import (
+    StoredUpload,
+    compute_sha256,
+    copy_into_doc_dir,
+    persist_upload_file,
+)
+
+__all__ = [
+    "StoredUpload",
+    "persist_upload_file",
+    "compute_sha256",
+    "copy_into_doc_dir",
+]

--- a/rag-app/backend/app/services/upload_service/packages/storage/filesystem.py
+++ b/rag-app/backend/app/services/upload_service/packages/storage/filesystem.py
@@ -1,0 +1,137 @@
+"""Filesystem helpers for uploaded file persistence."""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+from dataclasses import dataclass
+from pathlib import Path
+from shutil import copy2
+from tempfile import NamedTemporaryFile
+from typing import Iterable
+
+from .....config import get_settings
+from .....util.errors import ValidationError
+from .....util.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+@dataclass(slots=True)
+class StoredUpload:
+    """Descriptor for a file persisted to the quarantine directory."""
+
+    path: str
+    original_filename: str
+    size_bytes: int
+    sha256: str
+    content_type: str | None = None
+
+
+def _quarantine_root() -> Path:
+    settings = get_settings()
+    root = Path(settings.artifact_root_path) / "quarantine"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def _random_suffix() -> str:
+    return secrets.token_hex(8)
+
+
+async def persist_upload_file(
+    upload_file: "UploadFile", *, max_bytes: int | None = None
+) -> StoredUpload:  # pragma: no cover - exercised via FastAPI tests
+    """Persist an inbound ``UploadFile`` to disk and compute checksum."""
+
+    try:
+        from fastapi import UploadFile
+    except Exception as exc:  # pragma: no cover - defensive import guard
+        raise RuntimeError("FastAPI UploadFile unavailable") from exc
+
+    if not isinstance(upload_file, UploadFile):  # pragma: no cover - guardrail
+        raise TypeError("persist_upload_file expects a FastAPI UploadFile")
+
+    settings = get_settings()
+    chunk_size = settings.storage_chunk_bytes()
+    quarantine = _quarantine_root()
+    original_name = upload_file.filename or f"upload-{_random_suffix()}"
+    suffix = Path(original_name).suffix or ".bin"
+
+    hasher = hashlib.sha256()
+    size_bytes = 0
+    with NamedTemporaryFile(
+        mode="wb", suffix=suffix, dir=quarantine, delete=False
+    ) as handle:
+        while True:
+            chunk = await upload_file.read(chunk_size)
+            if not chunk:
+                break
+            size_bytes += len(chunk)
+            if max_bytes is not None and size_bytes > max_bytes:
+                handle.close()
+                Path(handle.name).unlink(missing_ok=True)
+                raise ValidationError("uploaded file exceeds configured size limit")
+            hasher.update(chunk)
+            handle.write(chunk)
+        stored_path = handle.name
+
+    sha256 = hasher.hexdigest()
+    logger.info(
+        "upload.persist_upload_file",
+        extra={
+            "path": stored_path,
+            "size_bytes": size_bytes,
+            "sha256": sha256,
+            "content_type": upload_file.content_type,
+        },
+    )
+    # Reset the upload file pointer so downstream consumers can re-read if needed
+    await upload_file.seek(0)
+    return StoredUpload(
+        path=stored_path,
+        original_filename=original_name,
+        size_bytes=size_bytes,
+        sha256=sha256,
+        content_type=upload_file.content_type,
+    )
+
+
+def compute_sha256(path: str | Path) -> str:
+    """Compute the SHA-256 hash for a local file path."""
+
+    target = Path(path)
+    hasher = hashlib.sha256()
+    with target.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def copy_into_doc_dir(source: Path, destination_dir: Path, name_candidates: Iterable[str]) -> Path:
+    """Copy or move a source file into the document directory."""
+
+    destination_dir.mkdir(parents=True, exist_ok=True)
+    clean_names = [candidate for candidate in name_candidates if candidate]
+    filename = clean_names[0] if clean_names else f"upload-{_random_suffix()}{source.suffix}"
+    safe_name = Path(filename).name
+    destination = destination_dir / safe_name
+    if destination.exists():
+        if "quarantine" in source.parts:
+            source.unlink(missing_ok=True)
+        return destination
+    if source.is_file():
+        copy2(source, destination)
+        if "quarantine" in source.parts:
+            source.unlink(missing_ok=True)
+    else:
+        destination.write_bytes(b"")
+    return destination
+
+
+__all__ = [
+    "StoredUpload",
+    "persist_upload_file",
+    "compute_sha256",
+    "copy_into_doc_dir",
+]

--- a/rag-app/backend/app/services/upload_service/upload_controller.py
+++ b/rag-app/backend/app/services/upload_service/upload_controller.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 import hashlib
 import json
+import mimetypes
+import re
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -14,9 +17,13 @@ from ...util.audit import stage_record
 from ...util.errors import AppError, NotFoundError, ValidationError
 from ...util.logging import get_logger
 from .packages.emit.manifest import write_manifest
-from .packages.guards.validators import validate_upload_inputs
+from .packages.guards.validators import (
+    validate_upload_inputs,
+    validate_uploaded_file,
+)
 from .packages.normalize.ocr import try_ocr_if_needed
 from .packages.normalize.pdf_reader import normalize_pdf
+from .packages.storage import StoredUpload, copy_into_doc_dir, compute_sha256
 
 logger = get_logger(__name__)
 
@@ -30,29 +37,93 @@ class NormalizedDocInternal(BaseModel):
     avg_coverage: float
     block_count: int
     ocr_performed: bool
+    sha256: str
+    source_path: str
+    size_bytes: int
+    content_type: str | None
 
 
 def ensure_normalized(
-    file_id: str | None = None, file_name: str | None = None
+    file_id: str | None = None,
+    file_name: str | None = None,
+    upload: StoredUpload | None = None,
 ) -> NormalizedDocInternal:
     """Controller: orchestrates validators, pdf normalize, OCR, manifest & DB."""
     settings = get_settings()
     try:
-        validate_upload_inputs(file_id=file_id, file_name=file_name)
-        doc_id = make_doc_id(file_id=file_id, file_name=file_name)
+        source = _resolve_source(
+            file_id=file_id,
+            file_name=file_name,
+            upload=upload,
+            settings=settings,
+        )
+        doc_id = make_doc_id(
+            file_id=file_id,
+            file_name=source["original_name"],
+            checksum=source["sha256"],
+        )
         artifact_root = Path(settings.artifact_root_path)
         artifact_root.mkdir(parents=True, exist_ok=True)
         doc_dir = artifact_root / doc_id
         doc_dir.mkdir(parents=True, exist_ok=True)
+        source_path = copy_into_doc_dir(
+            Path(source["path"]),
+            doc_dir / "source",
+            [source["original_name"], file_name],
+        )
 
-        logger.info("upload.ensure_normalized.start", extra={"doc_id": doc_id})
-        normalized = normalize_pdf(doc_id=doc_id, file_id=file_id, file_name=file_name)
+        logger.info(
+            "upload.ensure_normalized.start",
+            extra={
+                "doc_id": doc_id,
+                "source": str(source_path),
+                "size_bytes": source["size_bytes"],
+                "sha256": source["sha256"],
+            },
+        )
+
+        normalized_path = doc_dir / "normalize.json"
+        if normalized_path.exists():
+            existing_payload = json.loads(
+                normalized_path.read_text(encoding="utf-8")
+            )
+            manifest = write_manifest(
+                doc_id=doc_id, artifact_path=str(normalized_path), kind="normalize"
+            )
+            stats = existing_payload.get("stats", {})
+            logger.info(
+                "upload.ensure_normalized.cache_hit",
+                extra={
+                    "doc_id": doc_id,
+                    "path": str(normalized_path),
+                    "sha256": source["sha256"],
+                },
+            )
+            return NormalizedDocInternal(
+                doc_id=doc_id,
+                normalized_path=str(normalized_path),
+                manifest_path=manifest["manifest_path"],
+                avg_coverage=float(stats.get("avg_coverage", 0.0)),
+                block_count=int(stats.get("block_count", 0)),
+                ocr_performed=bool(stats.get("ocr_performed", False)),
+                sha256=source["sha256"],
+                source_path=str(source_path),
+                size_bytes=source["size_bytes"],
+                content_type=source["content_type"],
+            )
+
+        normalized = normalize_pdf(
+            doc_id=doc_id,
+            source_path=source_path,
+            source_sha256=source["sha256"],
+            original_filename=source["original_name"],
+            content_type=source["content_type"],
+            size_bytes=source["size_bytes"],
+        )
         normalized = try_ocr_if_needed(normalized)
         normalized.setdefault("audit", []).append(
             stage_record(stage="normalize.persist", status="ok", doc_id=doc_id)
         )
-
-        normalized_path = doc_dir / "normalize.json"
         normalized_path.write_text(
             json.dumps(normalized, indent=2, ensure_ascii=False),
             encoding="utf-8",
@@ -60,31 +131,52 @@ def ensure_normalized(
         manifest = write_manifest(
             doc_id=doc_id, artifact_path=str(normalized_path), kind="normalize"
         )
+        normalized_stats = normalized.get("stats", {})
+        stats = {
+            "avg_coverage": float(normalized_stats.get("avg_coverage", 0.0)),
+            "block_count": int(normalized_stats.get("block_count", 0)),
+            "ocr_performed": bool(normalized_stats.get("ocr_performed", False)),
+        }
         logger.info(
             "upload.ensure_normalized.success",
             extra={
                 "doc_id": doc_id,
                 "path": str(normalized_path),
-                "avg_coverage": normalized["stats"].get("avg_coverage", 0.0),
-                "block_count": normalized["stats"].get("block_count", 0),
-                "ocr_performed": normalized["stats"].get("ocr_performed", False),
+                "avg_coverage": stats["avg_coverage"],
+                "block_count": stats["block_count"],
+                "ocr_performed": stats["ocr_performed"],
+                "sha256": source["sha256"],
+                "size_bytes": source["size_bytes"],
             },
         )
         return NormalizedDocInternal(
             doc_id=doc_id,
             normalized_path=str(normalized_path),
             manifest_path=manifest["manifest_path"],
-            avg_coverage=float(normalized["stats"].get("avg_coverage", 0.0)),
-            block_count=int(normalized["stats"].get("block_count", 0)),
-            ocr_performed=bool(normalized["stats"].get("ocr_performed", False)),
+            avg_coverage=stats["avg_coverage"],
+            block_count=stats["block_count"],
+            ocr_performed=stats["ocr_performed"],
+            sha256=source["sha256"],
+            source_path=str(source_path),
+            size_bytes=source["size_bytes"],
+            content_type=source["content_type"],
         )
     except Exception as exc:  # noqa: BLE001 - convert to domain errors
         handle_upload_errors(exc)
         raise  # pragma: no cover - handle_upload_errors will raise
 
 
-def make_doc_id(file_id: str | None = None, file_name: str | None = None) -> str:
-    """Generate stable doc_id from inputs/time."""
+def make_doc_id(
+    file_id: str | None = None,
+    file_name: str | None = None,
+    checksum: str | None = None,
+) -> str:
+    """Generate stable doc_id from checksum/inputs."""
+
+    if checksum:
+        prefix = _slugify(file_name or file_id or "document")
+        return f"{prefix}-{checksum[:16]}"
+
     timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d%H%M%S%f")
     seed = "|".join(filter(None, [file_id or "", file_name or ""]))
     digest = hashlib.sha1(seed.encode("utf-8"), usedforsecurity=False).hexdigest()[:12]
@@ -103,3 +195,91 @@ def handle_upload_errors(e: Exception) -> None:
         raise
     logger.error("upload.unexpected", extra={"error": str(e), "type": type(e).__name__})
     raise AppError("upload normalization failed") from e
+
+
+def _slugify(candidate: str) -> str:
+    text = candidate.strip().lower()
+    text = re.sub(r"[^a-z0-9]+", "-", text)
+    text = re.sub(r"-+", "-", text).strip("-")
+    return text or "document"
+
+
+def _resolve_source(
+    *,
+    file_id: str | None,
+    file_name: str | None,
+    upload: StoredUpload | None,
+    settings: Any,
+) -> dict[str, Any]:
+    """Resolve the physical file to normalize."""
+
+    if upload is not None:
+        max_bytes = int(settings.upload_max_size_mb) * 1024 * 1024
+        persisted = validate_uploaded_file(
+            path=upload.path,
+            original_filename=upload.original_filename,
+            content_type=upload.content_type,
+            allowed_extensions=settings.upload_allowed_extensions,
+            allowed_mimes=settings.upload_mime_allowlist,
+            max_bytes=max_bytes,
+        )
+        return {
+            "path": upload.path,
+            "original_name": upload.original_filename,
+            "size_bytes": int(persisted["size_bytes"]),
+            "sha256": upload.sha256,
+            "content_type": persisted.get("mime") or upload.content_type,
+        }
+
+    validate_upload_inputs(file_id=file_id, file_name=file_name)
+    if file_name:
+        source_path = Path(file_name)
+        if not source_path.exists():
+            raise FileNotFoundError(file_name)
+        sha256 = compute_sha256(source_path)
+        guessed_type, _ = mimetypes.guess_type(source_path.name)
+        allowed_extensions = list(settings.upload_allowed_extensions)
+        allowed_mimes = list(settings.upload_mime_allowlist)
+        suffix = source_path.suffix.lower()
+        if suffix and suffix not in {ext.lower() for ext in allowed_extensions}:
+            allowed_extensions.append(suffix)
+        if guessed_type and guessed_type not in allowed_mimes:
+            allowed_mimes.append(guessed_type)
+        persisted = validate_uploaded_file(
+            path=str(source_path),
+            original_filename=source_path.name,
+            content_type=guessed_type,
+            allowed_extensions=allowed_extensions,
+            allowed_mimes=allowed_mimes,
+            max_bytes=int(settings.upload_max_size_mb) * 1024 * 1024,
+        )
+        return {
+            "path": str(source_path),
+            "original_name": source_path.name,
+            "size_bytes": int(persisted["size_bytes"]),
+            "sha256": sha256,
+            "content_type": persisted.get("mime") or guessed_type,
+        }
+
+    candidate = file_id or ""
+    temp_path = Path(settings.artifact_root_path) / "quarantine"
+    temp_path.mkdir(parents=True, exist_ok=True)
+    name = f"inline-{datetime.now(tz=timezone.utc).strftime('%Y%m%d%H%M%S%f')}.txt"
+    target = temp_path / name
+    target.write_text(candidate, encoding="utf-8")
+    sha256 = compute_sha256(target)
+    persisted = validate_uploaded_file(
+        path=str(target),
+        original_filename=name,
+        content_type="text/plain",
+        allowed_extensions=settings.upload_allowed_extensions + [".txt"],
+        allowed_mimes=settings.upload_mime_allowlist + ["text/plain"],
+        max_bytes=int(settings.upload_max_size_mb) * 1024 * 1024,
+    )
+    return {
+        "path": str(target),
+        "original_name": name,
+        "size_bytes": int(persisted["size_bytes"]),
+        "sha256": sha256,
+        "content_type": persisted.get("mime") or "text/plain",
+    }

--- a/rag-app/backend/app/tests/unit/test_orchestrator_routes.py
+++ b/rag-app/backend/app/tests/unit/test_orchestrator_routes.py
@@ -61,6 +61,11 @@ def _prepare_normalized_doc(doc_id: str) -> NormalizedDoc:
     manifest_path = Path(str(manifest_payload["manifest_path"]))
     manifest_path.write_text(json.dumps(manifest_payload), encoding="utf-8")
 
+    source_dir = doc_root / "source"
+    source_dir.mkdir(parents=True, exist_ok=True)
+    source_file = source_dir / "document.pdf"
+    source_file.write_bytes(b"%PDF-1.4")
+
     return NormalizedDoc(
         doc_id=doc_id,
         normalized_path=str(normalized_path),
@@ -68,6 +73,10 @@ def _prepare_normalized_doc(doc_id: str) -> NormalizedDoc:
         avg_coverage=0.6,
         block_count=4,
         ocr_performed=False,
+        sha256="abc123",
+        source_path=str(source_file),
+        size_bytes=2048,
+        content_type="application/pdf",
     )
 
 

--- a/rag-app/backend/app/tests/unit/test_route_error_mapping.py
+++ b/rag-app/backend/app/tests/unit/test_route_error_mapping.py
@@ -22,6 +22,10 @@ def _make_normalized_doc() -> NormalizedDoc:
         doc_id="doc",
         normalized_path="/tmp/normalize.json",
         manifest_path="/tmp/manifest.json",
+        sha256="abc123",
+        source_path="/tmp/source.pdf",
+        size_bytes=1024,
+        content_type="application/pdf",
     )
 
 

--- a/rag-app/requirements.txt
+++ b/rag-app/requirements.txt
@@ -5,3 +5,10 @@ pydantic-settings==2.2.1
 python-dotenv==1.0.1
 pytest==8.1.1
 httpx==0.27.0
+Pillow==10.3.0
+pdfplumber==0.11.0
+pymupdf==1.24.6
+pytesseract==0.3.10
+filetype==1.2.0
+langdetect==1.0.9
+python-multipart==0.0.20


### PR DESCRIPTION
## Summary
- add multipart upload handling with quarantine persistence, checksum-based doc IDs, and stronger validators for file ingestion
- replace PDF normalization/OCR stubs with PyMuPDF/pdfplumber extraction, graceful OCR fallback, and richer artifact metadata
- upgrade parser fan-out to timed sequential extractors and update documentation/tests to reflect resolved Phase 1 gaps

## Testing
- pytest rag-app/backend/app/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68db2b6b57e883249fe4c7af83b55c43