### PR TITLE
Plan Phase 2 upload/parser finalstubs

### DIFF
--- a/app_plan/finalstubs_config.json
+++ b/app_plan/finalstubs_config.json
@@ -1,0 +1,80 @@
+{
+  "module": "config",
+  "version": "phase2.v1",
+  "files": [
+    {
+      "path": "configs/app.toml",
+      "sections": {
+        "upload": {
+          "max_mb": {"type": "int", "default": 100, "description": "Maximum allowed upload size in megabytes."},
+          "allowed_ext": {"type": "list[str]", "default": [".pdf"], "description": "Allowed file extensions."},
+          "allowed_mime": {"type": "list[str]", "default": ["application/pdf"], "description": "Allowed MIME types after sniffing."},
+          "storage.temp": {"type": "str", "default": "storage/uploads/tmp", "description": "Temporary upload directory."},
+          "storage.final": {"type": "str", "default": "storage/uploads/final", "description": "Final upload directory."},
+          "rate_limit.per_minute": {"type": "int", "default": 60, "description": "Requests per minute allowed per client."}
+        },
+        "parser": {
+          "ocr.enabled": {"type": "bool", "default": true, "description": "Enable OCR fallback."},
+          "ocr.languages": {"type": "list[str]", "default": ["eng"], "description": "Languages to pass to Tesseract."},
+          "tuning.enabled": {"type": "bool", "default": true, "description": "Allow bounded coordinate search for EFHG parameters."},
+          "efhg.weights.regex": {"type": "float", "default": 1.0},
+          "efhg.weights.style": {"type": "float", "default": 1.0},
+          "efhg.weights.entropy": {"type": "float", "default": 0.8},
+          "efhg.weights.graph": {"type": "float", "default": 1.1},
+          "efhg.weights.fluid": {"type": "float", "default": 0.9},
+          "efhg.weights.llm_vote": {"type": "float", "default": 1.0},
+          "efhg.thresholds.header": {"type": "float", "default": 0.65},
+          "efhg.thresholds.subheader": {"type": "float", "default": 0.5},
+          "efhg.stitching.adjacency_weight": {"type": "float", "default": 0.8},
+          "efhg.stitching.entropy_join_delta": {"type": "float", "default": 0.15},
+          "efhg.stitching.style_cont_threshold": {"type": "float", "default": 0.7},
+          "sequence_repair.hole_penalty": {"type": "float", "default": 0.4},
+          "sequence_repair.max_gap_span_pages": {"type": "int", "default": 2},
+          "sequence_repair.min_schema_support": {"type": "int", "default": 2}
+        },
+        "cors": {
+          "allowed_origins": {"type": "list[str]", "default": ["*"]},
+          "allowed_methods": {"type": "list[str]", "default": ["GET", "POST"]},
+          "allowed_headers": {"type": "list[str]", "default": ["Authorization", "Content-Type"]}
+        },
+        "logging": {
+          "level": {"type": "str", "default": "INFO"},
+          "json": {"type": "bool", "default": true}
+        }
+      }
+    }
+  ],
+  "tuned_config": {
+    "path": "configs/tuned/header_detector.toml",
+    "precedence": {
+      "order": ["configs/tuned/header_detector.toml", "configs/app.toml"],
+      "merge_strategy": "Tuned config overrides parser.* keys when timestamp is newer; fallback to app defaults otherwise."
+    },
+    "schema": {
+      "efhg": {
+        "weights": {
+          "regex": "float",
+          "style": "float",
+          "entropy": "float",
+          "graph": "float",
+          "fluid": "float",
+          "llm_vote": "float"
+        },
+        "thresholds": {
+          "header": "float",
+          "subheader": "float"
+        },
+        "stitching": {
+          "adjacency_weight": "float",
+          "entropy_join_delta": "float",
+          "style_cont_threshold": "float"
+        }
+      },
+      "sequence_repair": {
+        "hole_penalty": "float",
+        "max_gap_span_pages": "int",
+        "min_schema_support": "int"
+      }
+    }
+  }
+}

