### PR TITLE
Add guarded upload route and integration test

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,6 +2,7 @@
 testpaths =
     rag-app/backend/app/tests
     rag-app/tests
+    tests
 pythonpath = rag-app
 markers =
     phase4: Phase 4 acceptance coverage
@@ -10,3 +11,4 @@ markers =
     phase7: Phase 7 acceptance coverage
     phase8: Phase 8 acceptance coverage
     phase9: Phase 9 acceptance coverage
+    integration: Integration-level upload verification

--- a/rag-app/backend/app/adapters/__init__.py
+++ b/rag-app/backend/app/adapters/__init__.py
@@ -3,8 +3,12 @@
 from .db import upsert_document_record
 from .llm import LLMClient, call_llm
 from .storage import (
+    StorageAdapter,
+    assert_no_unmanaged_writes,
     ensure_parent_dirs,
+    get_storage_guard,
     read_jsonl,
+    reset_storage_guard,
     stream_read,
     stream_write,
     write_json,
@@ -26,11 +30,15 @@ __all__ = [
     "hybrid_search",
     "LLMClient",
     "call_llm",
+    "StorageAdapter",
+    "assert_no_unmanaged_writes",
     "write_json",
     "write_jsonl",
     "read_jsonl",
     "stream_read",
     "stream_write",
     "ensure_parent_dirs",
+    "get_storage_guard",
+    "reset_storage_guard",
     "upsert_document_record",
 ]

--- a/rag-app/backend/app/routes/upload.py
+++ b/rag-app/backend/app/routes/upload.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, File, HTTPException, UploadFile
 from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel
 
 from ..services.upload_service import NormalizedDoc, ensure_normalized
 from ..util.errors import AppError, NotFoundError, ValidationError
+from ..util.logging import get_logger
 
 router = APIRouter(prefix="/upload", tags=["upload"])
+
+logger = get_logger(__name__)
 
 
 class UploadRequest(BaseModel):
@@ -23,8 +26,34 @@ class UploadRequest(BaseModel):
 async def normalize_upload(request: UploadRequest) -> NormalizedDoc:
     """Normalize an uploaded file and return artifact metadata."""
     try:
+        logger.info(
+            "route.upload.normalize", extra={"file_id": request.file_id, "file_name": request.file_name}
+        )
         return await run_in_threadpool(
             ensure_normalized, request.file_id, request.file_name
+        )
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except NotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except AppError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.post("/pdf", response_model=NormalizedDoc)
+async def upload_pdf(file: UploadFile = File(...)) -> NormalizedDoc:
+    """Accept a raw PDF upload and process it via the upload service."""
+
+    try:
+        filename = file.filename or "uploaded.pdf"
+        logger.info("route.upload.pdf", extra={"upload_filename": filename})
+        payload = await file.read()
+        return await run_in_threadpool(
+            ensure_normalized,
+            None,
+            None,
+            upload_bytes=payload,
+            upload_filename=filename,
         )
     except ValidationError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/rag-app/backend/app/services/upload_service/main.py
+++ b/rag-app/backend/app/services/upload_service/main.py
@@ -19,14 +19,22 @@ class NormalizedDoc(BaseModel):
     ocr_performed: bool = False
     source_checksum: str = Field(min_length=1)
     source_bytes: int = Field(default=0, ge=0)
+    source_path: str = Field(min_length=1)
 
 
 def ensure_normalized(
-    file_id: str | None = None, file_name: str | None = None
+    file_id: str | None = None,
+    file_name: str | None = None,
+    *,
+    upload_bytes: bytes | None = None,
+    upload_filename: str | None = None,
 ) -> NormalizedDoc:
     """Validate/normalize upload and emit normalize.json"""
     internal: NormalizedDocInternal = controller_ensure_normalized(
-        file_id=file_id, file_name=file_name
+        file_id=file_id,
+        file_name=file_name,
+        upload_bytes=upload_bytes,
+        upload_filename=upload_filename,
     )
     return NormalizedDoc(**internal.model_dump())
 

--- a/rag-app/backend/app/tests/unit/test_orchestrator_routes.py
+++ b/rag-app/backend/app/tests/unit/test_orchestrator_routes.py
@@ -46,6 +46,9 @@ def _prepare_normalized_doc(doc_id: str) -> NormalizedDoc:
     doc_root = artifact_root / doc_id
     doc_root.mkdir(parents=True, exist_ok=True)
 
+    source_path = doc_root / "source.pdf"
+    source_path.write_bytes(b"%PDF-1.4 test")
+
     normalized_path = doc_root / "normalize.json"
     normalized_path.write_text("{}", encoding="utf-8")
 
@@ -70,6 +73,7 @@ def _prepare_normalized_doc(doc_id: str) -> NormalizedDoc:
         ocr_performed=False,
         source_checksum="abc123",
         source_bytes=normalized_path.stat().st_size,
+        source_path=str(source_path),
     )
 
 

