### PR TITLE
Add Phase 11 verification run summary

### DIFF
--- a/rag-app/reports/phase_11_outcome.md
+++ b/rag-app/reports/phase_11_outcome.md
@@ -13,6 +13,13 @@
 - `ruff check backend/app tests --fix` — no remaining lint violations after auto-fix.
 - `ruff format backend/app tests` — codebase formatted.
 
+## Verification Run — 2025-10-04
+- README audit confirmed quickstart, environment setup, and troubleshooting guidance remain aligned with Phase 11 scope.
+- Release tooling (`scripts/release_checklist.py`, `scripts/offline_pipeline_demo.py`) present and callable for handover workflows.
+- Changelog reflects Phase 11 deliverables with documentation of new scripts and README updates.
+- Backlog and outcome reports (`reports/post_phase_backlog.md`, this file) available for next-iteration planning.
+- `pytest` (full backend suite covering phases 1–11) — 107 passed on Python 3.12.10.
+
 ## Cross-Phase Adjustments
 - `pytest.ini` now includes `rag-app/tests` so frontend/demo suites remain part of the default run.
 


### PR DESCRIPTION
## Summary
- document the latest Phase 11 verification pass in `reports/phase_11_outcome.md`
- capture checks confirming README coverage, release tooling, backlog docs, and changelog status
- record the most recent pytest run spanning the Phase 1–11 backend suites

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dc7df42a7883248286e6a834b6d9c8