### PR TITLE
Normalize ordinal parsing in header repair

### DIFF
--- a/rag-app/backend/app/services/header_service/packages/repair/sequence.py
+++ b/rag-app/backend/app/services/header_service/packages/repair/sequence.py
@@ -12,6 +12,17 @@ _MIN_STRONG_SCORE = 0.55
 _MIN_RECOVERY_SCORE = 0.35
 
 
+def _as_int_ordinal(value: Any) -> int | None:
+    """Safely convert an ordinal value into an integer if possible."""
+
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def _series_bucket(header: dict[str, Any]) -> str:
     return str(header.get("section_key") or "root").lower()
 
@@ -28,7 +39,7 @@ def repair_sequence(headers: list[dict[str, Any]]) -> list[dict[str, Any]]:
     for series, series_headers in buckets.items():
         ordered = sorted(
             series_headers,
-            key=lambda h: (h.get("ordinal") or 0, h.get("chunk_index", 0)),
+            key=lambda h: (_as_int_ordinal(h.get("ordinal")) or 0, h.get("chunk_index", 0)),
         )
         strong = [h for h in ordered if float(h.get("score", 0.0)) >= _MIN_STRONG_SCORE]
         weak = [
@@ -36,6 +47,16 @@ def repair_sequence(headers: list[dict[str, Any]]) -> list[dict[str, Any]]:
             for h in ordered
             if _MIN_RECOVERY_SCORE <= float(h.get("score", 0.0)) < _MIN_STRONG_SCORE
         ]
+        weak_lookup: dict[int, dict[str, Any]] = {}
+        for weak_header in weak:
+            ordinal_int = _as_int_ordinal(weak_header.get("ordinal"))
+            if ordinal_int is None:
+                continue
+            existing = weak_lookup.get(ordinal_int)
+            if existing is None or float(weak_header.get("score", 0.0)) > float(
+                existing.get("score", 0.0)
+            ):
+                weak_lookup[ordinal_int] = weak_header
         if not strong:
             # Promote the best weak candidate to ensure coverage if it looks plausible.
             if weak:
@@ -45,36 +66,66 @@ def repair_sequence(headers: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 strong.append(best)
         recovered_ordinals: set[int] = set()
         strong_sorted = sorted(
-            strong, key=lambda h: (h.get("ordinal") or 0, h.get("chunk_index", 0))
+            strong,
+            key=lambda h: (_as_int_ordinal(h.get("ordinal")) or 0, h.get("chunk_index", 0)),
         )
         for i, header in enumerate(strong_sorted):
             repaired.append(header)
-            current_ord = header.get("ordinal")
+            current_ord = _as_int_ordinal(header.get("ordinal"))
             if current_ord is None:
                 continue
             next_ord = None
             if i + 1 < len(strong_sorted):
-                next_ord = strong_sorted[i + 1].get("ordinal")
+                next_ord = _as_int_ordinal(strong_sorted[i + 1].get("ordinal"))
             if next_ord is None:
                 continue
-            gap = int(next_ord) - int(current_ord)
+            gap = next_ord - current_ord
             if gap <= 1:
                 continue
-            for missing in range(int(current_ord) + 1, int(next_ord)):
+            for missing in range(current_ord + 1, next_ord):
                 if missing in recovered_ordinals:
                     continue
-                candidate = None
-                for weak_header in weak:
-                    if int(weak_header.get("ordinal") or -1) == missing:
-                        candidate = dict(weak_header)
-                        break
+                candidate = weak_lookup.get(missing)
                 if candidate:
+                    candidate = dict(candidate)
                     candidate["recovered"] = True
                     candidate["score"] = max(
                         candidate.get("score", 0.0), _MIN_RECOVERY_SCORE
                     )
                     recovered_ordinals.add(missing)
                     repaired.append(candidate)
+        ordinal_values = [
+            ordinal
+            for header in strong_sorted
+            if (ordinal := _as_int_ordinal(header.get("ordinal"))) is not None
+        ]
+        if ordinal_values:
+            min_strong = min(ordinal_values)
+            max_strong = max(ordinal_values)
+            for missing in sorted(
+                ord_val
+                for ord_val in weak_lookup
+                if ord_val < min_strong and ord_val not in recovered_ordinals
+            ):
+                candidate = dict(weak_lookup[missing])
+                candidate["recovered"] = True
+                candidate["score"] = max(
+                    candidate.get("score", 0.0), _MIN_RECOVERY_SCORE
+                )
+                recovered_ordinals.add(missing)
+                repaired.append(candidate)
+            for missing in sorted(
+                ord_val
+                for ord_val in weak_lookup
+                if ord_val > max_strong and ord_val not in recovered_ordinals
+            ):
+                candidate = dict(weak_lookup[missing])
+                candidate["recovered"] = True
+                candidate["score"] = max(
+                    candidate.get("score", 0.0), _MIN_RECOVERY_SCORE
+                )
+                recovered_ordinals.add(missing)
+                repaired.append(candidate)
         logger.debug(
             "headers.repair.series",
             extra={
@@ -84,7 +135,12 @@ def repair_sequence(headers: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 "recovered": len(recovered_ordinals),
             },
         )
-    repaired.sort(key=lambda h: (h.get("chunk_index", 0), h.get("ordinal") or 0))
+    repaired.sort(
+        key=lambda h: (
+            h.get("chunk_index", 0),
+            _as_int_ordinal(h.get("ordinal")) or 0,
+        )
+    )
     return repaired
 
 

--- a/rag-app/requirements-dev.txt
+++ b/rag-app/requirements-dev.txt
@@ -1,3 +1,4 @@
+-r requirements.txt
 pytest-cov==5.0.0
 mypy==1.10.0
 ruff==0.5.6


### PR DESCRIPTION
## Summary
- track weak appendix candidates by ordinal so sequence repair can promote the best low-scoring options
- backfill leading and trailing gaps when only weak candidates exist, keeping recovered headers flagged for audit visibility
- guard ordinal parsing while ordering and filling gaps, and ensure dev installs also pull in the multipart dependency

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dbc041d8988324bf3fc07a74cd84bc