--- a/app_plan/finalstubs_latest.json
+++ b/app_plan/finalstubs_latest.json
@@ -1,0 +1,130 @@
+{
+  "version": "phase2.finalstubs.v1",
+  "generated_at": "2024-06-09T00:00:00Z",
+  "description": "Aggregator for Phase 2 upload and parser finalstubs. These definitions supersede earlier drafts and will drive Phase 3 implementation.",
+  "modules": [
+    {
+      "name": "upload_service",
+      "path": "app_plan/finalstubs_upload.json",
+      "version": "phase2.v1",
+      "summary": "Route contract, validation, storage, and error handling for POST /api/uploads."
+    },
+    {
+      "name": "upload_controller",
+      "path": "app_plan/finalstubs_upload_controller.json",
+      "version": "phase2.v1",
+      "summary": "Orchestration logic linking upload persistence with parser job submission and observability."
+    },
+    {
+      "name": "parser_pipeline",
+      "path": "app_plan/finalstubs_parser.json",
+      "version": "phase2.v1",
+      "summary": "Extractor hierarchy, normalization, UF chunking, EFHG scoring, sequence repair, artifacts, and result routes."
+    },
+    {
+      "name": "config",
+      "path": "app_plan/finalstubs_config.json",
+      "version": "phase2.v1",
+      "summary": "TOML configuration keys and tuned config precedence for upload and parser subsystems."
+    },
+    {
+      "name": "logging_telemetry",
+      "path": "app_plan/finalstubs_logging_telemetry.json",
+      "version": "phase2.v1",
+      "summary": "Structured logging, metrics, and tracing expectations across upload and parser flows."
+    },
+    {
+      "name": "tests",
+      "path": "app_plan/finalstubs_tests.json",
+      "version": "phase2.v1",
+      "summary": "Acceptance tests required in Phase 3 covering validation, parser correctness, and API flows."
+    }
+  ],
+  "contracts": {
+    "routes": [
+      {
+        "method": "POST",
+        "path": "/api/uploads",
+        "module_ref": "upload_service",
+        "response_schema": "docs/schemas/upload_response.schema.json"
+      },
+      {
+        "method": "GET",
+        "path": "/api/docs/{doc_id}",
+        "module_ref": "parser_pipeline",
+        "response_schema": "docs/schemas/status_response.schema.json"
+      },
+      {
+        "method": "GET",
+        "path": "/api/docs/{doc_id}/headers",
+        "module_ref": "parser_pipeline",
+        "response_schema": "docs/schemas/headers_tree.schema.json"
+      }
+    ],
+    "job_flow": {
+      "submission": "upload_controller -> parser.jobs.submit_job",
+      "status_source": "uploads table state model",
+      "artifacts_dir": "storage/parser/{doc_id}"
+    },
+    "config_keys": [
+      "upload.max_mb",
+      "upload.allowed_ext",
+      "upload.allowed_mime",
+      "upload.storage.temp",
+      "upload.storage.final",
+      "upload.rate_limit.per_minute",
+      "parser.ocr.enabled",
+      "parser.ocr.languages",
+      "parser.tuning.enabled",
+      "parser.efhg.weights.regex",
+      "parser.efhg.weights.style",
+      "parser.efhg.weights.entropy",
+      "parser.efhg.weights.graph",
+      "parser.efhg.weights.fluid",
+      "parser.efhg.weights.llm_vote",
+      "parser.efhg.thresholds.header",
+      "parser.efhg.thresholds.subheader",
+      "parser.efhg.stitching.adjacency_weight",
+      "parser.efhg.stitching.entropy_join_delta",
+      "parser.efhg.stitching.style_cont_threshold",
+      "parser.sequence_repair.hole_penalty",
+      "parser.sequence_repair.max_gap_span_pages",
+      "parser.sequence_repair.min_schema_support",
+      "logging.level",
+      "logging.json",
+      "logging.efhg.debug_rate",
+      "cors.allowed_origins",
+      "cors.allowed_methods",
+      "cors.allowed_headers"
+    ],
+    "artifact_schemas": [
+      {
+        "schema": "docs/schemas/upload_response.schema.json",
+        "describes": "Response payload returned by POST /api/uploads"
+      },
+      {
+        "schema": "docs/schemas/headers_tree.schema.json",
+        "describes": "detected_headers.json file and GET /api/docs/{doc_id}/headers payload"
+      },
+      {
+        "schema": "docs/schemas/gaps_report.schema.json",
+        "describes": "gaps.json artifact"
+      },
+      {
+        "schema": "docs/schemas/status_response.schema.json",
+        "describes": "GET /api/docs/{doc_id} payload"
+      }
+    ],
+    "tests": {
+      "required": [
+        "tests/test_upload_validation.py",
+        "tests/test_parser_headers.py",
+        "tests/test_api_flow.py"
+      ]
+    }
+  },
+  "compatibility": {
+    "breaking_changes": false,
+    "notes": "Routes reuse existing /api/docs patterns; POST /api/uploads replaces prior /pipeline/run upload semantics with richer validation."
+  }
+}

--- a/app_plan/finalstubs_logging_telemetry.json
+++ b/app_plan/finalstubs_logging_telemetry.json
@@ -1,0 +1,65 @@
+{
+  "module": "logging_telemetry",
+  "version": "phase2.v1",
+  "logging": {
+    "format": "structured_json",
+    "fields": {
+      "request_id": "propagated from upload controller into parser pipeline",
+      "doc_id": "present on every event after validation",
+      "job_id": "attached once parser job is enqueued",
+      "event": "short action string (upload.received, parser.chunking.started, parser.efhg.promote)",
+      "duration_ms": "optional timing information per stage",
+      "error_code": "populate when failures occur"
+    },
+    "levels": {
+      "upload.validation": "INFO",
+      "upload.rejection": "WARNING",
+      "parser.extract": "INFO",
+      "parser.efhg": "DEBUG",
+      "parser.sequence_repair": "DEBUG",
+      "parser.error": "ERROR"
+    },
+    "efhg_debug_payload": {
+      "enabled": true,
+      "fields": ["uf_chunk_id", "component_scores", "thresholds", "decision"],
+      "sampling": {
+        "mode": "probabilistic",
+        "rate": 1.0,
+        "config_key": "logging.efhg.debug_rate"
+      }
+    }
+  },
+  "telemetry": {
+    "metrics": {
+      "namespace": "fluidrag",
+      "counters": [
+        "upload.requests.total",
+        "upload.requests.rejected",
+        "parser.documents.completed",
+        "parser.documents.failed"
+      ],
+      "gauges": [
+        "parser.queue.depth"
+      ],
+      "histograms": [
+        "upload.duration.ms",
+        "parser.extract.duration.ms",
+        "parser.total.duration.ms"
+      ]
+    },
+    "tracing": {
+      "enabled": true,
+      "instrumentation": "OpenTelemetry FastAPI + background tasks",
+      "spans": [
+        "upload.receive",
+        "upload.save",
+        "parser.extract",
+        "parser.chunk",
+        "parser.efhg",
+        "parser.sequence_repair",
+        "parser.artifacts.write"
+      ],
+      "attributes": ["request_id", "doc_id", "job_id", "component"]
+    }
+  }
+}

