### PR TITLE
Add parser report artifact for EPF upload pipeline

### DIFF
--- a/rag-app/backend/app/services/parser_service/main.py
+++ b/rag-app/backend/app/services/parser_service/main.py
@@ -13,6 +13,7 @@ class ParseResult(BaseModel):
 
     doc_id: str
     enriched_path: str
+    report_path: str | None = Field(default=None)
     language: str = Field(default="und", min_length=2)
     summary: dict[str, object] = Field(default_factory=dict)
     metrics: dict[str, float] = Field(default_factory=dict)

--- a/rag-app/backend/app/tests/unit/test_parser.py
+++ b/rag-app/backend/app/tests/unit/test_parser.py
@@ -37,6 +37,12 @@ def test_parse_and_enrich_generates_enriched_artifact(sample_pdf_path: Path) -> 
     assert payload["lists"], "list detection should capture bullet points"
     assert any(block["text"].startswith("2. Controls") for block in payload["blocks"])
 
+    report_path = Path(result.report_path)
+    assert report_path.exists()
+    report_payload = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report_payload["doc_id"] == result.doc_id
+    assert report_payload["summary"] == result.summary
+
 
 def test_parse_and_enrich_missing_normalized(tmp_path: Path) -> None:
     with pytest.raises(NotFoundError):


### PR DESCRIPTION
## Summary
- emit a JSON parse report alongside the enriched artifact and expose its path via the parser API
- verify the generated report contents in parser unit tests and EPF upload integration tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dddd26a4a0832495ac1ab38a4832e4