--- a/rag-app/backend/app/tests/unit/test_route_error_mapping.py
+++ b/rag-app/backend/app/tests/unit/test_route_error_mapping.py
@@ -24,6 +24,7 @@ def _make_normalized_doc() -> NormalizedDoc:
         manifest_path="/tmp/manifest.json",
         source_checksum="abc123",
         source_bytes=10,
+        source_path="/tmp/source.pdf",
     )
 
 

--- a/rag-app/backend/app/tests/unit/test_upload.py
+++ b/rag-app/backend/app/tests/unit/test_upload.py
@@ -27,6 +27,12 @@ def test_validate_upload_inputs_rejects_invalid() -> None:
         validate_upload_inputs(file_name="https://example.com/file.pdf")
     with pytest.raises(ValidationError):
         validate_upload_inputs(file_name="unsafe\nname.pdf")
+    with pytest.raises(ValidationError):
+        validate_upload_inputs(upload_bytes=b"", upload_filename="doc.pdf")
+    with pytest.raises(ValidationError):
+        validate_upload_inputs(
+            file_id="abc", upload_bytes=b"data", upload_filename="doc.pdf"
+        )
 
 
 def test_ensure_normalized_emits_manifest(sample_pdf_path: Path) -> None:

--- a/rag-app/requirements.txt
+++ b/rag-app/requirements.txt
@@ -1,4 +1,5 @@
 fastapi>=0.111,<1.0
+python-multipart>=0.0.7
 uvicorn[standard]>=0.22,<1.0
 pydantic==2.6.4
 pydantic-settings==2.2.1

--- a/sample_docs/Epf, Co.pdf
+++ b/sample_docs/Epf, Co.pdf
@@ -1,0 +1,16 @@
+%PDF-1.4
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj
+2 0 obj<</Type/Pages/Count 1/Kids[3 0 R]>>endobj
+3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 200 200]/Contents 4 0 R>>endobj
+4 0 obj<</Length 44>>stream
+BT /F1 12 Tf 72 120 Td (hello) Tj ET
+endstream endobj
+xref
+0 5
+0000000000 65535 f 
+0000000010 00000 n 
+0000000060 00000 n 
+0000000117 00000 n 
+0000000210 00000 n 
+trailer<</Root 1 0 R>>
+%%EOF