--- a/app_plan/finalstubs_parser.json
+++ b/app_plan/finalstubs_parser.json
@@ -1,0 +1,235 @@
+{
+  "module": "parser_pipeline",
+  "version": "phase2.v1",
+  "overview": "Deterministic PDF parser that extracts text with style metadata, performs UF chunking, EFHG scoring, sequence repair, and emits audit artifacts beyond RAG-Anything capabilities.",
+  "extractors": {
+    "order": ["pymupdf", "pdfplumber", "pdfminer", "ocr_tesseract"],
+    "pymupdf": {
+      "enabled": true,
+      "notes": "Primary extractor; return page-level spans with font size/weight/flags and bounding boxes.",
+      "failure_modes": ["encrypted_pdf", "unsupported_font"]
+    },
+    "pdfplumber": {
+      "enabled": true,
+      "trigger": "Fallback when PyMuPDF raises extraction errors or returns <80% page coverage.",
+      "style_capture": "Capture font size approximations and line breaks."
+    },
+    "pdfminer": {
+      "enabled": true,
+      "trigger": "Used when both PyMuPDF and pdfplumber fail; ensures text extraction for unusual encodings.",
+      "limitations": "Style fidelity is reduced; normalization must reconcile inconsistent whitespace."
+    },
+    "ocr_tesseract": {
+      "enabled": true,
+      "config_key": "parser.ocr.enabled",
+      "trigger": "Pages flagged as image-only (<5 text characters) are routed through OCR.",
+      "output_format": "hOCR parsed into spans with bounding boxes and dummy style metadata",
+      "language_config": "parser.ocr.languages"
+    }
+  },
+  "normalization": {
+    "unicode_normalization": "NFKC",
+    "ligature_map": "Apply standard replacements (ﬁ -> fi, ﬂ -> fl, …)",
+    "whitespace_policy": "Preserve intentional line breaks; collapse internal sequences greater than one space unless style tokens indicate fixed width.",
+    "style_cues": ["font_size", "font_weight", "font_name", "leading", "bbox"],
+    "tokenization": {
+      "strategy": "Deterministic whitespace tokenizer with fallback to spaCy for debugging",
+      "seed": 0
+    }
+  },
+  "chunking": {
+    "type": "UF",
+    "max_tokens": 90,
+    "overlap_tokens": 12,
+    "id_policy": {
+      "format": "{doc_id}:uf:{page}:{index}",
+      "stability": "Ids must remain stable between runs for identical inputs."
+    }
+  },
+  "efhg_scoring": {
+    "components": [
+      {
+        "name": "regex",
+        "description": "Detect numbering schemas (numeric, appendix, letter-numeric) using compiled regex families.",
+        "weight_config_key": "parser.efhg.weights.regex",
+        "default_weight": 1.0
+      },
+      {
+        "name": "style",
+        "description": "Assess font size/weight/leading contrasts vs neighborhood text.",
+        "weight_config_key": "parser.efhg.weights.style",
+        "default_weight": 1.0
+      },
+      {
+        "name": "entropy",
+        "description": "Measure entropy troughs/peaks around candidate boundaries.",
+        "weight_config_key": "parser.efhg.weights.entropy",
+        "default_weight": 0.8
+      },
+      {
+        "name": "graph",
+        "description": "Use punctuation and line-break graph to score adjacency cues.",
+        "weight_config_key": "parser.efhg.weights.graph",
+        "default_weight": 1.1
+      },
+      {
+        "name": "fluid",
+        "description": "Model-based confidence that text is header-like vs body content.",
+        "weight_config_key": "parser.efhg.weights.fluid",
+        "default_weight": 0.9
+      },
+      {
+        "name": "llm_vote",
+        "description": "Soft agreement from lightweight LLM heuristics without literal strings.",
+        "weight_config_key": "parser.efhg.weights.llm_vote",
+        "default_weight": 1.0
+      }
+    ],
+    "thresholds": {
+      "t_header": {
+        "default": 0.65,
+        "config_key": "parser.efhg.thresholds.header"
+      },
+      "t_subheader": {
+        "default": 0.5,
+        "config_key": "parser.efhg.thresholds.subheader"
+      }
+    },
+    "stitching": {
+      "adjacency_weight": {
+        "default": 0.8,
+        "config_key": "parser.efhg.stitching.adjacency_weight"
+      },
+      "entropy_join_delta": {
+        "default": 0.15,
+        "config_key": "parser.efhg.stitching.entropy_join_delta"
+      },
+      "style_cont_threshold": {
+        "default": 0.7,
+        "config_key": "parser.efhg.stitching.style_cont_threshold"
+      },
+      "notes": "Stitch multi-line headers when adjacency_weight exceeds threshold and entropy drop is within delta."
+    }
+  },
+  "sequence_repair": {
+    "schemas": {
+      "numeric": "^\\d+(\\.\\d+)*$",
+      "appendix": "^Appendix\\s+[A-Z]$",
+      "letter_numeric": "^[A-Z]\\d+(\\.\\d+)*$"
+    },
+    "gap_detection": {
+      "continuity_window": 3,
+      "local_evidence": ["style_similarity", "graph_connectivity", "page_distance"],
+      "no_literal_promotion": true
+    },
+    "tuning_keys": {
+      "hole_penalty": {
+        "default": 0.4,
+        "config_key": "parser.sequence_repair.hole_penalty"
+      },
+      "max_gap_span_pages": {
+        "default": 2,
+        "config_key": "parser.sequence_repair.max_gap_span_pages"
+      },
+      "min_schema_support": {
+        "default": 2,
+        "config_key": "parser.sequence_repair.min_schema_support"
+      }
+    }
+  },
+  "tuning": {
+    "enabled_config": "parser.tuning.enabled",
+    "method": "bounded_coordinate_search",
+    "search_space": {
+      "parser.efhg.weights.regex": [0.8, 1.6],
+      "parser.efhg.weights.style": [0.6, 1.4],
+      "parser.efhg.weights.entropy": [0.4, 1.2],
+      "parser.efhg.weights.graph": [0.6, 1.6],
+      "parser.efhg.weights.fluid": [0.4, 1.2],
+      "parser.efhg.weights.llm_vote": [0.6, 1.6],
+      "parser.efhg.thresholds.header": [0.55, 0.80],
+      "parser.efhg.thresholds.subheader": [0.45, 0.70],
+      "parser.efhg.stitching.adjacency_weight": [0.4, 1.2],
+      "parser.efhg.stitching.entropy_join_delta": [0.08, 0.22],
+      "parser.efhg.stitching.style_cont_threshold": [0.55, 0.85],
+      "parser.sequence_repair.hole_penalty": [0.2, 0.6],
+      "parser.sequence_repair.max_gap_span_pages": [1, 3],
+      "parser.sequence_repair.min_schema_support": [2, 4]
+    },
+    "artifact_path": "configs/tuned/header_detector.toml",
+    "persist_policy": "Write tuned values to configs/tuned/header_detector.toml and load on subsequent runs if newer than app defaults."
+  },
+  "artifacts": {
+    "base_dir": "storage/parser/{doc_id}",
+    "files": [
+      {
+        "name": "detected_headers.json",
+        "schema_ref": "docs/schemas/headers_tree.schema.json",
+        "description": "Ordered header tree with per-feature scores and stitch decisions."
+      },
+      {
+        "name": "gaps.json",
+        "schema_ref": "docs/schemas/gaps_report.schema.json",
+        "description": "Gap detection and repair report with confidence scores."
+      },
+      {
+        "name": "audit.html",
+        "description": "Human-readable audit pack summarizing detection and repairs."
+      },
+      {
+        "name": "audit.md",
+        "description": "Markdown audit summary for git diffs and CI logs."
+      },
+      {
+        "name": "results.junit.xml",
+        "description": "JUnit-compatible report of parser assertions."
+      },
+      {
+        "name": "configs/tuned/header_detector.toml",
+        "description": "Tuned global or project-specific header detector configuration."
+      }
+    ]
+  },
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/api/docs/{doc_id}",
+      "summary": "Return document metadata and current parser state.",
+      "response_schema": "docs/schemas/status_response.schema.json"
+    },
+    {
+      "method": "GET",
+      "path": "/api/docs/{doc_id}/headers",
+      "summary": "Return detected header tree, gaps, and artifact references.",
+      "response_schema": "docs/schemas/headers_tree.schema.json",
+      "includes": [
+        "gaps.json",
+        "audit artifacts"
+      ]
+    }
+  ],
+  "error_taxonomy": [
+    {
+      "category": "validation",
+      "codes": [
+        {"code": "parser.unsupported_pdf", "http_status": 422},
+        {"code": "parser.ocr_unavailable", "http_status": 503}
+      ]
+    },
+    {
+      "category": "processing",
+      "codes": [
+        {"code": "parser.extract_failed", "http_status": 500},
+        {"code": "parser.chunk_failed", "http_status": 500},
+        {"code": "parser.sequence_repair_failed", "http_status": 500}
+      ]
+    },
+    {
+      "category": "system",
+      "codes": [
+        {"code": "parser.storage_write_failed", "http_status": 500},
+        {"code": "parser.config_missing", "http_status": 500}
+      ]
+    }
+  ]
+}

--- a/app_plan/finalstubs_tests.json
+++ b/app_plan/finalstubs_tests.json
@@ -1,0 +1,51 @@
+{
+  "module": "tests",
+  "version": "phase2.v1",
+  "test_cases": [
+    {
+      "path": "tests/test_upload_validation.py",
+      "description": "Validate upload size, extension, MIME, and duplicate detection policies.",
+      "fixtures": {
+        "large_file": "Temporary file exceeding upload.max_mb by 1 byte.",
+        "bad_extension": "File named payload.exe pretending to be PDF.",
+        "bad_mime": "PDF extension but plain text content.",
+        "duplicate": "Two uploads of same file verifying checksum short-circuit."
+      },
+      "assertions": [
+        "Uploading a file larger than max_mb returns 413 and error code file_too_large.",
+        "Double-extension payload.pdf.exe is rejected with error unsupported_extension.",
+        "MIME sniff mismatch returns 415 unsupported_mime despite extension.",
+        "Duplicate upload returns 200 with duplicate_document and existing doc_id."
+      ]
+    },
+    {
+      "path": "tests/test_parser_headers.py",
+      "description": "Ensure parser promotes headers with EFHG, handles OCR fallback, and produces gaps report.",
+      "fixtures": {
+        "text_pdf": "Sample multi-level PDF with numeric and appendix headers.",
+        "image_pdf": "Image-only PDF verifying OCR branch."
+      },
+      "assertions": [
+        "Detected headers include stable ids and per-component scores.",
+        "OCR fallback populates text for image-only pages when parser.ocr.enabled is true.",
+        "gaps.json lists repaired headers with confidence in [0,1].",
+        "Sequence repair does not promote literal titles but fills numbering gaps based on schema continuity."
+      ]
+    },
+    {
+      "path": "tests/test_api_flow.py",
+      "description": "Full API regression from upload through parser results endpoints.",
+      "fixtures": {
+        "client": "FastAPI test client or httpx.AsyncClient configured against app routes.",
+        "pdf_file": "Representative PDF from sample_docs/.",
+        "mock_parser_job": "Monkeypatched parser job to return deterministic artifacts for polling."
+      },
+      "assertions": [
+        "POST /api/uploads returns 201 with schema-compliant body.",
+        "GET /api/docs/{doc_id} transitions from queued to completed when mock job finishes.",
+        "GET /api/docs/{doc_id}/headers returns headers tree referencing artifacts in storage/parser/{doc_id}.",
+        "Logs capture request_id and doc_id across upload and parser events (inspect test logger)."
+      ]
+    }
+  ]
+}