--- a/tests/integration/test_upload_epf_co.py
+++ b/tests/integration/test_upload_epf_co.py
@@ -1,0 +1,141 @@
+"""Integration test verifying the guarded upload pipeline."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.app.adapters.storage import (
+    StorageAdapter,
+    assert_no_unmanaged_writes,
+    reset_storage_guard,
+)
+from backend.app.config import get_settings
+from backend.app.main import create_app
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture()
+def test_environment(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Isolate settings and storage guard for the integration test."""
+
+    artifact_root = tmp_path / "artifacts"
+    monkeypatch.setenv("FLUIDRAG_OFFLINE", "true")
+    monkeypatch.setenv("ARTIFACT_ROOT", str(artifact_root))
+    get_settings.cache_clear()
+    reset_storage_guard()
+    yield artifact_root
+    reset_storage_guard()
+    get_settings.cache_clear()
+
+
+@pytest.fixture()
+def app_client(test_environment: Path) -> TestClient:
+    """Return a FastAPI test client bound to the upload routes."""
+
+    app = create_app()
+    client = TestClient(app)
+    try:
+        yield client
+    finally:
+        client.close()
+
+
+@pytest.fixture()
+def storage_adapter_spy(monkeypatch: pytest.MonkeyPatch):
+    """Spy on StorageAdapter.save_source_pdf invocations."""
+
+    calls: list[dict[str, object]] = []
+    original = StorageAdapter.save_source_pdf
+
+    def traced(self, *, doc_id: str, filename: str | None, payload: bytes):
+        path = original(self, doc_id=doc_id, filename=filename, payload=payload)
+        calls.append(
+            {
+                "doc_id": doc_id,
+                "filename": filename,
+                "bytes": len(payload),
+                "path": path,
+            }
+        )
+        return path
+
+    monkeypatch.setattr(StorageAdapter, "save_source_pdf", traced)
+
+    class Spy:
+        @property
+        def called(self) -> bool:
+            return bool(calls)
+
+        def calls_for(self, doc_id: str) -> int:
+            return sum(1 for call in calls if call["doc_id"] == doc_id)
+
+        def paths(self) -> list[Path]:
+            return [call["path"] for call in calls]
+
+    return Spy()
+
+
+def _ensure_sample_pdf() -> Path:
+    sample_dir = Path("sample_docs")
+    sample_dir.mkdir(parents=True, exist_ok=True)
+    pdf_path = sample_dir / "Epf, Co.pdf"
+    if not pdf_path.exists():
+        pdf_bytes = (
+            b"%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n"
+            b"2 0 obj<</Type/Pages/Count 1/Kids[3 0 R]>>endobj\n"
+            b"3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 200 200]/Contents 4 0 R>>endobj\n"
+            b"4 0 obj<</Length 44>>stream\nBT /F1 12 Tf 72 120 Td (hello) Tj ET\nendstream endobj\n"
+            b"xref\n0 5\n0000000000 65535 f \n0000000010 00000 n \n"
+            b"0000000060 00000 n \n0000000117 00000 n \n0000000210 00000 n \n"
+            b"trailer<</Root 1 0 R>>\n%%EOF"
+        )
+        pdf_path.write_bytes(pdf_bytes)
+    return pdf_path
+
+
+def test_upload_pdf_uses_app_functions_only(
+    app_client: TestClient,
+    storage_adapter_spy,
+    test_environment: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Uploading a PDF must flow through controller → service → storage adapter."""
+
+    pdf_path = _ensure_sample_pdf()
+    with pdf_path.open("rb") as handle:
+        files = {"file": (pdf_path.name, io.BytesIO(handle.read()), "application/pdf")}
+        response = app_client.post("/upload/pdf", files=files)
+
+    assert response.status_code == 200
+    payload = response.json()
+    doc_id = payload.get("doc_id")
+    assert doc_id, "doc_id missing from upload response"
+
+    assert storage_adapter_spy.called, "StorageAdapter.save_source_pdf was not invoked"
+    assert storage_adapter_spy.calls_for(doc_id) >= 1
+
+    managed_path = test_environment / doc_id / "source.pdf"
+    assert managed_path.is_file(), f"Missing managed source PDF at {managed_path}"
+
+    assert_no_unmanaged_writes()
+
+    existing_pdfs = {path.resolve() for path in test_environment.rglob("*.pdf")}
+    reset_storage_guard()
+
+    def blocked(self, *, doc_id: str, filename: str | None, payload: bytes):
+        raise RuntimeError("storage adapter blocked")
+
+    monkeypatch.setattr(StorageAdapter, "save_source_pdf", blocked)
+
+    with pdf_path.open("rb") as handle:
+        files = {"file": (pdf_path.name, io.BytesIO(handle.read()), "application/pdf")}
+        failure = app_client.post("/upload/pdf", files=files)
+
+    assert failure.status_code >= 500
+    new_pdfs = {path.resolve() for path in test_environment.rglob("*.pdf")}
+    assert new_pdfs == existing_pdfs, "Unexpected unmanaged PDF write detected"


### PR DESCRIPTION
## Summary
- add a multipart POST /upload/pdf route wired into the existing normalization service
- instrument the storage adapter with guard tracking and update validation to support direct PDF uploads
- add the Epf, Co.pdf sample and an integration test to verify uploads only use the sanctioned path

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dbbbe604a4832494e5edf2af3f46de