--- a/app_plan/finalstubs_upload.json
+++ b/app_plan/finalstubs_upload.json
@@ -1,0 +1,172 @@
+{
+  "module": "upload_service",
+  "version": "phase2.v1",
+  "route": {
+    "method": "POST",
+    "path": "/api/uploads",
+    "summary": "Accept a single PDF upload and stage it for parsing.",
+    "content_type": "multipart/form-data",
+    "form_fields": {
+      "file": {
+        "type": "FileStorage",
+        "required": true,
+        "description": "Binary PDF payload submitted by the user interface or client."
+      },
+      "doc_label": {
+        "type": "string",
+        "required": false,
+        "max_length": 200,
+        "description": "Optional human-readable label retained with document metadata."
+      },
+      "project_id": {
+        "type": "string",
+        "required": false,
+        "description": "Optional grouping token for downstream project-specific routing."
+      }
+    }
+  },
+  "validation": {
+    "max_mb": {
+      "config_key": "upload.max_mb",
+      "default": 100,
+      "behavior": "Reject files whose size in mebibytes exceeds the configured limit before persisting to disk.",
+      "failure_error": "file_too_large"
+    },
+    "allowed_ext": {
+      "config_key": "upload.allowed_ext",
+      "default": [".pdf"],
+      "behavior": "Require file extensions to case-insensitively match the allow list; strip leading dots before comparison.",
+      "double_extension_guard": true,
+      "failure_error": "unsupported_extension"
+    },
+    "allowed_mime": {
+      "config_key": "upload.allowed_mime",
+      "default": ["application/pdf"],
+      "behavior": "Perform MIME sniffing on the buffered payload and reject mismatches.",
+      "failure_error": "unsupported_mime"
+    },
+    "mime_sniffing": {
+      "implementation": "Use python-magic (or equivalent libmagic binding) to detect the actual content type, falling back to PyPDF detection if magic is unavailable.",
+      "trust_boundary": "Form-submitted MIME types are ignored in favor of server-side detection.",
+      "failure_error": "mime_detection_failed"
+    },
+    "checksum": {
+      "algorithm": "sha256",
+      "hexdigest": true,
+      "normalize_before_hash": false,
+      "failure_error": "checksum_failed"
+    },
+    "duplicate_policy": {
+      "strategy": "checksum+size",
+      "action": "If an identical checksum+size pair already exists, short-circuit storage and return the canonical doc_id while updating metadata timestamps.",
+      "collision_resolution": "If checksum collision occurs with differing sizes, reject upload with conflict error."
+    }
+  },
+  "storage": {
+    "temp_dir": {
+      "config_key": "upload.storage.temp",
+      "default": "storage/uploads/tmp",
+      "behavior": "Write streamed chunks to a temp directory with per-request staging folders before validation completes."
+    },
+    "final_dir": {
+      "config_key": "upload.storage.final",
+      "default": "storage/uploads/final",
+      "behavior": "Move validated payloads into a deterministic directory keyed by doc_id."
+    },
+    "safe_filename_policy": {
+      "strategy": "Slugify filename base, preserve original extension, and collapse whitespace/unsafe characters into hyphens.",
+      "max_length": 180,
+      "unicode_normalization": "NFKC"
+    },
+    "staging_index": {
+      "path_template": "{final_dir}/{doc_id}/index.json",
+      "schema": {
+        "doc_id": "string",
+        "filename_original": "string",
+        "filename_stored": "string",
+        "size_bytes": "int",
+        "sha256": "string",
+        "doc_label": "string | null",
+        "project_id": "string | null",
+        "uploaded_at": "datetime",
+        "storage_path": "string"
+      }
+    }
+  },
+  "response": {
+    "status_code": 201,
+    "schema_ref": "docs/schemas/upload_response.schema.json",
+    "example": {
+      "doc_id": "d-20240601-abcdef",
+      "filename": "specification.pdf",
+      "size_bytes": 1048576,
+      "sha256": "d2a4d...",
+      "stored_path": "storage/uploads/final/d-20240601-abcdef/specification.pdf"
+    }
+  },
+  "security": {
+    "cors_policy_ref": "configs/app.toml::cors",
+    "auth": {
+      "mode": "optional",
+      "header": "Authorization",
+      "scheme": "Bearer",
+      "behavior": "If auth is enabled globally, require a valid bearer token; otherwise allow anonymous uploads for development."
+    },
+    "rate_limit": {
+      "enabled": true,
+      "config_key": "upload.rate_limit.per_minute",
+      "default": 60,
+      "notes": "Hook in FastAPI dependency for rate limiting; respond with 429 on exceedance."
+    }
+  },
+  "errors": [
+    {
+      "code": "file_too_large",
+      "http_status": 413,
+      "message": "Uploaded file exceeds maximum size.",
+      "log_level": "warning"
+    },
+    {
+      "code": "unsupported_extension",
+      "http_status": 400,
+      "message": "File extension is not allowed.",
+      "log_level": "info"
+    },
+    {
+      "code": "unsupported_mime",
+      "http_status": 415,
+      "message": "File MIME type is not supported.",
+      "log_level": "info"
+    },
+    {
+      "code": "mime_detection_failed",
+      "http_status": 500,
+      "message": "Server could not determine file MIME type.",
+      "log_level": "error"
+    },
+    {
+      "code": "checksum_failed",
+      "http_status": 500,
+      "message": "Failed to compute checksum for uploaded file.",
+      "log_level": "error"
+    },
+    {
+      "code": "duplicate_document",
+      "http_status": 200,
+      "message": "Document already uploaded; returning canonical reference.",
+      "log_level": "info"
+    },
+    {
+      "code": "checksum_collision",
+      "http_status": 409,
+      "message": "Checksum collision detected with mismatched metadata.",
+      "log_level": "warning"
+    },
+    {
+      "code": "storage_failure",
+      "http_status": 500,
+      "message": "Server failed to persist uploaded file.",
+      "log_level": "error"
+    }
+  ]
+}

--- a/app_plan/finalstubs_upload_controller.json
+++ b/app_plan/finalstubs_upload_controller.json
@@ -1,0 +1,91 @@
+{
+  "module": "upload_controller",
+  "version": "phase2.v1",
+  "overview": "Service-level orchestration that bridges the upload route with the parser job queue, manages metadata, and exposes request lifecycle IDs.",
+  "doc_id_policy": {
+    "format": "ulid",
+    "prefix": "doc_",
+    "collision_strategy": "Regenerate on collision before metadata commit.",
+    "exposure": "Returned in upload response and reused by parser + status routes."
+  },
+  "sequence": [
+    "Validate multipart payload using rules from finalstubs_upload.json.",
+    "Stream file into temp_dir while computing sha256 incrementally.",
+    "Persist index.json metadata and move file into final_dir/doc_id/filename.",
+    "Record upload event in persistence layer (postgres table uploads or equivalent).",
+    "Submit parser job with document metadata and return response payload."
+  ],
+  "parser_job_submission": {
+    "mode": "async_queue",
+    "service": "parser.jobs",
+    "call_signature": "submit_job(doc: UploadMetadata) -> JobHandle",
+    "payload_contract": {
+      "doc_id": "string",
+      "source_path": "string",
+      "sha256": "string",
+      "size_bytes": "int",
+      "doc_label": "string | null",
+      "project_id": "string | null",
+      "request_id": "string",
+      "received_at": "datetime"
+    },
+    "response_contract": {
+      "job_id": "string",
+      "status": "queued",
+      "eta": "datetime | null"
+    },
+    "retry_policy": {
+      "max_attempts": 3,
+      "backoff_seconds": [1, 5, 15],
+      "failure_event": "emit parser.job_submission_failed log with request_id + doc_id"
+    },
+    "fallback": "If queue is unavailable, mark upload as failed and return 503 with error code parser_queue_unavailable."
+  },
+  "status_and_results_flow": {
+    "status_route": "/api/docs/{doc_id}",
+    "results_route": "/api/docs/{doc_id}/headers",
+    "job_id_propagation": "Upload response includes job_id when available; otherwise clients poll using doc_id only.",
+    "state_model": [
+      "uploaded",
+      "queued",
+      "processing",
+      "completed",
+      "failed"
+    ],
+    "persistence": "Track state transitions in uploads table with updated_at timestamps and failure reasons."
+  },
+  "observability": {
+    "request_id_generation": {
+      "source": "fastapi_request.state.request_id",
+      "fallback": "uuid4",
+      "propagate_to": ["logs", "parser job payload", "index.json"]
+    },
+    "structured_log_fields": ["request_id", "doc_id", "job_id", "client_ip", "mime", "size_bytes"],
+    "metrics": {
+      "enabled": true,
+      "counters": [
+        {"name": "upload.requests.total", "description": "Total upload attempts."},
+        {"name": "upload.requests.rejected", "description": "Validation rejections."},
+        {"name": "parser.jobs.submitted", "description": "Jobs successfully enqueued."}
+      ],
+      "histograms": [
+        {"name": "upload.save.duration_ms", "description": "Time to persist upload file."},
+        {"name": "upload.total.duration_ms", "description": "End-to-end upload controller latency."}
+      ]
+    }
+  },
+  "error_mapping": [
+    {
+      "code": "parser_queue_unavailable",
+      "http_status": 503,
+      "description": "Parser job queue could not accept new work.",
+      "client_action": "Retry later"
+    },
+    {
+      "code": "parser_submission_timeout",
+      "http_status": 504,
+      "description": "Parser job submission timed out after retries.",
+      "client_action": "Check status endpoint for eventual consistency"
+    }
+  ]
+}

--- a/docs/artifacts/phase2_finalstubs_crosswalk.json
+++ b/docs/artifacts/phase2_finalstubs_crosswalk.json
@@ -1,0 +1,116 @@
+{
+  "items": [
+    {
+      "type": "route",
+      "name": "POST /api/uploads",
+      "status": "added",
+      "plan_module": "app_plan/finalstubs_upload.json",
+      "runtime_targets": ["rag-app/backend/app/api/routes/uploads.py::post_upload"],
+      "public_signature": "POST /api/uploads -> upload_response.schema.json"
+    },
+    {
+      "type": "route",
+      "name": "GET /api/docs/{doc_id}",
+      "status": "updated",
+      "plan_module": "app_plan/finalstubs_parser.json",
+      "runtime_targets": ["rag-app/backend/app/api/routes/docs.py::get_doc_status"],
+      "public_signature": "GET /api/docs/{doc_id} -> status_response.schema.json"
+    },
+    {
+      "type": "route",
+      "name": "GET /api/docs/{doc_id}/headers",
+      "status": "updated",
+      "plan_module": "app_plan/finalstubs_parser.json",
+      "runtime_targets": ["rag-app/backend/app/api/routes/docs.py::get_doc_headers"],
+      "public_signature": "GET /api/docs/{doc_id}/headers -> headers_tree.schema.json"
+    },
+    {
+      "type": "module",
+      "name": "upload_service",
+      "status": "added",
+      "plan_module": "app_plan/finalstubs_upload.json",
+      "runtime_targets": ["rag-app/backend/app/services/upload_service.py"],
+      "public_signature": "save_upload(file, doc_label=None, project_id=None) -> UploadResult"
+    },
+    {
+      "type": "module",
+      "name": "upload_controller",
+      "status": "added",
+      "plan_module": "app_plan/finalstubs_upload_controller.json",
+      "runtime_targets": ["rag-app/backend/app/controllers/upload_controller.py"],
+      "public_signature": "handle_upload(request) -> UploadResponse"
+    },
+    {
+      "type": "module",
+      "name": "parser_pipeline",
+      "status": "updated",
+      "plan_module": "app_plan/finalstubs_parser.json",
+      "runtime_targets": ["rag-app/backend/app/services/parser_pipeline.py"],
+      "public_signature": "run_parser(doc_id, source_path, sha256, metadata) -> ParserResult"
+    },
+    {
+      "type": "config",
+      "name": "configs/app.toml::upload",
+      "status": "added",
+      "plan_module": "app_plan/finalstubs_config.json",
+      "runtime_targets": ["rag-app/backend/app/config.py"],
+      "public_signature": "upload.max_mb:int, upload.allowed_ext:list[str], ..."
+    },
+    {
+      "type": "config",
+      "name": "configs/app.toml::parser",
+      "status": "added",
+      "plan_module": "app_plan/finalstubs_config.json",
+      "runtime_targets": ["rag-app/backend/app/config.py"],
+      "public_signature": "parser.efhg.weights.*, parser.sequence_repair.*"
+    },
+    {
+      "type": "config",
+      "name": "configs/tuned/header_detector.toml",
+      "status": "added",
+      "plan_module": "app_plan/finalstubs_config.json",
+      "runtime_targets": ["rag-app/backend/app/config.py", "configs/tuned/header_detector.toml"],
+      "public_signature": "Overrides parser.* keys when present"
+    },
+    {
+      "type": "logging",
+      "name": "Structured logs",
+      "status": "added",
+      "plan_module": "app_plan/finalstubs_logging_telemetry.json",
+      "runtime_targets": ["rag-app/backend/app/logging.py"],
+      "public_signature": "log(event, request_id, doc_id, job_id, **kwargs)"
+    },
+    {
+      "type": "telemetry",
+      "name": "Metrics & tracing",
+      "status": "added",
+      "plan_module": "app_plan/finalstubs_logging_telemetry.json",
+      "runtime_targets": ["rag-app/backend/app/telemetry.py"],
+      "public_signature": "record_metric(name, value, tags); start_span(name, attrs)"
+    },
+    {
+      "type": "test",
+      "name": "tests/test_upload_validation.py",
+      "status": "added",
+      "plan_module": "app_plan/finalstubs_tests.json",
+      "runtime_targets": ["tests/test_upload_validation.py"],
+      "public_signature": "pytest file validating upload guardrails"
+    },
+    {
+      "type": "test",
+      "name": "tests/test_parser_headers.py",
+      "status": "added",
+      "plan_module": "app_plan/finalstubs_tests.json",
+      "runtime_targets": ["tests/test_parser_headers.py"],
+      "public_signature": "pytest file covering parser outputs"
+    },
+    {
+      "type": "test",
+      "name": "tests/test_api_flow.py",
+      "status": "added",
+      "plan_module": "app_plan/finalstubs_tests.json",
+      "runtime_targets": ["tests/test_api_flow.py"],
+      "public_signature": "pytest file covering upload->status->headers flow"
+    }
+  ]
+}

--- a/docs/artifacts/phase2_finalstubs_summary.md
+++ b/docs/artifacts/phase2_finalstubs_summary.md
@@ -1,0 +1,29 @@
+# Phase 2 Finalstubs Summary — Upload & Parser Upgrade
+
+## Inputs Reviewed
+- `parser_upgrade_plan/overview.md`
+- `parser_upgrade_plan/phase2_finalstubs.md`
+- Existing planning materials in `app_plan/03_Upload_Parser.md` and `app_plan/07_Routes_Orchestrator.md`
+- Phase 1 artifacts were not present in the repository; gaps were inferred from planning notes.
+
+## Major Additions
+1. **Uploader Surface** — Defined `POST /api/uploads` contract with strict validation (size, extension, MIME sniffing, checksum) and storage/indexing expectations in `app_plan/finalstubs_upload.json`.
+2. **Upload Controller Handoff** — Captured ULID doc ID policy, queue submission contract, and observability propagation in `app_plan/finalstubs_upload_controller.json`.
+3. **Parser Pipeline** — Detailed extractor hierarchy, normalization, UF chunking, EFHG scoring thresholds, sequence repair schemas, tuning bounds, artifact inventory, and result routes in `app_plan/finalstubs_parser.json`.
+4. **Configuration Surface** — Documented TOML keys and tuned-config precedence in `app_plan/finalstubs_config.json` to generalize policies without document-specific hacks.
+5. **Logging & Telemetry** — Set structured logging expectations, EFHG debug payloads, metrics, and traces in `app_plan/finalstubs_logging_telemetry.json`.
+6. **Test Requirements** — Enumerated Phase 3 regression tests for validation, parser behavior (including OCR), and full API flow in `app_plan/finalstubs_tests.json`.
+7. **Aggregator Update** — Published `app_plan/finalstubs_latest.json` referencing every Phase 2 module with shared route/config summaries for downstream tooling.
+8. **Schemas & Docs** — Authored JSON Schemas for upload responses, headers tree, gaps report, and status payload plus this summary and the crosswalk artifact.
+
+## Phase 1 Gap Coverage
+- **Upload validation gaps** (size/MIME/double extension) addressed via explicit validation block.
+- **Parser observability gaps** bridged by structured log + trace definitions.
+- **Artifact schema ambiguity** resolved by delivering JSON Schemas and tying them to routes.
+- **Test coverage gaps** mapped to concrete pytest targets with fixtures and assertions.
+
+## Implementation Guidance for Phase 3
+- Align FastAPI route implementations with the schemas referenced in the finalstubs.
+- Ensure parser jobs persist artifacts exactly under `storage/parser/{doc_id}` with the enumerated filenames.
+- Load configuration via `configs/app.toml`, overriding with tuned configs when present, and respect the stated precedence.
+- Integrate metrics/tracing instrumentation early to maintain observability parity with the plan.

--- a/docs/schemas/gaps_report.schema.json
+++ b/docs/schemas/gaps_report.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://fluidrag.app/schemas/gaps_report.schema.json",
+  "title": "GapsReport",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["doc_id", "generated_at", "schemas", "holes_filled"],
+  "properties": {
+    "doc_id": {"type": "string"},
+    "generated_at": {"type": "string", "format": "date-time"},
+    "schemas": {
+      "type": "array",
+      "items": {"type": "string", "enum": ["numeric", "appendix", "letter_numeric"]},
+      "uniqueItems": true
+    },
+    "holes_filled": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["expected", "evidence", "confidence"],
+        "properties": {
+          "expected": {"type": "string"},
+          "inserted_id": {"type": "string"},
+          "evidence": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "left": {"type": ["string", "null"]},
+              "right": {"type": ["string", "null"]},
+              "style_sim": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+              "graph_adj": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+              "page_distance": {"type": "integer", "minimum": 0}
+            }
+          },
+          "confidence": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+          "notes": {"type": "string"}
+        }
+      }
+    },
+    "unresolved_gaps": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["expected", "reason"],
+        "properties": {
+          "expected": {"type": "string"},
+          "reason": {"type": "string"},
+          "confidence": {"type": "number", "minimum": 0.0, "maximum": 1.0}
+        }
+      }
+    }
+  }
+}

--- a/docs/schemas/headers_tree.schema.json
+++ b/docs/schemas/headers_tree.schema.json
@@ -1,0 +1,155 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://fluidrag.app/schemas/headers_tree.schema.json",
+  "title": "HeadersTree",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["doc_id", "generated_at", "nodes"],
+  "properties": {
+    "doc_id": {
+      "type": "string",
+      "description": "Document identifier associated with the parse."
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Timestamp when the headers tree was produced."
+    },
+    "source_sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$",
+      "description": "Checksum of the source document used for parsing."
+    },
+    "tuning_profile": {
+      "type": ["string", "null"],
+      "description": "Name of the tuned configuration applied, if any."
+    },
+    "nodes": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "id",
+          "parent_id",
+          "level",
+          "text_raw",
+          "text_norm",
+          "page_range",
+          "scores",
+          "decision",
+          "stitch"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "pattern": "^header:[0-9A-Za-z-_:]+$",
+            "description": "Stable identifier for the header node."
+          },
+          "parent_id": {
+            "type": ["string", "null"],
+            "description": "Identifier of the parent header or null for root nodes."
+          },
+          "level": {
+            "type": "integer",
+            "minimum": 1,
+            "description": "Hierarchy level where 1 is top-level."
+          },
+          "text_raw": {
+            "type": "string",
+            "description": "Original header text as extracted, with styling preserved where possible."
+          },
+          "text_norm": {
+            "type": "string",
+            "description": "Lower-cased and normalized header text."
+          },
+          "page_range": {
+            "type": "object",
+            "required": ["start", "end"],
+            "additionalProperties": false,
+            "properties": {
+              "start": {"type": "integer", "minimum": 1},
+              "end": {"type": "integer", "minimum": 1}
+            }
+          },
+          "spans": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["page", "bbox", "uf_chunk_id"],
+              "properties": {
+                "page": {"type": "integer", "minimum": 1},
+                "bbox": {
+                  "type": "array",
+                  "items": {"type": "number"},
+                  "minItems": 4,
+                  "maxItems": 4
+                },
+                "uf_chunk_id": {"type": "string"},
+                "token_start": {"type": "integer", "minimum": 0},
+                "token_end": {"type": "integer", "minimum": 0}
+              }
+            }
+          },
+          "scores": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["regex", "style", "entropy", "graph", "fluid", "llm_vote", "total"],
+            "properties": {
+              "regex": {"type": "number", "minimum": 0.0, "maximum": 2.0},
+              "style": {"type": "number", "minimum": 0.0, "maximum": 2.0},
+              "entropy": {"type": "number", "minimum": 0.0, "maximum": 2.0},
+              "graph": {"type": "number", "minimum": 0.0, "maximum": 2.0},
+              "fluid": {"type": "number", "minimum": 0.0, "maximum": 2.0},
+              "llm_vote": {"type": "number", "minimum": 0.0, "maximum": 2.0},
+              "total": {"type": "number", "minimum": 0.0}
+            }
+          },
+          "decision": {
+            "type": "string",
+            "enum": [
+              "promote.header",
+              "promote.subheader",
+              "reject",
+              "stitch.joined"
+            ]
+          },
+          "stitch": {
+            "type": "object",
+            "required": ["joined"],
+            "additionalProperties": false,
+            "properties": {
+              "joined": {"type": "boolean"},
+              "source_ids": {
+                "type": "array",
+                "items": {"type": "string"}
+              }
+            }
+          },
+          "sequence_repair": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "repaired": {"type": "boolean"},
+              "schema": {"type": "string", "enum": ["numeric", "appendix", "letter_numeric"]},
+              "confidence": {"type": "number", "minimum": 0.0, "maximum": 1.0}
+            }
+          }
+        }
+      }
+    },
+    "artifacts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["gaps_path", "audit_html", "audit_md", "results_junit"],
+      "properties": {
+        "gaps_path": {"type": "string"},
+        "audit_html": {"type": "string"},
+        "audit_md": {"type": "string"},
+        "results_junit": {"type": "string"}
+      }
+    }
+  }
+}

--- a/docs/schemas/status_response.schema.json
+++ b/docs/schemas/status_response.schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://fluidrag.app/schemas/status_response.schema.json",
+  "title": "DocumentStatus",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "doc_id",
+    "status",
+    "uploaded_at",
+    "updated_at"
+  ],
+  "properties": {
+    "doc_id": {"type": "string"},
+    "filename": {"type": "string"},
+    "doc_label": {"type": ["string", "null"]},
+    "project_id": {"type": ["string", "null"]},
+    "size_bytes": {"type": "integer", "minimum": 0},
+    "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+    "status": {
+      "type": "string",
+      "enum": ["uploaded", "queued", "processing", "completed", "failed"]
+    },
+    "job_id": {"type": ["string", "null"]},
+    "uploaded_at": {"type": "string", "format": "date-time"},
+    "updated_at": {"type": "string", "format": "date-time"},
+    "artifacts": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "base_dir": {"type": "string"},
+        "detected_headers": {"type": "string"},
+        "gaps": {"type": "string"},
+        "audit_html": {"type": "string"},
+        "audit_md": {"type": "string"},
+        "results_junit": {"type": "string"}
+      }
+    },
+    "error": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "code": {"type": "string"},
+        "message": {"type": "string"}
+      }
+    }
+  }
+}

--- a/docs/schemas/upload_response.schema.json
+++ b/docs/schemas/upload_response.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://fluidrag.app/schemas/upload_response.schema.json",
+  "title": "UploadResponse",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["doc_id", "filename", "size_bytes", "sha256", "stored_path"],
+  "properties": {
+    "doc_id": {
+      "type": "string",
+      "description": "Server-generated document identifier (ULID prefixed with doc_).",
+      "pattern": "^doc_[0-9A-HJKMNP-TV-Z]{26}$"
+    },
+    "filename": {
+      "type": "string",
+      "description": "Sanitized filename persisted to storage.",
+      "minLength": 1,
+      "maxLength": 180
+    },
+    "size_bytes": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Size of the stored file in bytes."
+    },
+    "sha256": {
+      "type": "string",
+      "description": "Hex-encoded SHA-256 checksum computed during upload.",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "stored_path": {
+      "type": "string",
+      "description": "Absolute or app-relative path to the stored file."
+    },
+    "job_id": {
+      "type": ["string", "null"],
+      "description": "Optional parser job identifier when enqueued synchronously."
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add modular finalstubs covering upload validation, controller handoff, parser pipeline, config, telemetry, and tests
- update the Phase 2 aggregator to reference new modules and enumerate routes, config keys, and schemas
- document the design with a Phase 2 summary, crosswalk mapping, and JSON Schemas for API responses and artifacts

## Testing
- not run (plan-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dc10a5e1a48324a3908de6cb2f6294